### PR TITLE
Change function paramters to use 'const' rather than 'in'.

### DIFF
--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -206,7 +206,7 @@ alias NullableSizeT = Nullable!(size_t, size_t.max);
 /** csv2tsvFiles reads multiple files and standard input and writes the results to
  * standard output.
  */
-void csv2tsvFiles(in Csv2tsvOptions cmdopt, in string[] inputFiles)
+void csv2tsvFiles(const ref Csv2tsvOptions cmdopt, const string[] inputFiles)
 {
     import std.algorithm : joiner;
     import tsv_utils.common.utils : BufferedOutputRange;

--- a/number-lines/src/tsv_utils/number-lines.d
+++ b/number-lines/src/tsv_utils/number-lines.d
@@ -127,7 +127,7 @@ int main(string[] cmdArgs)
  * Reads lines lines from each file, outputing each with a line number prepended. The
  * header from the first file is written, the header from subsequent files is dropped.
  */
-void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
+void numberLines(const NumberLinesOptions cmdopt, const string[] inputFiles)
 {
     import std.conv : to;
     import std.range;

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -785,7 +785,7 @@ struct TsvFilterOptions
 
 /** tsvFilter processes the input files and runs the tests.
  */
-void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
+void tsvFilter(const TsvFilterOptions cmdopt, const string[] inputFiles)
 {
     import std.algorithm : all, any, splitter;
     import std.range;

--- a/tsv-join/src/tsv_utils/tsv-join.d
+++ b/tsv-join/src/tsv_utils/tsv-join.d
@@ -292,7 +292,7 @@ int main(string[] cmdArgs)
 
 /** tsvJoin does the primary work of the tsv-join program.
  */
-void tsvJoin(in TsvJoinOptions cmdopt, in string[] inputFiles)
+void tsvJoin(const TsvJoinOptions cmdopt, const string[] inputFiles)
 {
     import tsv_utils.common.utils : InputFieldReordering, bufferedByLine, BufferedOutputRange, throwIfWindowsNewlineOnUnix;
     import std.algorithm : splitter;

--- a/tsv-pretty/src/tsv_utils/tsv-pretty.d
+++ b/tsv-pretty/src/tsv_utils/tsv-pretty.d
@@ -243,7 +243,7 @@ struct TsvPrettyOptions
  * This routine also handles identification of preamble lines. This is mostly for
  * simplification of the TsvPrettyProcessor code.
  */
-void tsvPretty(in ref TsvPrettyOptions options, string[] files)
+void tsvPretty(const ref TsvPrettyOptions options, const string[] files)
 {
     import std.algorithm : canFind;
 
@@ -723,7 +723,7 @@ public:
      */
     size_t writeHeader (Flag!"writeUnderline" writeUnderline = No.writeUnderline,
                         Flag!"fullWidthUnderline" fullWidthUnderline = No.fullWidthUnderline)
-        (OutputRange!char outputStream, in ref TsvPrettyOptions options)
+        (OutputRange!char outputStream, const ref TsvPrettyOptions options)
     {
         import std.range : repeat;
 
@@ -869,7 +869,7 @@ public:
      * This is called during look-ahead caching to register a new sample value for the
      * column. The key components updates are field type and print width.
      */
-    void updateForFieldValue(const char[] fieldValue, in ref TsvPrettyOptions options) @safe
+    void updateForFieldValue(const char[] fieldValue, const ref TsvPrettyOptions options) @safe
     {
         import std.algorithm : findAmong, findSplit, max, min;
         import std.conv : to, ConvException;
@@ -991,7 +991,7 @@ public:
      * called after adding field entries via updateForFieldValue(). It returns its new
      * end position.
      */
-    size_t finalizeFormatting (size_t startPosition, in ref TsvPrettyOptions options) @safe pure @nogc nothrow
+    size_t finalizeFormatting (size_t startPosition, const ref TsvPrettyOptions options) @safe pure @nogc nothrow
     {
         import std.algorithm : max, min;
         _startPosition = startPosition;

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -1484,7 +1484,7 @@ static struct InputBlock
  * unless the end of a file has been reached. Each file gets its own block so that
  * header processing can be done.
  */
-InputBlock[] readFileData(string[] files)
+InputBlock[] readFileData(const string[] files)
 {
     import std.algorithm : find, min;
     import std.range : retro;

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -199,7 +199,7 @@ enum CTERestLocation { none, first, last };
  * in a larger program, but is faster. Run-time improvements of 25% were measured compared
  * to the non-templatized version. (Note: 'cte' stands for 'compile time evaluation'.)
  */
-void tsvSelect(CTERestLocation cteRest)(in TsvSelectOptions cmdopt, in string[] inputFiles)
+void tsvSelect(CTERestLocation cteRest)(const TsvSelectOptions cmdopt, const string[] inputFiles)
 {
     import tsv_utils.common.utils: BufferedOutputRange, bufferedByLine, InputFieldReordering, throwIfWindowsNewlineOnUnix;
     import std.algorithm: splitter;

--- a/tsv-summarize/src/tsv_utils/tsv-summarize.d
+++ b/tsv-summarize/src/tsv_utils/tsv-summarize.d
@@ -435,7 +435,7 @@ struct TsvSummarizeOptions {
 
 /** tsvSummarize does the primary work of the tsv-summarize program.
  */
-void tsvSummarize(TsvSummarizeOptions cmdopt, in string[] inputFiles)
+void tsvSummarize(TsvSummarizeOptions cmdopt, const string[] inputFiles)
 {
     import tsv_utils.common.utils : bufferedByLine, throwIfWindowsNewlineOnUnix;
 
@@ -1672,12 +1672,12 @@ final class MissingFieldPolicy
     private bool _replaceMissing = false;     // True if missing values are replaced.
     private string _missingReplacement;       // Replacement string if replaceMissing is true.
 
-    this (in bool excludeMissing = false, in string missingReplacement = "")
+    this (const bool excludeMissing = false, string missingReplacement = "")
     {
         updatePolicy(excludeMissing, missingReplacement);
     }
 
-    void updatePolicy(in bool excludeMissing, in string missingReplacement)
+    void updatePolicy(const bool excludeMissing, string missingReplacement)
     {
         _missingReplacement = missingReplacement;
         _replaceMissing = missingReplacement.length != 0;

--- a/tsv-uniq/src/tsv_utils/tsv-uniq.d
+++ b/tsv-uniq/src/tsv_utils/tsv-uniq.d
@@ -271,7 +271,7 @@ int main(string[] cmdArgs)
  * The first time a line is seen it is output. If key fields are being used these are
  * used as the basis for the associative array entries rather than the full line.
  */
-void tsvUniq(in TsvUniqOptions cmdopt, in string[] inputFiles)
+void tsvUniq(const TsvUniqOptions cmdopt, const string[] inputFiles)
 {
     import tsv_utils.common.utils : InputFieldReordering, bufferedByLine, BufferedOutputRange, joinAppend;
     import std.algorithm : splitter;


### PR DESCRIPTION
D best practices guidance has been changed to stop using `in` parameters and instead use `const` or `scope const` ([https://dlang.org/spec/function.html#parameters](https://dlang.org/spec/function.html#parameters)). This PR changes the few uses of `in` to `const` to follow that guidance.