### PR TITLE
csv2tsv, keep-header: Use 128KB read buffers.

### DIFF
--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -211,7 +211,7 @@ void csv2tsvFiles(const ref Csv2tsvOptions cmdopt, const string[] inputFiles)
     import std.algorithm : joiner;
     import tsv_utils.common.utils : BufferedOutputRange;
 
-    ubyte[1024 * 1024] fileRawBuf;
+    ubyte[1024 * 128] fileRawBuf;
     ubyte[] stdinRawBuf = fileRawBuf[0..1024];
     auto stdoutWriter = BufferedOutputRange!(typeof(stdout))(stdout);
     bool firstFile = true;

--- a/keep-header/src/tsv_utils/keep-header.d
+++ b/keep-header/src/tsv_utils/keep-header.d
@@ -131,7 +131,7 @@ int main(string[] args)
             }
             else
             {
-                ubyte[1024*1024] readBuffer;
+                ubyte[1024 * 128] readBuffer;
                 foreach (ubyte[] chunk; inputStream.byChunk(readBuffer))
                 {
                     pipe.stdin.write(cast(char[])chunk);


### PR DESCRIPTION
Have been using 128KB (1024*128 byte) read buffers everywhere, this PR updates `csv2tsv` and `keep-header` to follow this.