### PR TITLE
Improve module layout

### DIFF
--- a/buildtools/aggregate-codecov.d
+++ b/buildtools/aggregate-codecov.d
@@ -1,9 +1,10 @@
 /**
-This tool aggregates D coverage files to a common directory.
+This tool aggregates D code coverage files to a common directory.
 
 D code coverage files are written to the directory where the test was initiated. When
 multiple tests are run from different directories, multiple output files are produced.
-This tool moves these files to a common directory, aggregating them in the process.
+This tool moves these files to a common directory, aggregating coverage files for the
+same source code file along the way.
 
 Copyright (c) 2017, eBay Software Foundation
 Initially written by Jon Degenhardt
@@ -44,7 +45,7 @@ int main(string[] cmdArgs)
             return 1;
         }
     }
-    
+
     foreach (cf; coverageFiles)
     {
         auto targetFile = buildPath(targetDir, cf.baseName);
@@ -73,7 +74,7 @@ void mergeCoverageFiles(string fromFile, string toFile)
     auto lines = appender!(LineCounter[])();
     string lastLine = "";
     long maxCounter = -1;
-    
+
     {   // Scope for file opens
         auto toInput = toFile.File;
         auto fromInput = fromFile.File;
@@ -114,7 +115,7 @@ void mergeCoverageFiles(string fromFile, string toFile)
                 (f1Counter == -1) ? f2Counter :
                 (f2Counter == -1) ? f1Counter :
                 f1Counter + f2Counter;
-            
+
             auto lc = LineCounter(counter, f1Split[2].to!string);
             lines ~= lc;
             if (counter > maxCounter) maxCounter = counter;
@@ -132,7 +133,7 @@ void mergeCoverageFiles(string fromFile, string toFile)
         blanks ~= ' ';
         zeros ~= '0';
     }
-    
+
     size_t codeLines = 0;
     size_t coveredCodeLines = 0;
     auto ofile = toFile.File("w");

--- a/buildtools/codecov-to-relative-paths.d
+++ b/buildtools/codecov-to-relative-paths.d
@@ -1,5 +1,5 @@
 /**
-This tool coverts D code coverage files from absolute to relative paths.
+This tool converts D code coverage files from absolute to relative paths.
 
 D code coverage files are written using absolute path names if absolute paths are
 used in the build command. (This enables running coverage tests from a directory
@@ -44,7 +44,7 @@ int main(string[] cmdArgs)
             return 1;
         }
     }
-    
+
     foreach (cf; coverageFiles)
     {
         auto rootDir = cf.absolutePath.buildNormalizedPath.dirName;
@@ -59,7 +59,7 @@ int main(string[] cmdArgs)
             auto lastLineSplit = lastLine.findSplit(" ");
             auto lastLinePath = lastLineSplit[1].empty ? "" : lastLineSplit[0];
             auto lastLinePathNoExt = lastLinePath.stripExtension;
-            if (lastLinePath.isAbsolute && 
+            if (lastLinePath.isAbsolute &&
                 lastLinePathNoExt.tr("\\/", "--") == fileNameNoExt &&
                 rootDir.length + 1 <= lastLine.length &&
                 rootDir.length + 1 <= fileName.length)

--- a/common/makefile
+++ b/common/makefile
@@ -40,9 +40,9 @@ test-codecov: unittest-codecov
 unittest-codecov:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests with code coverage.'
 	-rm ./*.lst
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsvutil.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/util.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/getopt_inorder.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsv_numerics.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/numerics.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsvutils_version.d
 	-rm ./__main.lst
 	@echo '---> Unit tests completed successfully (code coverage on).'

--- a/common/makefile
+++ b/common/makefile
@@ -1,7 +1,8 @@
 include ../makedefs.mk
 
-unittest_utils_srcs ?= $(CURDIR)/src/unittest_utils.d
-imports ?= -I$(CURDIR)/src
+srcdir = $(CURDIR)/src/tsv_utils/common
+unittest_utils_srcs ?= $(srcdir)/unittest_utils.d
+imports ?= -I$(srcdir)
 
 release: ;
 debug: ;
@@ -22,10 +23,10 @@ test: unittest
 .PHONY: unittest
 unittest:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests'
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/tsvutil.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/getopt_inorder.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/tsv_numerics.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/tsvutils_version.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/util.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/getopt_inorder.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/numerics.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/tsvutils_version.d
 	@echo '---> Unit tests completed successfully.'
 
 test-debug: ;
@@ -39,10 +40,10 @@ test-codecov: unittest-codecov
 unittest-codecov:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests with code coverage.'
 	-rm ./*.lst
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsvutil.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/getopt_inorder.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsv_numerics.d
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsvutils_version.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsvutil.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/getopt_inorder.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsv_numerics.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsvutils_version.d
 	-rm ./__main.lst
 	@echo '---> Unit tests completed successfully (code coverage on).'
 

--- a/common/makefile
+++ b/common/makefile
@@ -23,7 +23,7 @@ test: unittest
 .PHONY: unittest
 unittest:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests'
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/util.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/utils.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/getopt_inorder.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/numerics.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(srcdir)/tsvutils_version.d
@@ -40,7 +40,7 @@ test-codecov: unittest-codecov
 unittest-codecov:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests with code coverage.'
 	-rm ./*.lst
-	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/util.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/utils.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/getopt_inorder.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/numerics.d
 	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(srcdir)/tsvutils_version.d

--- a/common/src/tsv_utils/common/getopt_inorder.d
+++ b/common/src/tsv_utils/common/getopt_inorder.d
@@ -27,6 +27,8 @@ Acknowledgments:
   Copyright: 2008-2015 Andrei Alexandrescu
 */
 
