### PR TITLE
Travis-ci: Add dmd-nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,12 +132,14 @@ matrix:
       language: d
       d: dmd-nightly
       env: DUBTEST=1 MAKETEST=1
+      if: type IN (cron)
     - os: osx
       osx_image: xcode11
       group: travis_latest
       language: d
       d: dmd-nightly
       env: DUBTEST=1 MAKETEST=1
+      if: type IN (cron)
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,20 @@ matrix:
       d: ldc-beta
       env: LTOPGO_V2=default
       if: type IN (cron)
+    - os: linux
+      dist: xenial
+      group: travis_latest
+      language: d
+      d: dmd-nightly
+      env: DUBTEST=1 MAKETEST=1
+      if: type IN (cron)
+    - os: osx
+      osx_image: xcode11
+      group: travis_latest
+      language: d
+      d: dmd-nightly
+      env: DUBTEST=1 MAKETEST=1
+      if: type IN (cron)
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,14 +132,12 @@ matrix:
       language: d
       d: dmd-nightly
       env: DUBTEST=1 MAKETEST=1
-      if: type IN (cron)
     - os: osx
       osx_image: xcode11
       group: travis_latest
       language: d
       d: dmd-nightly
       env: DUBTEST=1 MAKETEST=1
-      if: type IN (cron)
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update


### PR DESCRIPTION
Adding `dmd-nightly` to the weekly cron job builds. `tsv-utils` is part of the dlang test suites, so it normally get regular testing on all dlang PRs. However, Dub issue [1812](https://github.com/dlang/dub/issues/1812) showed this could fail in areas outside dlang test cases.