### PR TITLE
Modify file slow to load in emacs.

### DIFF
--- a/buildtools/diff-test-result-dirs.d
+++ b/buildtools/diff-test-result-dirs.d
@@ -82,10 +82,10 @@ This tool runs diff comparisons of test result files. The exit status gives the 
 status. Zero indicates success (no differences), one indicates failure (differences).
 
 This tool was developed for TSV Utilities command line tests. Command line tests work
-by running a tool (executable) against a set of command line test inputs. Results are
-written to files and compared to a "gold" set of correct results. Tests generate one
-or more output files; all written to a single directory. The resulting comparison is
-a "test" directory vs a "gold" directory.
+by running a tool against a set of command line test inputs. Results are written to
+files and compared to a "gold" set of correct results. Tests generate one or more
+output files; all written to a single directory. The resulting comparison is a "test"
+directory vs a "gold" directory.
 
 A directory level 'diff' is sufficient in many cases. This is the default behavior of
 this tool. In some cases the corrent results depend on the compiler version. The main


### PR DESCRIPTION
For some unknown reason, the `(executable)` text at line 85, in the heredoc string, causes the file to load very slowly in emacs. 20-30 seconds at least. The text inside the parens doesn't matter, only that the parens are there. Parens elsewhere aren't affecting anything.

It's not clear why this happens. DCD and d-mode are the obvious candidates. After removing it the file loads instantly.