### PR TITLE
tsv-sample: Use formatNumber to append directly to output buffer (performance).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ matrix:
 #      osx_image: xcode9.4
 #      group: travis_latest
 #      language: d
-#      d: ldc-1.2.0
+#      d: ldc-1.4.0
 #      env: DUBTEST=1 MAKETEST=1 APPLTO=off
     - os: linux
       group: travis_latest
       language: d
-      d: ldc-1.2.0
+      d: ldc-1.4.0
       env: DUBTEST=1 MAKETEST=1
       if: type IN (pull_request, cron)
 #      if: fork = true

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ For some distributions, a package can directly be installed:
 
 ### Build from source files
 
-[Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.070 or later, LDC version 1.0.0 or later.
+[Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.074.1 or later, LDC version 1.4.0 or later.
 
 Clone this repository, select a compiler, and run `make` from the top level directory:
 ```


### PR DESCRIPTION
This is a performance improvement when adding random values to the output, generally significant. If writes directly to the output buffer without creating a GC allocated string.