### PR TITLE
Drop the AUR prebuilt release from the README until a more up to date…

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,6 @@ $ curl -L https://github.com/eBay/tsv-utils/releases/download/v1.3.2/tsv-utils-v
 
 See the [Github releases](https://github.com/eBay/tsv-utils/releases) page for the latest release.
 
-For some distributions a package can directly be installed:
-
-| Distribution | Command               |
-| ------------ | --------------------- |
-| Arch Linux   | `pacaur -S tsv-utils` (see [`tsv-utils`](https://aur.archlinux.org/packages/tsv-utils/))
-
-*Note: The distributions above are not updated as frequently as the [Github releases](https://github.com/eBay/tsv-utils/releases) page.*
-
 ### Build from source files
 
 [Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.076.1 or later, LDC version 1.6.0 or later.


### PR DESCRIPTION
… version is available.

The AUR package is at 1.1.15, released nearly 18 months ago. The AUR package has now been flagged as out of date. Will add the AUR release information back into the readme when the package has been updated.