### PR TITLE
tsv-pretty auto preamble

### DIFF
--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -161,11 +161,11 @@ _tsv_pretty()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --version --header --no-header --lookahead --repeat-header --underline-header --format-floats --precision --replace-empty --empty-replacement --delimiter --space-between-fields --max-text-width --preamble"
+    opts="--help --help-verbose --version --header --no-header --lookahead --repeat-header --underline-header --format-floats --precision --replace-empty --empty-replacement --delimiter --space-between-fields --max-text-width --auto-preamble --preamble"
 
     # Options requiring an argument or precluding other options
     case $prev in
-         -h--help|--help-verbose|-V|--version|-l|--lookahead|-r|--repeat-header|-p|--precision|-E|--empty-replacement|-d|--delimiter|-s|--space-between-fields|-m|--max-text-width|-a|--preamble)
+         -h--help|--help-verbose|-V|--version|-l|--lookahead|-r|--repeat-header|-p|--precision|-E|--empty-replacement|-d|--delimiter|-s|--space-between-fields|-m|--max-text-width|-b|--preamble)
           return
           ;;
     esac

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -659,7 +659,7 @@ Features:
 
 * Exponential notion: As part of float formatting, `--f|format-floats` re-formats columns where exponential notation is found so all the values in the column are displayed using exponential notation and the same precision.
 
-* Preamble: A number of initial lines can be designated as a preamble and output unchanged. The preamble is before the header, if a header is present.
+* Preamble: A number of initial lines can be designated as a preamble and output unchanged. The preamble is before the header, if a header is present. Preamble lines can be auto-detected via the heuristic that they lack field delimiters. This works well when the field delimiter is a TAB.
 
 * Fonts: Fixed-width fonts are assumed. CJK characters are assumed to be double width. This is not always correct, but works well in most cases.
 
@@ -678,7 +678,8 @@ Features:
 * `--d|delimiter CHR` - Field delimiter. Default: TAB. (Single byte UTF-8 characters only.)
 * `--s|space-between-fields NUM` - Spaces between each field (Default: 2)
 * `--m|max-text-width NUM` - Max reserved field width for variable width text fields. Default: 40
-* `--a|preamble NUM` - Treat the first NUM lines as a preamble and output them unchanged.
+* `--a|auto-preamble` - Treat initial lines in a file as a preamble if the line contains no field delimiters. The preamble is output unchanged.
+* `--b|preamble NUM` - Treat the first NUM lines as a preamble and output them unchanged.
 * `--V|version` - Print version information and exit.
 * `--h|help` - This help information.
 

--- a/tsv-pretty/tests/gold/basic_tests_6.txt
+++ b/tsv-pretty/tests/gold/basic_tests_6.txt
@@ -1,3 +1,5 @@
+Fixed length preambles
+----------------------
 
 ====[tsv-pretty --preamble 1 input_5x1_preamble1.tsv]====
 ### A one line preamble ###
@@ -24,7 +26,7 @@ Text-1  Num-1  Mix-1  Mix-2  Mix-3
 ------  -----  -----  -----  -----
 ABC        22     14  .      ab
 
-====[tsv-pretty -a 1 -u input_5x2_preamble1.tsv input_5x3_preamble1.tsv]====
+====[tsv-pretty -b 1 -u input_5x2_preamble1.tsv input_5x3_preamble1.tsv]====
 ### A one line preamble ###
 Text-1    Num-1  Mix-1   Mix-2  Mix-3
 ------    -----  -----   -----  -----
@@ -32,7 +34,7 @@ ABC          22  14      .      ab
 DEF        2233  0.0     e      nan
 GHIJKLM  223344  1.4e07  17     ghi
 
-====[tsv-pretty -a 1 -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv input_5x3_preamble1.tsv]====
+====[tsv-pretty -b 1 -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv input_5x3_preamble1.tsv]====
 ### A one line preamble ###
 Text-1    Num-1  Mix-1   Mix-2  Mix-3
 ------    -----  -----   -----  -----
@@ -40,28 +42,28 @@ ABC          22  14      .      ab
 DEF        2233  0.0     e      nan
 GHIJKLM  223344  1.4e07  17     ghi
 
-====[tsv-pretty -a 1 --no-header input_5x1_noheader_preamble1.tsv]====
+====[tsv-pretty -b 1 --no-header input_5x1_noheader_preamble1.tsv]====
 ### A one line preamble ###
 ABC  22  14  .  ab
 
