### PR TITLE
Update Travis-CI to use Xcode10.2 (mojave) and Ubuntu 16.04 (Xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
       env: DUBTEST=1 MAKETEST=1
       if: type IN (cron)
     - os: linux
+      dist: xenial
       group: travis_latest
       language: d
       d: dmd
@@ -33,6 +34,7 @@ matrix:
 #      d: ldc-1.6.0
 #      env: DUBTEST=1 MAKETEST=1 APPLTO=off
     - os: linux
+      dist: xenial
       group: travis_latest
       language: d
       d: ldc-1.6.0
@@ -77,6 +79,7 @@ matrix:
       if: type IN (pull_request, cron)
 #      if: fork = true
     - os: linux
+      dist: xenial
       group: travis_latest
       language: d
       d: ldc
@@ -84,12 +87,14 @@ matrix:
       if: type IN (pull_request, cron)
 #      if: fork = true
     - os: linux
+      dist: xenial
       group: travis_latest
       language: d
       d: ldc
       env: LTOPGO=default
       if: type IN (pull_request, cron)
     - os: linux
+      dist: xenial
       group: travis_latest
       language: d
       d: ldc

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ matrix:
 #      d: ldc
 #      env: LINUX_SPECIAL=1
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       group: travis_latest
       language: d
@@ -116,7 +116,7 @@ matrix:
       env: DOCKERSPECIAL=1
       if: type IN (pull_request, cron)
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       group: travis_latest
       language: d

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
 #==> Use only in Cron build until Travis has more OSX capacity
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       group: travis_latest
       language: d
       d: dmd
@@ -27,7 +27,7 @@ matrix:
       d: dmd
       env: DUBTEST=1 MAKETEST=1 CODECOV=1
 #    - os: osx
-#      osx_image: xcode10.1
+#      osx_image: xcode10.2
 #      group: travis_latest
 #      language: d
 #      d: ldc-1.6.0
@@ -42,7 +42,7 @@ matrix:
 #
 #==> Put back when Travis has more OSX capacity
 #    - os: osx
-#      osx_image: xcode10.1
+#      osx_image: xcode10.2
 #      group: travis_latest
 #      language: d
 #      d: ldc
@@ -50,20 +50,20 @@ matrix:
 #      if: type IN (pull_request, cron)
 #      if: fork = true
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc
       env: LTOPGO=default
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc
       env: LTOPGO_V2=default
       if: type IN (pull_request, cron)
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       group: travis_latest
       language: d
       d: ldc-1.12.0


### PR DESCRIPTION
Travis recently made Xcode 10.2 available. The Ubuntu change is prompted by a bug in LDC 1.15.0 (just released) when building PGO instrumented builds on Ubuntu 14 (Trusty) See: [ldc #3054](https://github.com/ldc-developers/ldc/issues/3054). Also, Ubuntu 14 is very near end-of-life, so no reason not to switch.