### PR TITLE
Change structs in nested contexts to static structs.

### DIFF
--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -986,7 +986,7 @@ if (isOutputRange!(OutputRange, char))
 
     auto randomGenerator = Random(cmdopt.seed);
 
-    struct Entry(Flag!"preserveInputOrder" preserveInputOrder)
+    static struct Entry(Flag!"preserveInputOrder" preserveInputOrder)
     {
         double score;
         const(char)[] line;
@@ -1206,7 +1206,7 @@ if (isOutputRange!(OutputRange, char))
     assert(!cmdopt.printRandom);
     assert(!cmdopt.genRandomInorder);
 
-    struct Entry(Flag!"preserveInputOrder" preserveInputOrder)
+    static struct Entry(Flag!"preserveInputOrder" preserveInputOrder)
     {
         const(char)[] line;
         static if (preserveInputOrder) ulong lineNumber;
@@ -1460,7 +1460,7 @@ if (isOutputRange!(OutputRange, char))
  * The struct makes the data available through two members: 'filename', which is the
  * filename, and 'data', which is a character array of the data.
  */
-struct FileData
+static struct FileData
 {
     string filename;
     char[] data;
@@ -1495,7 +1495,7 @@ alias HasRandomValue = Flag!"hasRandomValue";
  * line found in a FileData array. The 'data' element contains the line. A 'randomValue'
  * line is included if random values are being generated.
  */
-struct InputLine(HasRandomValue hasRandomValue)
+static struct InputLine(HasRandomValue hasRandomValue)
 {
     const(char)[] data;
     static if (hasRandomValue) double randomValue;

--- a/tsv-uniq/src/tsv_utils/tsv-uniq.d
+++ b/tsv-uniq/src/tsv_utils/tsv-uniq.d
@@ -290,7 +290,7 @@ void tsvUniq(in TsvUniqOptions cmdopt, in string[] inputFiles)
     /* The master hash. The key is the specified fields concatenated together (including
      * separators). The value is a struct with the equiv-id and occurrence count.
      */
-    struct EquivEntry { size_t equivID; size_t count; }
+    static struct EquivEntry { size_t equivID; size_t count; }
     EquivEntry[string] equivHash;
 
     /* Reusable buffers for multi-field keys and case-insensitive keys. */


### PR DESCRIPTION
Ali's suggestion. Shouldn't affect these declarations, as they don't have member functions that would establish a context pointer. But its good practice to declare static structs unless the context pointer is actually used.