### PR TITLE
Update to flush logic in BufferedOuputRange.

### DIFF
--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -479,6 +479,22 @@ if (isFileHandle!(Unqual!OutputTarget) || isOutputRange!(Unqual!OutputTarget, ch
         if (_outputBuffer.data.length >= _maxSize) flush();
     }
 
+    /* maybeFlush is intended for the case where put is called with a trailing newline.
+     *
+     * Flushing occurs if the buffer has a trailing newline and has reached flush size.
+     * Flushing also occurs if the buffer has reached max size.
+     */
+    private bool maybeFlush()
+    {
+        immutable bool doFlush =
+            _outputBuffer.data.length >= _flushSize &&
+            (_outputBuffer.data[$-1] == '\n' || _outputBuffer.data.length >= _maxSize);
+
+        if (doFlush) flush();
+        return doFlush;
+    }
+
+
     private void appendRaw(T)(T stuff)
     {
         import std.range : rangePut = put;
@@ -488,7 +504,7 @@ if (isFileHandle!(Unqual!OutputTarget) || isOutputRange!(Unqual!OutputTarget, ch
     void append(T)(T stuff)
     {
         appendRaw(stuff);
-        flushIfMaxSize();
+        maybeFlush();
     }
 
     bool appendln()


### PR DESCRIPTION
Catch a common case of flushing on newline boundaries, when a newline is included in the `put` call (which goes through `append`).