### PR TITLE
Use GC Cleanup option none (available dmd 2.085).

### DIFF
--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -161,6 +161,8 @@ struct Csv2tsvOptions
     }
 }
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 version(unittest)
 {
     // No main in unittest

--- a/keep-header/src/tsv_utils/keep-header.d
+++ b/keep-header/src/tsv_utils/keep-header.d
@@ -32,6 +32,8 @@ Options:
 -h         --help   This help information.
 EOS";
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 /** keep-header is a simple program, it is implemented entirely in main.
  */
 int main(string[] args)

--- a/number-lines/src/tsv_utils/number-lines.d
+++ b/number-lines/src/tsv_utils/number-lines.d
@@ -97,6 +97,8 @@ struct NumberLinesOptions
     }
 }
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 /** Main program. */
 int main(string[] cmdArgs)
 {

--- a/tsv-append/src/tsv_utils/tsv-append.d
+++ b/tsv-append/src/tsv_utils/tsv-append.d
@@ -14,6 +14,8 @@ import std.range;
 import std.stdio;
 import std.typecons : tuple;
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 version(unittest)
 {
     // When running unit tests, use main from -main compiler switch.

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -28,6 +28,8 @@ import std.uni: asLowerCase, toLower;
  * a lengthy set, one for each test.
  */
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 /** Main program. Invokes command line arg processing and tsv-filter to perform
  * the real work. Any errors are caught and reported.
  */

--- a/tsv-join/src/tsv_utils/tsv-join.d
+++ b/tsv-join/src/tsv_utils/tsv-join.d
@@ -265,6 +265,8 @@ struct TsvJoinOptions
     }
 }
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 /** Main program.
  */
 int main(string[] cmdArgs)

--- a/tsv-pretty/src/tsv_utils/tsv-pretty.d
+++ b/tsv-pretty/src/tsv_utils/tsv-pretty.d
@@ -13,6 +13,8 @@ import std.range;
 import std.stdio;
 import std.typecons : Flag, Yes, No, tuple;
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 version(unittest)
 {
     // When running unit tests, use main from -main compiler switch.

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -14,6 +14,8 @@ import std.range;
 import std.stdio;
 import std.typecons : tuple, Flag;
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 version(unittest)
 {
     // When running unit tests, use main from -main compiler switch.

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -128,6 +128,8 @@ struct TsvSelectOptions
     }
 }
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 /** Main program.
  */
 int main(string[] cmdArgs)

--- a/tsv-summarize/src/tsv_utils/tsv-summarize.d
+++ b/tsv-summarize/src/tsv_utils/tsv-summarize.d
@@ -18,6 +18,8 @@ import std.stdio;
 import std.typecons : tuple;
 import std.container : DList;
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 version(unittest)
 {
     // When running unit tests, use main from -main compiler switch.

--- a/tsv-uniq/src/tsv_utils/tsv-uniq.d
+++ b/tsv-uniq/src/tsv_utils/tsv-uniq.d
@@ -208,6 +208,8 @@ struct TsvUniqOptions
     }
 }
 
+static if (__VERSION__ >= 2085) extern(C) __gshared string[] rt_options = [ "gcopt=cleanup:none" ];
+
 /** Main program. Processes command line arguments and calls tsvUniq which implements
  * the main processing logic.
  */


### PR DESCRIPTION
Use the new option to skip GC cleanup at program termination. Small performance improvements. Negligible in most tools, up to 5% in a couple.