+module tsv_utils.common.getopt_inorder;
+
 import std.getopt;
 
 /* checkForUnsupportedConfigOptions walks the option list looking for unsupported config

--- a/common/src/tsv_utils/common/numerics.d
+++ b/common/src/tsv_utils/common/numerics.d
@@ -15,6 +15,8 @@ Initially written by Jon Degenhardt
 License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
 */
 
+module tsv_utils.common.numerics;
+
 /**
 formatNumber is an alternate way to print numbers. It is especially useful when representing
 both integral and floating point values with float point data types.

--- a/common/src/tsv_utils/common/tsvutils_version.d
+++ b/common/src/tsv_utils/common/tsvutils_version.d
@@ -1,3 +1,8 @@
+/** tsv-utils version file.
+ */
+
+module tsv_utils.common.tsvutils_version;
+
 enum string tsvutilsVersion = "v1.2.3";
 
 string tsvutilsVersionNotice (string toolName)

--- a/common/src/tsv_utils/common/unittest_utils.d
+++ b/common/src/tsv_utils/common/unittest_utils.d
@@ -7,6 +7,8 @@ Initially written by Jon Degenhardt
 License: Boost License 1.0 (http://boost.org/LICENSE_1_0.txt)
 */
 
+module tsv_utils.common.unittest_utils;
+
 version(unittest)
 {
     /* Creates a temporary directory for writing unit test files. The path of the created

--- a/common/src/tsv_utils/common/util.d
+++ b/common/src/tsv_utils/common/util.d
@@ -1,5 +1,6 @@
 /**
-Utilities used by TSV applications.
+Utilities used by tsv-utils applications. InputFieldReordering, BufferedOututRange,
+and a several others.
 
 Utilities in this file:
 * InputFieldReordering - A class that creates a reordered subset of fields from an

--- a/common/src/tsv_utils/common/util.d
+++ b/common/src/tsv_utils/common/util.d
@@ -28,6 +28,8 @@ Initially written by Jon Degenhardt
 License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
 */
 
+module tsv_utils.common.util;
+
 import std.range;
 import std.traits : isIntegral, isSomeChar, isSomeString, isUnsigned;
 import std.typecons : Flag, No, Yes;
@@ -529,7 +531,7 @@ if (isFileHandle!(Unqual!OutputTarget) || isOutputRange!(Unqual!OutputTarget, ch
 
 unittest
 {
-    import unittest_utils;
+    import tsv_utils.common.unittest_utils;
     import std.file : rmdirRecurse, readText;
     import std.path : buildPath;
 

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -29,7 +29,7 @@ Initially written by Jon Degenhardt
 License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
 */
 
-module tsv_utils.common.util;
+module tsv_utils.common.utils;
 
 import std.range;
 import std.traits : isIntegral, isSomeChar, isSomeString, isUnsigned;
@@ -59,7 +59,7 @@ below, which has a performance improvement over join used here.)
 
     int main(string[] args)
     {
-        import tsvutil;
+        import tsv_utils.common.utils;
         import std.algorithm, std.array, std.range, std.stdio;
         size_t[] fieldIndicies = [3, 0, 2];
         auto fieldReordering = new InputFieldReordering!char(fieldIndicies);

--- a/csv2tsv/src/csv2tsv.d
+++ b/csv2tsv/src/csv2tsv.d
@@ -116,7 +116,7 @@ struct Csv2tsvOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("csv2tsv"));
                 return tuple(false, 0);
             }
@@ -207,7 +207,7 @@ alias NullableSizeT = Nullable!(size_t, size_t.max);
 void csv2tsvFiles(in Csv2tsvOptions cmdopt, in string[] inputFiles)
 {
     import std.algorithm : joiner;
-    import tsvutil : BufferedOutputRange;
+    import tsv_utils.common.util : BufferedOutputRange;
 
     ubyte[1024 * 1024] fileRawBuf;
     ubyte[] stdinRawBuf = fileRawBuf[0..1024];

--- a/csv2tsv/src/csv2tsv.d
+++ b/csv2tsv/src/csv2tsv.d
@@ -207,7 +207,7 @@ alias NullableSizeT = Nullable!(size_t, size_t.max);
 void csv2tsvFiles(in Csv2tsvOptions cmdopt, in string[] inputFiles)
 {
     import std.algorithm : joiner;
-    import tsv_utils.common.util : BufferedOutputRange;
+    import tsv_utils.common.utils : BufferedOutputRange;
 
     ubyte[1024 * 1024] fileRawBuf;
     ubyte[] stdinRawBuf = fileRawBuf[0..1024];

--- a/keep-header/src/keep-header.d
+++ b/keep-header/src/keep-header.d
@@ -66,7 +66,7 @@ int main(string[] args)
         else if (cmdArgs.length > 0 &&
                  (cmdArgs[0] == "-V" || cmdArgs[0] == "--V" ||  cmdArgs[0] == "--version"))
         {
-            import tsvutils_version;
+            import tsv_utils.common.tsvutils_version;
             stderr.writeln();
             stderr.writeln(tsvutilsVersionNotice("keep-header"));
         }

--- a/makeapp.mk
+++ b/makeapp.mk
@@ -1,5 +1,5 @@
 app ?= $(notdir $(basename $(CURDIR)))
-common_srcs ?= $(common_srcdir)/util.d $(common_srcdir)/numerics.d $(common_srcdir)/getopt_inorder.d $(common_srcdir)/unittest_utils.d $(common_srcdir)/tsvutils_version.d
+common_srcs ?= $(common_srcdir)/utils.d $(common_srcdir)/numerics.d $(common_srcdir)/getopt_inorder.d $(common_srcdir)/unittest_utils.d $(common_srcdir)/tsvutils_version.d
 app_src ?= $(CURDIR)/src/$(app).d
 srcs ?= $(app_src) $(common_srcs)
 imports ?= -I$(common_srcdir)

--- a/makeapp.mk
+++ b/makeapp.mk
@@ -1,5 +1,5 @@
 app ?= $(notdir $(basename $(CURDIR)))
-common_srcs ?= $(common_srcdir)/tsvutil.d $(common_srcdir)/tsv_numerics.d $(common_srcdir)/getopt_inorder.d $(common_srcdir)/unittest_utils.d $(common_srcdir)/tsvutils_version.d
+common_srcs ?= $(common_srcdir)/util.d $(common_srcdir)/numerics.d $(common_srcdir)/getopt_inorder.d $(common_srcdir)/unittest_utils.d $(common_srcdir)/tsvutils_version.d
 app_src ?= $(CURDIR)/src/$(app).d
 srcs ?= $(app_src) $(common_srcs)
 imports ?= -I$(common_srcdir)

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -41,7 +41,7 @@ LDC_PGO_TYPE ?= AST
 ## Directory and file paths
 
 project_dir ?= $(realpath ..)
-common_srcdir = $(project_dir)/common/src
+common_srcdir = $(project_dir)/common/src/tsv_utils/common
 project_bindir = $(project_dir)/bin
 buildtools_dir = $(project_dir)/buildtools
 diff_test_result_dirs = $(buildtools_dir)/diff-test-result-dirs

--- a/number-lines/src/number-lines.d
+++ b/number-lines/src/number-lines.d
@@ -79,7 +79,7 @@ struct NumberLinesOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("number-lines"));
                 return tuple(false, 0);
             }
@@ -129,7 +129,7 @@ void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
 {
     import std.conv : to;
     import std.range;
-    import tsvutil : BufferedOutputRange;
+    import tsv_utils.common.util : BufferedOutputRange;
 
     auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 

--- a/number-lines/src/number-lines.d
+++ b/number-lines/src/number-lines.d
@@ -129,7 +129,7 @@ void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
 {
     import std.conv : to;
     import std.range;
-    import tsv_utils.common.util : BufferedOutputRange;
+    import tsv_utils.common.utils : BufferedOutputRange;
 
     auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 

--- a/tsv-append/src/tsv-append.d
+++ b/tsv-append/src/tsv-append.d
@@ -25,7 +25,7 @@ else
      */
     int main(string[] cmdArgs)
     {
-        import tsv_utils.common.util : BufferedOutputRange;
+        import tsv_utils.common.utils : BufferedOutputRange;
         /* When running in DMD code coverage mode, turn on report merging. */
         version(D_Coverage) version(DigitalMars)
         {

--- a/tsv-append/src/tsv-append.d
+++ b/tsv-append/src/tsv-append.d
@@ -25,7 +25,7 @@ else
      */
     int main(string[] cmdArgs)
     {
-        import tsvutil : BufferedOutputRange;
+        import tsv_utils.common.util : BufferedOutputRange;
         /* When running in DMD code coverage mode, turn on report merging. */
         version(D_Coverage) version(DigitalMars)
         {
@@ -173,7 +173,7 @@ struct TsvAppendOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-append"));
                 return tuple(false, 0);
             }
@@ -247,7 +247,7 @@ version(unittest)
 {
     /* Unit test helper functions. */
 
-    import unittest_utils;   // tsv unit test helpers, from common/src/.
+    import tsv_utils.common.unittest_utils;   // tsv unit test helpers, from common/src/.
 
     void testTsvAppend(string[] cmdArgs, string[][] expected)
     {

--- a/tsv-filter/src/tsv-filter.d
+++ b/tsv-filter/src/tsv-filter.d
@@ -616,7 +616,7 @@ struct TsvFilterOptions
     {
         import std.getopt;
         import std.path : baseName, stripExtension;
-        import getopt_inorder;
+        import tsv_utils.common.getopt_inorder;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -767,7 +767,7 @@ struct TsvFilterOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-filter"));
                 return tuple(false, 0);
             }
@@ -787,7 +787,7 @@ void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
 {
     import std.algorithm : all, any, splitter;
     import std.range;
-    import tsvutil : BufferedOutputRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : BufferedOutputRange, throwIfWindowsNewlineOnUnix;
 
     /* BufferedOutputRange improves performance on narrow files with high percentages of
      * writes. Want responsive output if output is rare, so ensure the first matched

--- a/tsv-filter/src/tsv-filter.d
+++ b/tsv-filter/src/tsv-filter.d
@@ -787,7 +787,7 @@ void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
 {
     import std.algorithm : all, any, splitter;
     import std.range;
-    import tsv_utils.common.util : BufferedOutputRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : BufferedOutputRange, throwIfWindowsNewlineOnUnix;
 
     /* BufferedOutputRange improves performance on narrow files with high percentages of
      * writes. Want responsive output if output is rare, so ensure the first matched

--- a/tsv-join/src/tsv-join.d
+++ b/tsv-join/src/tsv-join.d
@@ -95,7 +95,7 @@ struct TsvJoinOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsv_utils.common.util :  makeFieldListOptionHandler;
+        import tsv_utils.common.utils :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -292,7 +292,7 @@ int main(string[] cmdArgs)
  */
 void tsvJoin(in TsvJoinOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.util : InputFieldReordering, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : InputFieldReordering, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
     import std.algorithm : splitter;
     import std.array : join;
     import std.range;

--- a/tsv-join/src/tsv-join.d
+++ b/tsv-join/src/tsv-join.d
@@ -95,7 +95,7 @@ struct TsvJoinOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsvutil :  makeFieldListOptionHandler;
+        import tsv_utils.common.util :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -150,7 +150,7 @@ struct TsvJoinOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-join"));
                 return tuple(false, 0);
             }
@@ -292,7 +292,7 @@ int main(string[] cmdArgs)
  */
 void tsvJoin(in TsvJoinOptions cmdopt, in string[] inputFiles)
 {
-    import tsvutil : InputFieldReordering, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : InputFieldReordering, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
     import std.algorithm : splitter;
     import std.array : join;
     import std.range;

--- a/tsv-pretty/src/tsv-pretty.d
+++ b/tsv-pretty/src/tsv-pretty.d
@@ -177,7 +177,7 @@ struct TsvPrettyOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-pretty"));
                 return tuple(false, 0);
             }
@@ -1164,6 +1164,7 @@ size_t significantDigits(const char[] numericString) @safe pure
     import std.math : isFinite;
     import std.string : isNumeric;
     import std.conv : to;
+
     assert (numericString.isNumeric);
 
     size_t significantDigits = 0;
@@ -1215,6 +1216,7 @@ size_t precisionDigits(const char[] numericString) @safe pure
     import std.math : isFinite;
     import std.string : isNumeric;
     import std.conv : to;
+
     assert (numericString.isNumeric);
 
     size_t precisionDigits = 0;

--- a/tsv-sample/src/tsv-sample.d
+++ b/tsv-sample/src/tsv-sample.d
@@ -39,7 +39,7 @@ else
         }
         try
         {
-            import tsvutil : BufferedOutputRange;
+            import tsv_utils.common.util : BufferedOutputRange;
             auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 
             tsvSample(cmdopt, bufferedOutput);
@@ -214,7 +214,7 @@ struct TsvSampleOptions
         import std.math : isNaN;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsvutil : makeFieldListOptionHandler;
+        import tsv_utils.common.util : makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -273,7 +273,7 @@ struct TsvSampleOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-sample"));
                 return tuple(false, 0);
             }
@@ -448,7 +448,7 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.format : formatValue, singleSpec;
     import std.random : Random = Mt19937, uniform01;
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -563,7 +563,7 @@ void bernoulliSkipSampling(OutputRange)(TsvSampleOptions cmdopt, OutputRange out
     import std.conv : to;
     import std.math : log, trunc;
     import std.random : Random = Mt19937, uniform01;
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.inclusionProbability > 0.0 && cmdopt.inclusionProbability < 1.0);
     assert(!cmdopt.printRandom);
@@ -634,7 +634,7 @@ if (isOutputRange!(OutputRange, char))
     import std.conv : to;
     import std.digest.murmurhash;
     import std.math : lrint;
-    import tsvutil : InputFieldReordering, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : InputFieldReordering, throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -828,7 +828,7 @@ if (isOutputRange!(OutputRange, char))
     import std.container.binaryheap;
     import std.format : formatValue, singleSpec;
     import std.random : Random = Mt19937, uniform01;
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     static if (isWeighted) assert(cmdopt.hasWeightField);
     else assert(!cmdopt.hasWeightField);
@@ -945,7 +945,7 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.format : formatValue, singleSpec;
     import std.random : Random = Mt19937, uniform01;
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.hasWeightField);
 
@@ -1028,7 +1028,7 @@ void reservoirSamplingAlgorithmR(OutputRange)(TsvSampleOptions cmdopt, auto ref 
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, randomShuffle, uniform;
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.sampleSize > 0);
     assert(!cmdopt.hasWeightField);
@@ -1322,7 +1322,7 @@ if (isOutputRange!(OutputRange, char))
     import std.algorithm : splitter;
     import std.array : appender;
     import std.random : Random = Mt19937, uniform01;
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     static assert(hasRandomValue || !isWeighted);
     static if(!hasRandomValue) assert(!cmdopt.printRandom);
@@ -1396,7 +1396,7 @@ if (isSomeChar!C)
 {
     import std.conv : ConvException, to;
     import std.format : format;
-    import tsvutil : getTsvFieldValue;
+    import tsv_utils.common.util : getTsvFieldValue;
 
     T val;
     try
@@ -1452,7 +1452,7 @@ version(unittest)
 {
     /* Unit test helper functions. */
 
-    import unittest_utils;   // tsv unit test helpers, from common/src/.
+    import tsv_utils.common.unittest_utils;   // tsv unit test helpers, from common/src/.
     import std.conv : to;
 
     void testTsvSample(string[] cmdArgs, string[][] expected)

--- a/tsv-sample/src/tsv-sample.d
+++ b/tsv-sample/src/tsv-sample.d
@@ -39,7 +39,7 @@ else
         }
         try
         {
-            import tsv_utils.common.util : BufferedOutputRange;
+            import tsv_utils.common.utils : BufferedOutputRange;
             auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 
             tsvSample(cmdopt, bufferedOutput);
@@ -182,30 +182,30 @@ EOS";
  */
 struct TsvSampleOptions
 {
-    string programName;
-    string[] files;
-    bool helpVerbose = false;                  // --help-verbose
-    bool hasHeader = false;                    // --H|header
-    size_t sampleSize = 0;                     // --n|num - Size of the desired sample
-    double inclusionProbability = double.nan;  // --p|prob - Inclusion probability
-    size_t[] keyFields;                        // --k|key-fields - Used with inclusion probability
-    size_t weightField = 0;                    // --w|weight-field - Field holding the weight
-    bool srsWithReplacement = false;           // --r|replace
-    bool staticSeed = false;                   // --s|static-seed
-    uint seedValueOptionArg = 0;               // --v|seed-value
-    bool printRandom = false;                  // --print-random
-    bool genRandomInorder = false;             // --gen-random-inorder
-    string randomValueHeader = "random_value"; // --random-value-header
-    bool compatibilityMode = false;            // --compatibility-mode
-    char delim = '\t';                         // --d|delimiter
-    bool versionWanted = false;                // --V|version
-    bool preferSkipSampling = false;           // --prefer-skip-sampling
-    bool preferAlgorithmR = false;             // --prefer-algorithm-r
-    bool hasWeightField = false;               // Derived.
-    bool useBernoulliSampling = false;         // Derived.
-    bool useDistinctSampling = false;          // Derived.
-    bool usingUnpredictableSeed = true;        // Derived from --static-seed, --seed-value
-    uint seed = 0;                             // Derived from --static-seed, --seed-value
+    string programName;                        /// Program name
+    string[] files;                            /// Input files
+    bool helpVerbose = false;                  /// --help-verbose
+    bool hasHeader = false;                    /// --H|header
+    size_t sampleSize = 0;                     /// --n|num - Size of the desired sample
+    double inclusionProbability = double.nan;  /// --p|prob - Inclusion probability
+    size_t[] keyFields;                        /// --k|key-fields - Used with inclusion probability
+    size_t weightField = 0;                    /// --w|weight-field - Field holding the weight
+    bool srsWithReplacement = false;           /// --r|replace
+    bool staticSeed = false;                   /// --s|static-seed
+    uint seedValueOptionArg = 0;               /// --v|seed-value
+    bool printRandom = false;                  /// --print-random
+    bool genRandomInorder = false;             /// --gen-random-inorder
+    string randomValueHeader = "random_value"; /// --random-value-header
+    bool compatibilityMode = false;            /// --compatibility-mode
+    char delim = '\t';                         /// --d|delimiter
+    bool versionWanted = false;                /// --V|version
+    bool preferSkipSampling = false;           /// --prefer-skip-sampling
+    bool preferAlgorithmR = false;             /// --prefer-algorithm-r
+    bool hasWeightField = false;               /// Derived.
+    bool useBernoulliSampling = false;         /// Derived.
+    bool useDistinctSampling = false;          /// Derived.
+    bool usingUnpredictableSeed = true;        /// Derived from --static-seed, --seed-value
+    uint seed = 0;                             /// Derived from --static-seed, --seed-value
 
     auto processArgs(ref string[] cmdArgs)
     {
@@ -214,7 +214,7 @@ struct TsvSampleOptions
         import std.math : isNaN;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsv_utils.common.util : makeFieldListOptionHandler;
+        import tsv_utils.common.utils : makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -402,7 +402,7 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Bernoulli sampling on the input stream.
+/** Invokes the appropriate Bernoulli sampling routine based on the command line arguments.
  *
  * This routine selects the appropriate bernoulli sampling function and template
  * instantiation to use based on the command line arguments.
@@ -435,7 +435,7 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Bernoulli sampling on the input stream.
+/** Bernoulli sampling of lines on the input stream.
  *
  * Each input line is a assigned a random value and output if less than
  * cmdopt.inclusionProbability. The order of the lines is not changed.
@@ -448,7 +448,7 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.format : formatValue, singleSpec;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -523,8 +523,7 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** bernoulliSkipSampling is an alternate implementation of bernoulliSampling that
- * uses skip sampling.
+/** bernoulliSkipSampling is an implementation of Bernoulli sampling using skips.
  *
  * Skip sampling works by skipping a random number of lines between selections. This
  * can be faster than assigning a random value to each line when the inclusion
@@ -563,7 +562,7 @@ void bernoulliSkipSampling(OutputRange)(TsvSampleOptions cmdopt, OutputRange out
     import std.conv : to;
     import std.math : log, trunc;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.inclusionProbability > 0.0 && cmdopt.inclusionProbability < 1.0);
     assert(!cmdopt.printRandom);
@@ -634,7 +633,7 @@ if (isOutputRange!(OutputRange, char))
     import std.conv : to;
     import std.digest.murmurhash;
     import std.math : lrint;
-    import tsv_utils.common.util : InputFieldReordering, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : InputFieldReordering, throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -745,7 +744,8 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Reservoir sampling on the input stream.
+/** Invokes the appropriate reservoir sampling routine based on the command line
+ * arguments.
  *
  * This routine selects the appropriate reservior sampling function and template
  * instantiation to use based on the command line arguments.
@@ -828,7 +828,7 @@ if (isOutputRange!(OutputRange, char))
     import std.container.binaryheap;
     import std.format : formatValue, singleSpec;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     static if (isWeighted) assert(cmdopt.hasWeightField);
     else assert(!cmdopt.hasWeightField);
@@ -945,7 +945,7 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.format : formatValue, singleSpec;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.hasWeightField);
 
@@ -996,7 +996,7 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Reservoir sampling, Algorithm R
+/** Reservoir sampling via Algorithm R
  *
  * This is an implementation of reservoir sampling using what is commonly known as
  * "Algorithm R", credited to Alan Waterman by Donald Knuth in the "The Art of
@@ -1028,7 +1028,7 @@ void reservoirSamplingAlgorithmR(OutputRange)(TsvSampleOptions cmdopt, auto ref 
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, randomShuffle, uniform;
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.sampleSize > 0);
     assert(!cmdopt.hasWeightField);
@@ -1094,9 +1094,10 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Randomize all the lines in files or standard input.
+/** Invokes the appropriate routine to randomize input lines based on the command line
+ * arguments.
  *
- * This routine selects the appropriate randomize-lines function and template instantiation
+ * This routine selects the appropriate randomize lines function and template instantiation
  * to use based on the command line arguments.
  */
 void randomizeLinesCommand(OutputRange)(TsvSampleOptions cmdopt, auto ref OutputRange outputStream)
@@ -1116,7 +1117,8 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Randomize all the lines in files or standard input.
+/** Randomize all the lines in files or standard input using assigned random weights
+ * and sorting.
  *
  * All lines in files and/or standard input are read in and written out in random
  * order. This algorithm assigns a random value to each line and sorts. This approach
@@ -1168,7 +1170,7 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/** Randomize all the lines in files or standard input.
+/** Randomize all the lines in files or standard input using a shuffling algorithm.
  *
  * All lines in files and/or standard input are read in and written out in random
  * order. This routine uses array shuffling, which is faster than sorting. This makes
@@ -1322,7 +1324,7 @@ if (isOutputRange!(OutputRange, char))
     import std.algorithm : splitter;
     import std.array : appender;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     static assert(hasRandomValue || !isWeighted);
     static if(!hasRandomValue) assert(!cmdopt.printRandom);
@@ -1387,8 +1389,9 @@ if (isOutputRange!(OutputRange, char))
 }
 
 
-/** Convenience function for extracting a single field from a line. See getTsvFieldValue in
- * common/src/tsvutils.d for details. This wrapper creates error text tailored for this program.
+/** Convenience function for extracting a single field from a line. See
+ * tsv_utils.common.utils.getTsvFieldValue for details. This wrapper creates error
+ * text tailored for this program.
  */
 import std.traits : isSomeChar;
 T getFieldValue(T, C)(const C[] line, size_t fieldIndex, C delim, string filename, size_t lineNum) pure @safe
@@ -1396,7 +1399,7 @@ if (isSomeChar!C)
 {
     import std.conv : ConvException, to;
     import std.format : format;
-    import tsv_utils.common.util : getTsvFieldValue;
+    import tsv_utils.common.utils : getTsvFieldValue;
 
     T val;
     try

--- a/tsv-sample/src/tsv-sample.d
+++ b/tsv-sample/src/tsv-sample.d
@@ -523,7 +523,7 @@ if (isOutputRange!(OutputRange, char))
     }
 }
 
-/* bernoulliSkipSampling is an alternate implementation of bernoulliSampling that
+/** bernoulliSkipSampling is an alternate implementation of bernoulliSampling that
  * uses skip sampling.
  *
  * Skip sampling works by skipping a random number of lines between selections. This

--- a/tsv-select/src/tsv-select.d
+++ b/tsv-select/src/tsv-select.d
@@ -78,7 +78,7 @@ struct TsvSelectOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsvutil :  makeFieldListOptionHandler;
+        import tsv_utils.common.util :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -108,7 +108,7 @@ struct TsvSelectOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-select"));
                 return tuple(false, 0);
             }
@@ -199,7 +199,7 @@ enum CTERestLocation { none, first, last };
  */
 void tsvSelect(CTERestLocation cteRest)(in TsvSelectOptions cmdopt, in string[] inputFiles)
 {
-    import tsvutil: BufferedOutputRange, InputFieldReordering, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util: BufferedOutputRange, InputFieldReordering, throwIfWindowsNewlineOnUnix;
     import std.algorithm: splitter;
     import std.format: format;
     import std.range;

--- a/tsv-select/src/tsv-select.d
+++ b/tsv-select/src/tsv-select.d
@@ -78,7 +78,7 @@ struct TsvSelectOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsv_utils.common.util :  makeFieldListOptionHandler;
+        import tsv_utils.common.utils :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -199,7 +199,7 @@ enum CTERestLocation { none, first, last };
  */
 void tsvSelect(CTERestLocation cteRest)(in TsvSelectOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.util: BufferedOutputRange, InputFieldReordering, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils: BufferedOutputRange, InputFieldReordering, throwIfWindowsNewlineOnUnix;
     import std.algorithm: splitter;
     import std.format: format;
     import std.range;

--- a/tsv-summarize/src/tsv-summarize.d
+++ b/tsv-summarize/src/tsv-summarize.d
@@ -173,7 +173,7 @@ struct TsvSummarizeOptions {
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsv_utils.common.getopt_inorder;
-        import tsv_utils.common.util :  makeFieldListOptionHandler;
+        import tsv_utils.common.utils :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -262,7 +262,7 @@ struct TsvSummarizeOptions {
     {
         import std.range : enumerate;
         import std.typecons : Yes, No;
-        import tsv_utils.common.util :  parseFieldList;
+        import tsv_utils.common.utils :  parseFieldList;
 
         auto valSplit = findSplit(optionVal, ":");
 
@@ -312,7 +312,7 @@ struct TsvSummarizeOptions {
     private void quantileOperatorOptionHandler(string option, string optionVal)
     {
         import std.typecons : Yes, No;
-        import tsv_utils.common.util :  parseFieldList;
+        import tsv_utils.common.utils :  parseFieldList;
 
         auto formatErrorMsg(string option, string optionVal)
         {
@@ -435,7 +435,7 @@ struct TsvSummarizeOptions {
  */
 void tsvSummarize(TsvSummarizeOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
     /* Pick the Summarizer based on the number of key-fields entered. */
     auto summarizer =

--- a/tsv-summarize/src/tsv-summarize.d
+++ b/tsv-summarize/src/tsv-summarize.d
@@ -172,8 +172,8 @@ struct TsvSummarizeOptions {
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import getopt_inorder;
-        import tsvutil :  makeFieldListOptionHandler;
+        import tsv_utils.common.getopt_inorder;
+        import tsv_utils.common.util :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -237,7 +237,7 @@ struct TsvSummarizeOptions {
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-summarize"));
                 return tuple(false, 0);
             }
@@ -262,7 +262,7 @@ struct TsvSummarizeOptions {
     {
         import std.range : enumerate;
         import std.typecons : Yes, No;
-        import tsvutil :  parseFieldList;
+        import tsv_utils.common.util :  parseFieldList;
 
         auto valSplit = findSplit(optionVal, ":");
 
@@ -312,7 +312,7 @@ struct TsvSummarizeOptions {
     private void quantileOperatorOptionHandler(string option, string optionVal)
     {
         import std.typecons : Yes, No;
-        import tsvutil :  parseFieldList;
+        import tsv_utils.common.util :  parseFieldList;
 
         auto formatErrorMsg(string option, string optionVal)
         {
@@ -435,7 +435,7 @@ struct TsvSummarizeOptions {
  */
 void tsvSummarize(TsvSummarizeOptions cmdopt, in string[] inputFiles)
 {
-    import tsvutil : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.util : throwIfWindowsNewlineOnUnix;
 
     /* Pick the Summarizer based on the number of key-fields entered. */
     auto summarizer =
@@ -593,7 +593,7 @@ struct SummarizerPrintOptions
     auto formatNumber(T)(T n) const
     if (isFloatingPoint!T || isIntegral!T)
     {
-        import tsv_numerics : formatNumber;
+        import tsv_utils.common.numerics : formatNumber;
         return formatNumber!T(n, floatPrecision);
     }
 }
@@ -1924,7 +1924,7 @@ class UniqueKeyValuesLists
         {
             if (!_haveMedian)
             {
-                import tsv_numerics : rangeMedian;
+                import tsv_utils.common.numerics : rangeMedian;
                 _medianValue = _values.data.rangeMedian();
                 _haveMedian = true;
             }
@@ -3195,7 +3195,7 @@ class QuantileOperator : SingleFieldOperator
 
         final string calculate(UniqueKeyValuesLists valuesLists, const ref SummarizerPrintOptions printOptions)
         {
-            import tsv_numerics : quantile;
+            import tsv_utils.common.numerics : quantile;
             return printOptions.formatNumber(
                 quantile(this.outer._prob, valuesLists.numericValuesSorted(fieldIndex)));
         }
@@ -3281,7 +3281,7 @@ class MadOperator : SingleFieldOperator
         final string calculate(UniqueKeyValuesLists valuesLists, const ref SummarizerPrintOptions printOptions)
         {
             import std.math : abs;
-            import tsv_numerics : rangeMedian;
+            import tsv_utils.common.numerics : rangeMedian;
 
             auto median = valuesLists.numericValuesMedian(fieldIndex);
             auto values = valuesLists.numericValues(fieldIndex);

--- a/tsv-uniq/src/tsv-uniq.d
+++ b/tsv-uniq/src/tsv-uniq.d
@@ -115,7 +115,7 @@ struct TsvUniqOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsvutil :  makeFieldListOptionHandler;
+        import tsv_utils.common.util :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -155,7 +155,7 @@ struct TsvUniqOptions
             }
             else if (versionWanted)
             {
-                import tsvutils_version;
+                import tsv_utils.common.tsvutils_version;
                 writeln(tsvutilsVersionNotice("tsv-uniq"));
                 return tuple(false, 0);
             }
@@ -240,7 +240,7 @@ int main(string[] cmdArgs)
  */
 void tsvUniq(in TsvUniqOptions cmdopt, in string[] inputFiles)
 {
-    import tsvutil : InputFieldReordering, BufferedOutputRange;
+    import tsv_utils.common.util : InputFieldReordering, BufferedOutputRange;
     import std.algorithm : splitter;
     import std.array : join;
     import std.conv : to;

--- a/tsv-uniq/src/tsv-uniq.d
+++ b/tsv-uniq/src/tsv-uniq.d
@@ -115,7 +115,7 @@ struct TsvUniqOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsv_utils.common.util :  makeFieldListOptionHandler;
+        import tsv_utils.common.utils :  makeFieldListOptionHandler;
 
         programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
@@ -240,7 +240,7 @@ int main(string[] cmdArgs)
  */
 void tsvUniq(in TsvUniqOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.util : InputFieldReordering, BufferedOutputRange;
+    import tsv_utils.common.utils : InputFieldReordering, BufferedOutputRange;
     import std.algorithm : splitter;
     import std.array : join;
     import std.conv : to;


### PR DESCRIPTION
This PR changes the module names and organization used in the common directory. This is to make it more standard, but in particular, so that Adam Ruppe's document generator can generate better documentation. See https://github.com/adamdruppe/dpldocs/issues/2. 

This document generator is used by the D code repository, so the documentation is available online. There are a few other code level documentation changes as well.