### PR TITLE
New docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@
 #   LTOPGO=[default|thin|full] - Like ALLLTO, but adds LDC_PGO=2 flag
 #   LTOPGO_V2=[default|thin|full] - Like ALLLTO_V2, but adds LDC_PGO=2 flag
 #   LINUX_SPECIAL - Settings linux static build would use if docker wasn't needed.
-#   DOCKERSPECIAL - Special dockerized build to run LDC with LTO, PGO and -static
-#   DOCKERSPECIAL2 - Like DOCKERSPECIAL (LDC w/ LTO/PGO -static), but a more recent LDC
-#       Only use one of DOCKERSPECIAL or DOCKERSPECIAL2
+#   DOCKERSPECIAL=[1|2] - Special dockerized build to run LDC with LTO, PGO and -static
+#       1 is the original. 2 was introduced Nov 2018 to use a docker image with an up-to-date LDC
 #   DEPLOY - Deploy if a tagged release.
 matrix:
   include:
@@ -114,7 +113,7 @@ matrix:
       language: d
       d: ldc-1.12.0
       services: docker
-      env: DOCKERSPECIAL2=1
+      env: DOCKERSPECIAL=2
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update
@@ -122,7 +121,7 @@ before_install:
       && docker pull dlanguage/ldc:1.7.0;
       export UID=$(id -u);
       export GID=$(id -g);
-    elif [[ "$DOCKERSPECIAL2" == "1" ]]; then
+    elif [[ "$DOCKERSPECIAL" == "2" ]]; then
       sudo apt-get -qq update
       && sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
       && docker pull dlang2/ldc-ubuntu:1.12.0;
@@ -196,7 +195,7 @@ script:
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild DCOMPILER=ldc2
     && make clean;
-  elif [[ "$DOCKERSPECIAL2" == "1" ]]; then
+  elif [[ "$DOCKERSPECIAL" == "2" ]]; then
     docker run --rm -ti -v $(pwd):/src -w /src dlang2/ldc-ubuntu:1.12.0 make test DCOMPILER=ldc2 LDC_LTO_RUNTIME=1 LDC_PGO=2 DFLAGS=-static
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild DCOMPILER=ldc2
@@ -215,7 +214,7 @@ before_deploy:
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
     docker run --rm -ti -v $(pwd):/src dlanguage/ldc:1.7.0 make package PKG_ROOT_DIR=tsv-utils DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 LDC_PGO=2 DFLAGS=-static;
     sudo chown -R $UID:$GID $(pwd);
-  elif [[ "$DOCKERSPECIAL2" == "1" ]]; then
+  elif [[ "$DOCKERSPECIAL" == "2" ]]; then
     docker run --rm -ti -v $(pwd):/src -w /src dlang2/ldc-ubuntu:1.12.0 make package PKG_ROOT_DIR=tsv-utils DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 LDC_PGO=2 DFLAGS=-static;
     sudo chown -R $UID:$GID $(pwd);
   else

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@
 #   LTOPGO_V2=[default|thin|full] - Like ALLLTO_V2, but adds LDC_PGO=2 flag
 #   LINUX_SPECIAL - Settings linux static build would use if docker wasn't needed.
 #   DOCKERSPECIAL - Special dockerized build to run LDC with LTO, PGO and -static
+#   DOCKERSPECIAL2 - Like DOCKERSPECIAL (LDC w/ LTO/PGO -static), but a more recent LDC
+#       Only use one of DOCKERSPECIAL or DOCKERSPECIAL2
 #   DEPLOY - Deploy if a tagged release.
 matrix:
   include:
@@ -105,11 +107,25 @@ matrix:
       d: ldc-1.7.0
       services: docker
       env: DOCKERSPECIAL=1 DEPLOY=1
+    - os: linux
+      dist: trusty
+      sudo: required
+      group: travis_latest
+      language: d
+      d: ldc-1.12.0
+      services: docker
+      env: DOCKERSPECIAL2=1
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update
       && sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
       && docker pull dlanguage/ldc:1.7.0;
+      export UID=$(id -u);
+      export GID=$(id -g);
+    elif [[ "$DOCKERSPECIAL2" == "1" ]]; then
+      sudo apt-get -qq update
+      && sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+      && docker pull dlang2/ldc-ubuntu:1.12.0;
       export UID=$(id -u);
       export GID=$(id -g);
     fi
@@ -180,6 +196,11 @@ script:
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild DCOMPILER=ldc2
     && make clean;
+  elif [[ "$DOCKERSPECIAL2" == "1" ]]; then
+    docker run --rm -ti -v $(pwd):/src -w /src dlang2/ldc-ubuntu:1.12.0 make test DCOMPILER=ldc2 LDC_LTO_RUNTIME=1 LDC_PGO=2 DFLAGS=-static
+    && sudo chown -R $UID:$GID $(pwd)
+    && make test-nobuild DCOMPILER=ldc2
+    && make clean;
   fi
 after_success:
 - if [[ "$CODECOV" == "1" ]]; then
@@ -193,6 +214,9 @@ before_deploy:
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
     docker run --rm -ti -v $(pwd):/src dlanguage/ldc:1.7.0 make package PKG_ROOT_DIR=tsv-utils DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 LDC_PGO=2 DFLAGS=-static;
+    sudo chown -R $UID:$GID $(pwd);
+  elif [[ "$DOCKERSPECIAL2" == "1" ]]; then
+    docker run --rm -ti -v $(pwd):/src -w /src dlang2/ldc-ubuntu:1.12.0 make package PKG_ROOT_DIR=tsv-utils DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 LDC_PGO=2 DFLAGS=-static;
     sudo chown -R $UID:$GID $(pwd);
   else
     make package PKG_ROOT_DIR=tsv-utils DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 LDC_PGO=2;


### PR DESCRIPTION
This is prep for switching pre-built binaries to the latest LDC release. The linux build requires using `-static` requires ubuntu 16+. Travis-CI uses 14.04, necessitating docker builds. This sets up using a different docker container, one with regularly updated LDC builds. The updated docker build also uses recently added support for LTO shipped runtime libs, available in LDC 1.9+ and supported starting a recent tsv-utils update (post 1.2.3).