-====[tsv-pretty -a 1 --no-header input_5x1_noheader_preamble1.tsv input_5x1_noheader_preamble1.tsv]====
+====[tsv-pretty -b 1 --no-header input_5x1_noheader_preamble1.tsv input_5x1_noheader_preamble1.tsv]====
 ### A one line preamble ###
 ABC  22  14  .  ab
 ABC  22  14  .  ab
 
-====[tsv-pretty -a 1 --no-header input_5x2_noheader_preamble1.tsv]====
+====[tsv-pretty -b 1 --no-header input_5x2_noheader_preamble1.tsv]====
 ### A one line preamble ###
 DEF        2233  0.0     e   nan
 GHIJKLM  223344  1.4e07  17  ghi
 
-====[tsv-pretty -a 1 -x input_5x2_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv]====
+====[tsv-pretty -b 1 -x input_5x2_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv]====
 ### A one line preamble ###
 DEF        2233  0.0     e   nan
 GHIJKLM  223344  1.4e07  17  ghi
 DEF        2233  0.0     e   nan
 GHIJKLM  223344  1.4e07  17  ghi
 
-====[tsv-pretty -a 1 -x input_5x1_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv]====
+====[tsv-pretty -b 1 -x input_5x1_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv]====
 ### A one line preamble ###
 ABC          22  14      .   ab
 DEF        2233  0.0     e   nan
@@ -97,7 +99,7 @@ Text-1  Num-1  Mix-1  Mix-2  Mix-3
 ------  -----  -----  -----  -----
 ABC        22     14  .      ab
 
