### PR TITLE
tsv_utils.common.utils.bufferedByLine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ matrix:
 #      osx_image: xcode10.1
 #      group: travis_latest
 #      language: d
-#      d: ldc-1.4.0
+#      d: ldc-1.6.0
 #      env: DUBTEST=1 MAKETEST=1 APPLTO=off
     - os: linux
       group: travis_latest
       language: d
-      d: ldc-1.4.0
+      d: ldc-1.6.0
       env: DUBTEST=0 MAKETEST=1
       if: type IN (pull_request, cron)
 #      if: fork = true

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ For some distributions a package can directly be installed:
 
 ### Build from source files
 
-[Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.074.1 or later, LDC version 1.4.0 or later.
+[Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.076.1 or later, LDC version 1.6.0 or later.
 
 Clone this repository, select a compiler, and run `make` from the top level directory:
 ```

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -837,8 +837,7 @@ if (is(Char == char) || is(Char == ubyte))
         /* Note: Call popFront at initialization to do the initial read. */
         void popFront()
         {
-            import std.stdio;
-            import std.algorithm: countUntil, copy, find;
+            import std.algorithm: copy, find;
             assert(!empty, "Attempt to popFront an empty bufferedByLine.");
 
             /* Pop the current line. */
@@ -851,14 +850,16 @@ if (is(Char == char) || is(Char == ubyte))
              * - 'find' returns the slice starting with the character searched for, or
              *   an empty range if not found.
              * - _lineEnd is set to _dataEnd both when the current buffer does not have
-             *   a newline and when it ends with one. This is reflected in the if-test.
+             *   a newline and when it ends with one.
              */
             auto found = _buffer[_lineStart .. _dataEnd].find(terminator);
             _lineEnd = found.empty ? _dataEnd : _dataEnd - found.length + 1;
 
             if (found.empty && !_file.eof)
             {
-                /* No newline in current buffer. Read from the file to find the next newline. */
+                /* No newline in current buffer. Read from the file until the next
+                 * newline is found.
+                 */
                 assert(_lineEnd == _dataEnd);
 
                 if (_lineStart > 0)
@@ -870,7 +871,7 @@ if (is(Char == char) || is(Char == ubyte))
                     _lineEnd = _dataEnd = remainingLength;
                 }
 
-                while (found.empty && !_file.eof)
+                do
                 {
                     /* Grow the buffer if necessary. */
                     immutable availableSize = _buffer.length - _dataEnd;
@@ -888,7 +889,8 @@ if (is(Char == char) || is(Char == ubyte))
 
                     found = _buffer[_lineEnd .. _dataEnd].find(terminator);
                     _lineEnd = found.empty ? _dataEnd : _dataEnd - found.length + 1;
-                }
+
+                } while (found.empty && !_file.eof);
             }
         }
     }

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -956,7 +956,9 @@ unittest
         foreach (a, b; lockstep(f1aIn, f1bIn, StoppingPolicy.requireSameLength)) assert(a == b);
     }
 
-    /* Exercise boundary cases in buffer growth. */
+    /* Exercise boundary cases in buffer growth.
+     * Note: static-foreach requires DMD 2.076 / LDC 1.6
+     */
     static foreach (readSize; [1, 2, 4])
     {
         static foreach (growSize; 1 .. readSize + 1)

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -12,6 +12,10 @@ $(LIST
     * [BufferedOutputRange] - An OutputRange with an internal buffer used to buffer
       output. Intended for use with stdout, it is a significant performance benefit.
 
+    * [bufferedByLine] - Returns an input range that reads from a File handle line by
+      line. It is similar to the standard library method std.stdio.File.byLine, but is
+      quite a bit faster due to the use of buffering when reading.
+
     * [joinAppend] - A function that performs a join, but appending the join output to
       an output stream. It is a performance improvement over using join or joiner with
       writeln.
@@ -770,9 +774,15 @@ unittest
 
 /**
 bufferedByLine is a performance enhancement over std.stdio.File.byLine. It works by
-reading a larger buffers from the input stream rather than just reading a single line.
+reading a large buffer from the input stream rather than just reading a single line.
 
-This is work in progress.
+The file argument needs to be a File open for reading, typically a real file or
+standard input. Use the Yes.keepTerminator template parameter to keep the newline.
+This is similar to stdio.File.byLine, except specified as a template paramter
+rather than a runtime parameter.
+
+bufferedByLine is often quite a bit faster than stdio.File.byLine. Buffering does
+mean that input is not read until a full buffer is available.
 */
 
 auto bufferedByLine(KeepTerminator keepTerminator = No.keepTerminator, Char = char, ubyte terminator = '\n')

--- a/number-lines/src/tsv_utils/number-lines.d
+++ b/number-lines/src/tsv_utils/number-lines.d
@@ -129,7 +129,7 @@ void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
 {
     import std.conv : to;
     import std.range;
-    import tsv_utils.common.utils : BufferedOutputRange;
+    import tsv_utils.common.utils : bufferedByLine, BufferedOutputRange;
 
     auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 
@@ -138,7 +138,7 @@ void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (cmdopt.hasHeader && fileLineNum == 1)
             {

--- a/tsv-append/src/tsv_utils/tsv-append.d
+++ b/tsv-append/src/tsv_utils/tsv-append.d
@@ -208,12 +208,14 @@ struct TsvAppendOptions
 void tsvAppend(OutputRange)(TsvAppendOptions cmdopt, auto ref OutputRange outputStream)
 if (isOutputRange!(OutputRange, char))
 {
+    import tsv_utils.common.utils : bufferedByLine;
+
     bool headerWritten = false;
     foreach (filename; (cmdopt.files.length > 0) ? cmdopt.files : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
         auto sourceName = cmdopt.fileSourceNames[filename];
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (cmdopt.hasHeader && fileLineNum == 1)
             {

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -787,7 +787,7 @@ void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
 {
     import std.algorithm : all, any, splitter;
     import std.range;
-    import tsv_utils.common.utils : BufferedOutputRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : BufferedOutputRange, bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     /* BufferedOutputRange improves performance on narrow files with high percentages of
      * writes. Want responsive output if output is rare, so ensure the first matched
@@ -805,7 +805,7 @@ void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (lineNum, line; inputStream.byLine.enumerate(1))
+        foreach (lineNum, line; inputStream.bufferedByLine.enumerate(1))
         {
             if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, lineNum);
             if (lineNum == 1 && cmdopt.hasHeader)

--- a/tsv-join/src/tsv_utils/tsv-join.d
+++ b/tsv-join/src/tsv_utils/tsv-join.d
@@ -292,7 +292,7 @@ int main(string[] cmdArgs)
  */
 void tsvJoin(in TsvJoinOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.utils : InputFieldReordering, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : InputFieldReordering, bufferedByLine, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
     import std.algorithm : splitter;
     import std.array : join;
     import std.range;
@@ -355,7 +355,7 @@ void tsvJoin(in TsvJoinOptions cmdopt, in string[] inputFiles)
     {
         bool needPerFieldProcessing = (numKeyFields > 0) || (numAppendFields > 0);
         auto filterStream = (cmdopt.filterFile == "-") ? stdin : cmdopt.filterFile.File;
-        foreach (lineNum, line; filterStream.byLine.enumerate(1))
+        foreach (lineNum, line; filterStream.bufferedByLine.enumerate(1))
         {
             debug writeln("[filter line] |", line, "|");
             if (needPerFieldProcessing)
@@ -434,7 +434,7 @@ void tsvJoin(in TsvJoinOptions cmdopt, in string[] inputFiles)
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (lineNum, line; inputStream.byLine.enumerate(1))
+        foreach (lineNum, line; inputStream.bufferedByLine.enumerate(1))
         {
             debug writeln("[input line] |", line, "|");
 

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -500,7 +500,7 @@ void bernoulliSampling(Flag!"generateRandomAll" generateRandomAll, OutputRange)
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -513,7 +513,7 @@ if (isOutputRange!(OutputRange, char))
     foreach (filename; cmdopt.files)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, fileLineNum);
             if (fileLineNum == 1 && cmdopt.hasHeader)
@@ -615,7 +615,7 @@ void bernoulliSkipSampling(OutputRange)(TsvSampleOptions cmdopt, OutputRange out
     import std.conv : to;
     import std.math : log, trunc;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.inclusionProbability > 0.0 && cmdopt.inclusionProbability < 1.0);
     assert(!cmdopt.printRandom);
@@ -637,7 +637,7 @@ void bernoulliSkipSampling(OutputRange)(TsvSampleOptions cmdopt, OutputRange out
     foreach (filename; cmdopt.files)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, fileLineNum);
             if (fileLineNum == 1 && cmdopt.hasHeader)
@@ -694,7 +694,7 @@ if (isOutputRange!(OutputRange, char))
     import std.conv : to;
     import std.digest.murmurhash;
     import std.math : lrint;
-    import tsv_utils.common.utils : InputFieldReordering, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, InputFieldReordering, throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -721,7 +721,7 @@ if (isOutputRange!(OutputRange, char))
     foreach (filename; cmdopt.files)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, fileLineNum);
             if (fileLineNum == 1 && cmdopt.hasHeader)
@@ -907,7 +907,7 @@ if (isOutputRange!(OutputRange, char))
     import std.container.array;
     import std.container.binaryheap;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     static if (isWeighted) assert(cmdopt.hasWeightField);
     else assert(!cmdopt.hasWeightField);
@@ -941,7 +941,7 @@ if (isOutputRange!(OutputRange, char))
     foreach (filename; cmdopt.files)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, fileLineNum);
             if (fileLineNum == 1 && cmdopt.hasHeader)
@@ -1021,7 +1021,7 @@ void generateWeightedRandomValuesInorder(OutputRange)(TsvSampleOptions cmdopt, a
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.hasWeightField);
 
@@ -1033,7 +1033,7 @@ if (isOutputRange!(OutputRange, char))
     foreach (filename; cmdopt.files)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, fileLineNum);
             if (fileLineNum == 1 && cmdopt.hasHeader)
@@ -1104,7 +1104,7 @@ void reservoirSamplingAlgorithmR(OutputRange)(TsvSampleOptions cmdopt, auto ref 
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, randomShuffle, uniform;
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.sampleSize > 0);
     assert(!cmdopt.hasWeightField);
@@ -1125,7 +1125,7 @@ if (isOutputRange!(OutputRange, char))
     foreach (filename; cmdopt.files)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
+        foreach (fileLineNum, line; inputStream.bufferedByLine!(KeepTerminator.no).enumerate(1))
         {
             if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, fileLineNum);
             if (fileLineNum == 1 && cmdopt.hasHeader)

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -199,7 +199,7 @@ enum CTERestLocation { none, first, last };
  */
 void tsvSelect(CTERestLocation cteRest)(in TsvSelectOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.utils: BufferedOutputRange, InputFieldReordering, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils: BufferedOutputRange, bufferedByLine, InputFieldReordering, throwIfWindowsNewlineOnUnix;
     import std.algorithm: splitter;
     import std.format: format;
     import std.range;
@@ -241,7 +241,7 @@ void tsvSelect(CTERestLocation cteRest)(in TsvSelectOptions cmdopt, in string[] 
     foreach (fileNum, filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (lineNum, line; inputStream.byLine.enumerate(1))
+        foreach (lineNum, line; inputStream.bufferedByLine.enumerate(1))
         {
             if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, lineNum);
 

--- a/tsv-summarize/src/tsv_utils/tsv-summarize.d
+++ b/tsv-summarize/src/tsv_utils/tsv-summarize.d
@@ -435,7 +435,7 @@ struct TsvSummarizeOptions {
  */
 void tsvSummarize(TsvSummarizeOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
     /* Pick the Summarizer based on the number of key-fields entered. */
     auto summarizer =
@@ -459,7 +459,7 @@ void tsvSummarize(TsvSummarizeOptions cmdopt, in string[] inputFiles)
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (lineNum, line; inputStream.byLine.enumerate(1))
+        foreach (lineNum, line; inputStream.bufferedByLine.enumerate(1))
         {
             if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, filename, lineNum);
 

--- a/tsv-uniq/src/tsv_utils/tsv-uniq.d
+++ b/tsv-uniq/src/tsv_utils/tsv-uniq.d
@@ -240,7 +240,7 @@ int main(string[] cmdArgs)
  */
 void tsvUniq(in TsvUniqOptions cmdopt, in string[] inputFiles)
 {
-    import tsv_utils.common.utils : InputFieldReordering, BufferedOutputRange;
+    import tsv_utils.common.utils : InputFieldReordering, bufferedByLine, BufferedOutputRange;
     import std.algorithm : splitter;
     import std.array : join;
     import std.conv : to;
@@ -265,7 +265,7 @@ void tsvUniq(in TsvUniqOptions cmdopt, in string[] inputFiles)
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (lineNum, line; inputStream.byLine.enumerate(1))
+        foreach (lineNum, line; inputStream.bufferedByLine.enumerate(1))
         {
             if (cmdopt.hasHeader && lineNum == 1)
             {


### PR DESCRIPTION
This adds a buffered version of `std.stdio.File.byLine` and uses it in most of the tools. This is a meaningful performance improvement. Testing on OSX show improvements between 10-40% on OS X, depending on the tool and file.