-====[tsv-pretty -a 2 -u input_5x2_preamble2.tsv input_5x3_preamble2.tsv]====
+====[tsv-pretty -b 2 -u input_5x2_preamble2.tsv input_5x3_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 Text-1    Num-1  Mix-1   Mix-2  Mix-3
@@ -106,7 +108,7 @@ ABC          22  14      .      ab
 DEF        2233  0.0     e      nan
 GHIJKLM  223344  1.4e07  17     ghi
 
-====[tsv-pretty -a 2 -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv input_5x3_preamble2.tsv]====
+====[tsv-pretty -b 2 -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv input_5x3_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 Text-1    Num-1  Mix-1   Mix-2  Mix-3
@@ -115,24 +117,24 @@ ABC          22  14      .      ab
 DEF        2233  0.0     e      nan
 GHIJKLM  223344  1.4e07  17     ghi
 
-====[tsv-pretty -a 2 --no-header input_5x1_noheader_preamble2.tsv]====
+====[tsv-pretty -b 2 --no-header input_5x1_noheader_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 ABC  22  14  .  ab
 
-====[tsv-pretty -a 2 --no-header input_5x1_noheader_preamble2.tsv input_5x1_noheader_preamble2.tsv]====
+====[tsv-pretty -b 2 --no-header input_5x1_noheader_preamble2.tsv input_5x1_noheader_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 ABC  22  14  .  ab
 ABC  22  14  .  ab
 
-====[tsv-pretty -a 2 --no-header input_5x2_noheader_preamble2.tsv]====
+====[tsv-pretty -b 2 --no-header input_5x2_noheader_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 DEF        2233  0.0     e   nan
 GHIJKLM  223344  1.4e07  17  ghi
 
-====[tsv-pretty -a 2 -x input_5x2_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv]====
+====[tsv-pretty -b 2 -x input_5x2_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 DEF        2233  0.0     e   nan
@@ -140,7 +142,7 @@ GHIJKLM  223344  1.4e07  17  ghi
 DEF        2233  0.0     e   nan
 GHIJKLM  223344  1.4e07  17  ghi
 
-====[tsv-pretty -a 2 -x input_5x1_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv]====
+====[tsv-pretty -b 2 -x input_5x1_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv]====
 ### First line of a two-line preamble ###
 ### Second line of a two-line preamble ###
 ABC          22  14      .   ab

--- a/tsv-pretty/tests/gold/basic_tests_7.txt
+++ b/tsv-pretty/tests/gold/basic_tests_7.txt
@@ -1,0 +1,150 @@
+Auto-detect Preambles
+---------------------
+
+====[tsv-pretty --auto-preamble input_5x1_preamble1.tsv]====
+### A one line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+
+====[tsv-pretty --auto-preamble input_5x2_preamble1.tsv]====
+### A one line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+ABC        22     14  .      ab
+
+====[tsv-pretty --auto-preamble input_5x3_preamble1.tsv]====
+### A one line preamble ###
+Text-1    Num-1  Mix-1   Mix-2  Mix-3
+DEF        2233  0.0     e      nan
+GHIJKLM  223344  1.4e07  17     ghi
+
+====[tsv-pretty --auto-preamble input_5x1_preamble1.tsv input_5x1_preamble1.tsv]====
+### A one line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+
+====[tsv-pretty --auto-preamble -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv]====
+### A one line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+------  -----  -----  -----  -----
+ABC        22     14  .      ab
+
+====[tsv-pretty -a -u input_5x2_preamble1.tsv input_5x3_preamble1.tsv]====
+### A one line preamble ###
+Text-1    Num-1  Mix-1   Mix-2  Mix-3
+------    -----  -----   -----  -----
+ABC          22  14      .      ab
+DEF        2233  0.0     e      nan
+GHIJKLM  223344  1.4e07  17     ghi
+
+====[tsv-pretty -a -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv input_5x3_preamble1.tsv]====
+### A one line preamble ###
+Text-1    Num-1  Mix-1   Mix-2  Mix-3
+------    -----  -----   -----  -----
+ABC          22  14      .      ab
+DEF        2233  0.0     e      nan
+GHIJKLM  223344  1.4e07  17     ghi
+
+====[tsv-pretty -a --no-header input_5x1_noheader_preamble1.tsv]====
+### A one line preamble ###
+ABC  22  14  .  ab
+
+====[tsv-pretty -a --no-header input_5x1_noheader_preamble1.tsv input_5x1_noheader_preamble1.tsv]====
+### A one line preamble ###
+ABC  22  14  .  ab
+ABC  22  14  .  ab
+
+====[tsv-pretty -a --no-header input_5x2_noheader_preamble1.tsv]====
+### A one line preamble ###
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+
+====[tsv-pretty -a -x input_5x2_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv]====
+### A one line preamble ###
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+
+====[tsv-pretty -a -x input_5x1_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv]====
+### A one line preamble ###
+ABC          22  14      .   ab
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+
+====[tsv-pretty --auto-preamble input_5x1_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+
+====[tsv-pretty --auto-preamble input_5x2_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+ABC        22     14  .      ab
+
+====[tsv-pretty --auto-preamble input_5x3_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1    Num-1  Mix-1   Mix-2  Mix-3
+DEF        2233  0.0     e      nan
+GHIJKLM  223344  1.4e07  17     ghi
+
+====[tsv-pretty --auto-preamble input_5x1_preamble2.tsv input_5x1_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+
+====[tsv-pretty --auto-preamble -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+------  -----  -----  -----  -----
+ABC        22     14  .      ab
+
+====[tsv-pretty -a -u input_5x2_preamble2.tsv input_5x3_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1    Num-1  Mix-1   Mix-2  Mix-3
+------    -----  -----   -----  -----
+ABC          22  14      .      ab
+DEF        2233  0.0     e      nan
+GHIJKLM  223344  1.4e07  17     ghi
+
+====[tsv-pretty -a -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv input_5x3_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+Text-1    Num-1  Mix-1   Mix-2  Mix-3
+------    -----  -----   -----  -----
+ABC          22  14      .      ab
+DEF        2233  0.0     e      nan
+GHIJKLM  223344  1.4e07  17     ghi
+
+====[tsv-pretty -a --no-header input_5x1_noheader_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+ABC  22  14  .  ab
+
+====[tsv-pretty -a --no-header input_5x1_noheader_preamble2.tsv input_5x1_noheader_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+ABC  22  14  .  ab
+ABC  22  14  .  ab
+
+====[tsv-pretty -a --no-header input_5x2_noheader_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+
+====[tsv-pretty -a -x input_5x2_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi
+
+====[tsv-pretty -a -x input_5x1_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv]====
+### First line of a two-line preamble ###
+### Second line of a two-line preamble ###
+ABC          22  14      .   ab
+DEF        2233  0.0     e   nan
+GHIJKLM  223344  1.4e07  17  ghi

--- a/tsv-pretty/tests/gold/basic_tests_8.txt
+++ b/tsv-pretty/tests/gold/basic_tests_8.txt
@@ -1,0 +1,150 @@
+Auto-detect Preambles: Misc tests
+---------------------------------
+
+===[cat input_mixed_1.tsv]===
+I1	T1	F1	T2	F2	Mixed
+3	A	.1	HelloWorld	-1.28098e-05	15
+89	B	0.008	23rd	18.23	23.0
+222	foo	135.6	thirty	3311.235	19.1
+4	foobar	-23.72	ten	0.0821	ABC
+-5900	foobarbaz	8.03556e-09	--text--	-31.002	1001
+6789e+23	abcdefghijklmnopqrstuvwxyz	-6.758191e-14	x	0.518	ABCDEFGHI
+17	cat	5.31	ABCDE	22.1	101
+
+====[tsv-pretty --auto-preamble input_mixed_1.tsv]====
+      I1  T1                                     F1  T2                    F2  Mixed
+       3  A                                      .1  HelloWorld  -1.28098e-05  15
+      89  B                                   0.008  23rd               18.23  23.0
+     222  foo                                 135.6  thirty          3311.235  19.1
+       4  foobar                             -23.72  ten               0.0821  ABC
+   -5900  foobarbaz                     8.03556e-09  --text--         -31.002  1001
+6789e+23  abcdefghijklmnopqrstuvwxyz  -6.758191e-14  x                  0.518  ABCDEFGHI
+      17  cat                                  5.31  ABCDE               22.1  101
+
+====[tsv-pretty --auto-preamble --preamble 0 input_mixed_1.tsv]====
+      I1  T1                                     F1  T2                    F2  Mixed
+       3  A                                      .1  HelloWorld  -1.28098e-05  15
+      89  B                                   0.008  23rd               18.23  23.0
+     222  foo                                 135.6  thirty          3311.235  19.1
+       4  foobar                             -23.72  ten               0.0821  ABC
+   -5900  foobarbaz                     8.03556e-09  --text--         -31.002  1001
+6789e+23  abcdefghijklmnopqrstuvwxyz  -6.758191e-14  x                  0.518  ABCDEFGHI
+      17  cat                                  5.31  ABCDE               22.1  101
+
+====[tsv-pretty -a -x input_mixed_1.tsv]====
+I1        T1                          F1             T2          F2            Mixed
+3         A                           .1             HelloWorld  -1.28098e-05  15
+89        B                           0.008          23rd        18.23         23.0
+222       foo                         135.6          thirty      3311.235      19.1
+4         foobar                      -23.72         ten         0.0821        ABC
+-5900     foobarbaz                   8.03556e-09    --text--    -31.002       1001
+6789e+23  abcdefghijklmnopqrstuvwxyz  -6.758191e-14  x           0.518         ABCDEFGHI
+17        cat                         5.31           ABCDE       22.1          101
+
+====[tsv-pretty -a -H input_mixed_1.tsv]====
+      I1  T1                                     F1  T2                    F2  Mixed
+       3  A                                      .1  HelloWorld  -1.28098e-05  15
+      89  B                                   0.008  23rd               18.23  23.0
+     222  foo                                 135.6  thirty          3311.235  19.1
+       4  foobar                             -23.72  ten               0.0821  ABC
+   -5900  foobarbaz                     8.03556e-09  --text--         -31.002  1001
+6789e+23  abcdefghijklmnopqrstuvwxyz  -6.758191e-14  x                  0.518  ABCDEFGHI
+      17  cat                                  5.31  ABCDE               22.1  101
+
+====[tsv-pretty -a --lookahead 3 input_mixed_1.tsv]====
+ I1  T1        F1  T2                    F2  Mixed
+  3  A       .1    HelloWorld  -1.28098e-05   15
+ 89  B      0.008  23rd               18.23   23.0
+222  foo  135.6    thirty          3311.235   19.1
+  4  foobar -23.72 ten               0.0821    ABC
+-5900 foobarbaz 8.03556e-09 --text-- -31.002 1001
+6789e+23 abcdefghijklmnopqrstuvwxyz -6.758191e-14 x 0.518 ABCDEFGHI
+ 17  cat    5.31   ABCDE               22.1  101
+
+===[cat input_mixed_2.tsv]===
+Date	Text	Value	Score
+07-17-2003	My hands were black with dirt	1029	17.58
+11-12-1991	two of our young Irish sculptors	14	107.3
+06-21-1983	Ahora, mi amigo Cincunegui se ha empeñado	972	73.83
+03-07-2011	C'était un vieux marin, basané, goudronné	114	0.92
+07-02-1823	Omtrent de werkelijke uitgestrektheid van het gebied	11	3.2
+08-24-1765	Hasta tal punto era desconocida de casi todos	32	123.0
+10-17-2001	Die teils aus groben Wollenstoffen	172	63.38
+04-13-1986	Die Männer traten jetzt näher herzu	46	78.32
+
+====[tsv-pretty --auto-preamble input_mixed_2.tsv]====
+Date        Text                                      Value   Score
+07-17-2003  My hands were black with dirt              1029   17.58
+11-12-1991  two of our young Irish sculptors             14  107.3
+06-21-1983  Ahora, mi amigo Cincunegui se ha empeñado   972   73.83
+03-07-2011  C'était un vieux marin, basané, goudronné   114    0.92
+07-02-1823  Omtrent de werkelijke uitgestrektheid van het gebied 11 3.2
+08-24-1765  Hasta tal punto era desconocida de casi todos 32 123.0
+10-17-2001  Die teils aus groben Wollenstoffen          172   63.38
+04-13-1986  Die Männer traten jetzt näher herzu          46   78.32
+
+====[tsv-pretty -a -u input_mixed_2.tsv]====
+Date        Text                                      Value   Score
+----        ----                                      -----   -----
+07-17-2003  My hands were black with dirt              1029   17.58
+11-12-1991  two of our young Irish sculptors             14  107.3
+06-21-1983  Ahora, mi amigo Cincunegui se ha empeñado   972   73.83
+03-07-2011  C'était un vieux marin, basané, goudronné   114    0.92
+07-02-1823  Omtrent de werkelijke uitgestrektheid van het gebied 11 3.2
+08-24-1765  Hasta tal punto era desconocida de casi todos 32 123.0
+10-17-2001  Die teils aus groben Wollenstoffen          172   63.38
+04-13-1986  Die Männer traten jetzt näher herzu          46   78.32
+
+===[cat input_5x1.tsv]===
+Text-1	Num-1	Mix-1	Mix-2	Mix-3
+
+====[tsv-pretty -a input_5x1.tsv]====
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+
+===[cat input_5x2.tsv]===
+Text-1	Num-1	Mix-1	Mix-2	Mix-3
+ABC	22	14	.	ab
+
+====[tsv-pretty -a input_5x2.tsv]====
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+ABC        22     14  .      ab
+
+====[tsv-pretty -a input_5x2.tsv input_5x2.tsv]====
+Text-1  Num-1  Mix-1  Mix-2  Mix-3
+ABC        22     14  .      ab
+ABC        22     14  .      ab
+
+===[cat input_comma_delim.tsv]===
+F1,Field Two,3,Four
+A to Z,def,3,4
+A-to-Z,DEF,3.,4.
+A到Z," PQR",3.0,4.00
+A〜Z,$@#,3.00,4.0
+
+====[tsv-pretty --auto-preamble input_comma_delim.tsv]====
+F1,Field Two,3,Four
+A to Z,def,3,4
+A-to-Z,DEF,3.,4.
+A到Z," PQR",3.0,4.00
+A〜Z,$@#,3.00,4.0
+
+====[tsv-pretty -a --delimiter , input_comma_delim.tsv]====
+F1      Field Two     3  Four
+A to Z  def        3     4
+A-to-Z  DEF        3.    4.
+A到Z    " PQR"     3.0   4.00
+A〜Z    $@#        3.00  4.0
+
+====[tsv-pretty -a --header -d , input_comma_delim.tsv]====
+F1      Field Two     3  Four
+A to Z  def        3     4
+A-to-Z  DEF        3.    4.
+A到Z    " PQR"     3.0   4.00
+A〜Z    $@#        3.00  4.0
+
+====[tsv-pretty -a --no-header -d , input_comma_delim.tsv]====
+F1      Field Two  3     Four
+A to Z  def        3     4
+A-to-Z  DEF        3.    4.
+A到Z    " PQR"     3.0   4.00
+A〜Z    $@#        3.00  4.0

--- a/tsv-pretty/tests/gold/basic_tests_8.txt
+++ b/tsv-pretty/tests/gold/basic_tests_8.txt
@@ -1,6 +1,50 @@
 Auto-detect Preambles: Misc tests
 ---------------------------------
 
+===[cat input_sample_preamble.tsv]===
+# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
+# Color is an alphabetic, the others are numeric.
+
+Color	Count	Ht	Wt
+Brown	106	202.2	1.5
+Canary Yellow	7	106	0.761
+Chartreuse	1139	77.02	6.22
+Fluorescent Orange	422	1141.7	7.921
+Grey	19	140.3	1.03
+
+====[tsv-pretty -f input_sample_preamble.tsv]====
+# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
+# Color is an alphabetic, the others are numeric.
+
+Color                                     Count  Ht      Wt
+Brown                                     106    202.2   1.5
+Canary Yellow                             7      106     0.761
+Chartreuse                                1139   77.02   6.22
+Fluorescent Orange                        422    1141.7  7.921
+Grey                                      19     140.3   1.03
+
+====[tsv-pretty -f --auto-preamble input_sample_preamble.tsv]====
+# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
+# Color is an alphabetic, the others are numeric.
+
+Color               Count       Ht     Wt
+Brown                 106   202.20  1.500
+Canary Yellow           7   106.00  0.761
+Chartreuse           1139    77.02  6.220
+Fluorescent Orange    422  1141.70  7.921
+Grey                   19   140.30  1.030
+
+====[tsv-pretty -f --preamble 3 input_sample_preamble.tsv]====
+# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
+# Color is an alphabetic, the others are numeric.
+
+Color               Count       Ht     Wt
+Brown                 106   202.20  1.500
+Canary Yellow           7   106.00  0.761
+Chartreuse           1139    77.02  6.220
+Fluorescent Orange    422  1141.70  7.921
+Grey                   19   140.30  1.030
+
 ===[cat input_mixed_1.tsv]===
 I1	T1	F1	T2	F2	Mixed
 3	A	.1	HelloWorld	-1.28098e-05	15

--- a/tsv-pretty/tests/gold/error_tests_1.txt
+++ b/tsv-pretty/tests/gold/error_tests_1.txt
@@ -28,6 +28,9 @@ Error [tsv-pretty]: Cannot open file `no_such_file.tsv' in mode `rb' (No such fi
 ====[tsv-pretty --lookahead 0 input_unicode.tsv]====
 [tsv-pretty] Error processing command line arguments: Cannot auto-detect header with zero look-ahead. Specify either '--H|header' or '--x|no-header' when using '--l|lookahead 0'.
 
+====[tsv-pretty --auto-preamble --preamble 1 input_unicode.tsv]====
+[tsv-pretty] Error processing command line arguments: Do not use '--b|preamble NUM' and '--a|auto-preamble' together. ('--b|preamble 0' is okay.)
+
 ====[tsv-pretty invalid_unicode.tsv]====
 Column-1       Column-2  Column-3
 white          Weiß      白

--- a/tsv-pretty/tests/input_sample_preamble.tsv
+++ b/tsv-pretty/tests/input_sample_preamble.tsv
@@ -1,0 +1,9 @@
+# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
+# Color is an alphabetic, the others are numeric.
+
+Color	Count	Ht	Wt
+Brown	106	202.2	1.5
+Canary Yellow	7	106	0.761
+Chartreuse	1139	77.02	6.22
+Fluorescent Orange	422	1141.7	7.921
+Grey	19	140.3	1.03

--- a/tsv-pretty/tests/tests.sh
+++ b/tsv-pretty/tests/tests.sh
@@ -575,35 +575,104 @@ echo "" >> ${basic_tests_5}; echo "====[cat input_5x5.tsv | tsv-pretty -u -- inp
 cat input_5x5.tsv | ${prog} -u -- input_5x2.tsv - >> ${basic_tests_5} 2>&1
 
 ###
-### Preamble tests. Use file ${basics_tests_6}
+### Preamble tests. Use files ${basics_tests_6}, ${basics_tests_7}, ${basics_tests_8}
 ###
 basic_tests_6=${odir}/basic_tests_6.txt
+
+echo "Fixed length preambles" >> ${basic_tests_6}
+echo "----------------------" >> ${basic_tests_6}
 
 runtest ${prog} "--preamble 1 input_5x1_preamble1.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 1 input_5x2_preamble1.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 1 input_5x3_preamble1.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 1 input_5x1_preamble1.tsv input_5x1_preamble1.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 1 -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 -u input_5x2_preamble1.tsv input_5x3_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv input_5x3_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 --no-header input_5x1_noheader_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 --no-header input_5x1_noheader_preamble1.tsv input_5x1_noheader_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 --no-header input_5x2_noheader_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 -x input_5x2_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv" ${basic_tests_6}
-runtest ${prog} "-a 1 -x input_5x1_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 -u input_5x2_preamble1.tsv input_5x3_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv input_5x3_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 --no-header input_5x1_noheader_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 --no-header input_5x1_noheader_preamble1.tsv input_5x1_noheader_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 --no-header input_5x2_noheader_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 -x input_5x2_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv" ${basic_tests_6}
+runtest ${prog} "-b 1 -x input_5x1_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv" ${basic_tests_6}
 
 runtest ${prog} "--preamble 2 input_5x1_preamble2.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 2 input_5x2_preamble2.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 2 input_5x3_preamble2.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 2 input_5x1_preamble2.tsv input_5x1_preamble2.tsv" ${basic_tests_6}
 runtest ${prog} "--preamble 2 -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 -u input_5x2_preamble2.tsv input_5x3_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv input_5x3_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 --no-header input_5x1_noheader_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 --no-header input_5x1_noheader_preamble2.tsv input_5x1_noheader_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 --no-header input_5x2_noheader_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 -x input_5x2_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv" ${basic_tests_6}
-runtest ${prog} "-a 2 -x input_5x1_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 -u input_5x2_preamble2.tsv input_5x3_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv input_5x3_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 --no-header input_5x1_noheader_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 --no-header input_5x1_noheader_preamble2.tsv input_5x1_noheader_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 --no-header input_5x2_noheader_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 -x input_5x2_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv" ${basic_tests_6}
+runtest ${prog} "-b 2 -x input_5x1_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv" ${basic_tests_6}
+
+###
+### A repeat of basic_tests_6, but using auto-detect
+###
+basic_tests_7=${odir}/basic_tests_7.txt
+
+echo "Auto-detect Preambles" >> ${basic_tests_7}
+echo "---------------------" >> ${basic_tests_7}
+
+runtest ${prog} "--auto-preamble input_5x1_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble input_5x2_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble input_5x3_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble input_5x1_preamble1.tsv input_5x1_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a -u input_5x2_preamble1.tsv input_5x3_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a -u input_5x1_preamble1.tsv input_5x2_preamble1.tsv input_5x3_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a --no-header input_5x1_noheader_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a --no-header input_5x1_noheader_preamble1.tsv input_5x1_noheader_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a --no-header input_5x2_noheader_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a -x input_5x2_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv" ${basic_tests_7}
+runtest ${prog} "-a -x input_5x1_noheader_preamble1.tsv input_5x2_noheader_preamble1.tsv" ${basic_tests_7}
+
+runtest ${prog} "--auto-preamble input_5x1_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble input_5x2_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble input_5x3_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble input_5x1_preamble2.tsv input_5x1_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "--auto-preamble -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a -u input_5x2_preamble2.tsv input_5x3_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a -u input_5x1_preamble2.tsv input_5x2_preamble2.tsv input_5x3_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a --no-header input_5x1_noheader_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a --no-header input_5x1_noheader_preamble2.tsv input_5x1_noheader_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a --no-header input_5x2_noheader_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a -x input_5x2_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv" ${basic_tests_7}
+runtest ${prog} "-a -x input_5x1_noheader_preamble2.tsv input_5x2_noheader_preamble2.tsv" ${basic_tests_7}
+
+###
+### Auto-detect preambles: None-detect cases; alternate delimiters, etc.
+###
+basic_tests_8=${odir}/basic_tests_8.txt
+
+echo "Auto-detect Preambles: Misc tests" >> ${basic_tests_8}
+echo "---------------------------------" >> ${basic_tests_8}
+
+runcmd "cat input_mixed_1.tsv" ${basic_tests_8}
+runtest ${prog} "--auto-preamble input_mixed_1.tsv" ${basic_tests_8}
+runtest ${prog} "--auto-preamble --preamble 0 input_mixed_1.tsv" ${basic_tests_8}
+runtest ${prog} "-a -x input_mixed_1.tsv" ${basic_tests_8}
+runtest ${prog} "-a -H input_mixed_1.tsv" ${basic_tests_8}
+runtest ${prog} "-a --lookahead 3 input_mixed_1.tsv" ${basic_tests_8}
+
+runcmd "cat input_mixed_2.tsv" ${basic_tests_8}
+runtest ${prog} "--auto-preamble input_mixed_2.tsv" ${basic_tests_8}
+runtest ${prog} "-a -u input_mixed_2.tsv" ${basic_tests_8}
+
+runcmd "cat input_5x1.tsv" ${basic_tests_8}
+runtest ${prog} "-a input_5x1.tsv" ${basic_tests_8}
+
+runcmd "cat input_5x2.tsv" ${basic_tests_8}
+runtest ${prog} "-a input_5x2.tsv" ${basic_tests_8}
+runtest ${prog} "-a input_5x2.tsv input_5x2.tsv" ${basic_tests_8}
+
+runcmd "cat input_comma_delim.tsv" ${basic_tests_8}
+runtest ${prog} "--auto-preamble input_comma_delim.tsv" ${basic_tests_8}
+runtest ${prog} "-a --delimiter , input_comma_delim.tsv" ${basic_tests_8}
+runtest ${prog} "-a --header -d , input_comma_delim.tsv" ${basic_tests_8}
+runtest ${prog} "-a --no-header -d , input_comma_delim.tsv" ${basic_tests_8}
 
 ## Error cases
 
@@ -621,4 +690,5 @@ runtest ${prog} "--lookahead 1.5 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "--space-between-fields 1.5 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "--max-text-width -1 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "--lookahead 0 input_unicode.tsv" ${error_tests_1}
+runtest ${prog} "--auto-preamble --preamble 1 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "invalid_unicode.tsv" ${error_tests_1}

--- a/tsv-pretty/tests/tests.sh
+++ b/tsv-pretty/tests/tests.sh
@@ -650,6 +650,11 @@ basic_tests_8=${odir}/basic_tests_8.txt
 echo "Auto-detect Preambles: Misc tests" >> ${basic_tests_8}
 echo "---------------------------------" >> ${basic_tests_8}
 
+runcmd "cat input_sample_preamble.tsv" ${basic_tests_8}
+runtest ${prog} "-f input_sample_preamble.tsv" ${basic_tests_8}
+runtest ${prog} "-f --auto-preamble input_sample_preamble.tsv" ${basic_tests_8}
+runtest ${prog} "-f --preamble 3 input_sample_preamble.tsv" ${basic_tests_8}
+
 runcmd "cat input_mixed_1.tsv" ${basic_tests_8}
 runtest ${prog} "--auto-preamble input_mixed_1.tsv" ${basic_tests_8}
 runtest ${prog} "--auto-preamble --preamble 0 input_mixed_1.tsv" ${basic_tests_8}


### PR DESCRIPTION
This PR adds the an option to tsv-pretty to auto-detect preamble lines. The option is `--a|auto-preamble`. The short form of the option `--preamble NUM` option was changed from 'a' to 'b'.

Auto-detection of preamble lines uses a very simple heuristic: Lines at the start of a file that do not contain field delimiters are considered part of the preamble. This works well when the field delimiter is TAB (default for TSV), and the file has two or more fields.

Without preamble support the initial lines are typically interpreted as a single field, interfering with header detection and correct field type and width interpretation. For example:
```
$ tsv-pretty -f sample.tsv
# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
# Color is an alphabetic, the others are numeric.

Color                                     Count  Ht      Wt
Brown                                     106    202.2   1.5
Canary Yellow                             7      106     0.761
Chartreuse                                1139   77.02   6.22
Fluorescent Orange                        422    1141.7  7.921
Grey                                      19     140.3   1.03
```

`sample.tsv` has three preamble lines, two starting with '#' and one blank line. Turning preamble detection on corrects the output:
```
$ tsv-pretty -f --auto-preamble sample.tsv
# This file contains 4 fields: Color, Count, Height (Ht), and Weight (Wt).
# Color is an alphabetic, the others are numeric.

Color               Count       Ht     Wt
Brown                 106   202.20  1.500
Canary Yellow           7   106.00  0.761
Chartreuse           1139    77.02  6.220
Fluorescent Orange    422  1141.70  7.921
Grey                   19   140.30  1.030
```

This preamble behavior could have been done before by using the `--preamble NUM` option. In the above example, `--preamble 3`. Having auto-preamble detection avoids needing to know the number of lines.