### PR TITLE
Add sample scripts

### DIFF
--- a/buildtools/ReleasePackageReadme.txt
+++ b/buildtools/ReleasePackageReadme.txt
@@ -12,3 +12,7 @@ repository (https://github.com/eBay/tsv-utils/blob/master/README.md).
 The 'bash_completion' directory contains support for enabling command
 option completion for the individual tools. For setup instructions, see
 https://github.com/eBay/tsv-utils/blob/master/docs/TipsAndTricks.md#enable-bash-completion.
+
+The 'extras/scripts' directory contains sample implementations of scripts
+described on the Tips and Tricks page on the Github repository:
+https://github.com/eBay/tsv-utils/blob/master/docs/TipsAndTricks.md.

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -31,7 +31,7 @@ Despite limitations of the benchmarks, this is certainly a good result. The benc
 
 The graphs below summarize the results of the 2018 benchmark study. Each graph shows the times of the top-4 tools on that test. Times are in seconds. Times for TSV Utilities tools are show with a green bar.
 
-The benchmarks are described in detail in the [Comparative Benchmark Study](#comparative-benchmark-study) and the [2017](comparative-benchmarks-2017.md) and [2018](comparative-benchmarks-2018.md) comparative benchmark reports. These reports include goals, methodology, test details, caveats, conclusions, etc.
+The benchmarks are described in detail in the [Comparative Benchmark Study](#comparative-benchmark-study) section (above) and the [2017](comparative-benchmarks-2017.md) and [2018](comparative-benchmarks-2018.md) comparative benchmark reports. These reports include goals, methodology, test details, caveats, conclusions, etc.
 
 ### Numeric row filter
 

--- a/docs/TipsAndTricks.md
+++ b/docs/TipsAndTricks.md
@@ -176,7 +176,7 @@ Now type 'r', then TAB, and the command will complete up to `$ tsv-select --rest
 
 Enabling bash completion is a bit more involved than other packages, but still not too hard. It will often be necessary to install a package. The way to do this is system specific. A good source of instructions can be found at the [bash-completion GitHub repository](https://github.com/scop/bash-completion). Mac users may find the MacPorts [How to use bash-completion](https://trac.macports.org/wiki/howto/bash-completion) guide useful. Procedures for Homebrew are similar, but the details differ a bit.
 
-After enabling bash-completion, add completions for the tsv-utils package. Completions are available in the `bash_completion/tsv-utils` file in the repository. This file is also included with the prebuilt binary release packages. One way to add them is to 'source' the file from the `~/.bash_completion` file. A line like the following will achieve this:
+After enabling bash-completion, add completions for the tsv-utils package. Completions are available in the `tsv-utils` file in the [bash_completion](../bash_completion) directory in the tsv-utils GitHub repository. This file is also included with the prebuilt binary release packages. One way to add them is to 'source' the file from the `~/.bash_completion` file. A line like the following will achieve this:
 ```
 if [ -r ~/tsv-utils/bash_completion/tsv-utils ]; then
     . ~/tsv-utils/bash_completion/tsv-utils

--- a/docs/TipsAndTricks.md
+++ b/docs/TipsAndTricks.md
@@ -65,7 +65,7 @@ fi
 
 Put the above in the file `tsv-header` somewhere on the PATH. A common location is the `~/bin` directory, but this is not required. Run the command `$ chmod a+x tsv-header` to make it executable. Now it can be invoked just like the alias version of `tsv-header`.
 
-The are a couple of simple sample scripts in the [Customize the Unix sort command](#customize-the-unix-sort-command) section.
+The are a couple of simple sample scripts in the [Customize the sort command](#customize-the-sort-command) section.
 
 ## macOS: Install GNU versions of Unix command line tools
 

--- a/docs/TipsAndTricks.md
+++ b/docs/TipsAndTricks.md
@@ -138,7 +138,7 @@ $ keep-header file.txt -- tsv-sort
 
 Remember to use the correct `sort` program name if an updated version has been installed under a different name. This may be `gsort` on some systems.
 
-A sample implementation of this script can be found in the [extras/scripts](../extras/scripts) directory.
+A sample implementation of this script can be found in the [extras/scripts](../extras/scripts) directory in the tsv-utils GitHub repository.
 
 *More details*: The `--buffer-size` option may affect `sort` programs differently depending on whether input is being read from files or standard input. This is the case for [GNU sort](https://www.gnu.org/software/coreutils/manual/coreutils.html#sort-invocation), perhaps the most common `sort` program available. This is because by default `sort` uses different methods to choose an internal buffer size when reading from files and when reading from standard input. `--buffer-size` controls both. On a machine with large amounts of RAM, e.g. 64 GB, picking a 1 or 2 GB buffer size may actually slow `sort` down when reading from files while speeding it up when reading from standard input. The author has not experimented with enough systems to make a universal recommendation, but a bit of experimentation on any specific system should help. [GNU sort](https://www.gnu.org/software/coreutils/manual/coreutils.html#sort-invocation) has additional options when optimum performance is needed.
 
@@ -158,7 +158,7 @@ Locale sensitive sorting can be turned off when not needed. This is done by sett
 
 The `tsv-sort-fast` script can be used the same way as the `tsv-sort` script shown earlier.
 
-A sample implementation of this script can be found in the [extras/scripts](../extras/scripts) directory.
+A sample implementation of this script can be found in the [extras/scripts](../extras/scripts) directory in the tsv-utils GitHub repository.
 
 ## Enable bash-completion
 

--- a/docs/TipsAndTricks.md
+++ b/docs/TipsAndTricks.md
@@ -20,7 +20,7 @@ Contents:
 
 A bash alias is a keystroke shortcut known by the shell. They are setup in the user's `~/.bashrc` or another shell init file. A convenient alias when working with TSV files is `tsv-header` which lists the field numbers for each field in a TSV file. To define it, put the following in `~/.bashrc` or other init file:
 ```
-tsv-header () { head -n 1 "$@" | tr $'\t' $'\n' | nl ; }
+tsv-header () { head -n 1 "$@" | tr $'\t' $'\n' | nl -ba ; }
 ```
 
 Once this is defined, use it as follows:
@@ -37,8 +37,8 @@ $ tsv-header worldcitiespop.tsv
 
 A similar alias can be setup for CSV files. Here are two. The first uses  [csv2tsv](ToolReference.md#csv2tsv-reference) to interpret the CSV header line, including CSV escape characters. The second uses only standard Unix tools. It won't interpret CSV escapes, but many header lines don't use escapes. (Define only one):
 ```
-csv-header () { csv2tsv "$@" | head -n 1 | tr $'\t' $'\n' | nl ; }
-csv-header () { head -n 1 "$@" | tr $',' $'\n' | nl ; }
+csv-header () { csv2tsv "$@" | head -n 1 | tr $'\t' $'\n' | nl -ba ; }
+csv-header () { head -n 1 "$@" | tr $',' $'\n' | nl -ba ; }
 ```
 
 Many useful aliases can be defined. Here is another the author finds useful with TSV files. It prints a file excluding the first line (the header line):
@@ -59,7 +59,7 @@ if [ "$1" == "-h" ] || [ "$1" == "--h" ] || [ "$1" = "--help" ]; then
     echo ""
     echo "Print field numbers and header text from the first line of <tsv-file>."
 else
-    head -n 1 "$@" | tr $'\t' $'\n' | nl
+    head -n 1 "$@" | tr $'\t' $'\n' | nl -ba
 fi
 ```
 
@@ -138,6 +138,8 @@ $ keep-header file.txt -- tsv-sort
 
 Remember to use the correct `sort` program name if an updated version has been installed under a different name. This may be `gsort` on some systems.
 
+A sample implementation of this script can be found in the [extras/scripts](../extras/scripts) directory.
+
 *More details*: The `--buffer-size` option may affect `sort` programs differently depending on whether input is being read from files or standard input. This is the case for [GNU sort](https://www.gnu.org/software/coreutils/manual/coreutils.html#sort-invocation), perhaps the most common `sort` program available. This is because by default `sort` uses different methods to choose an internal buffer size when reading from files and when reading from standard input. `--buffer-size` controls both. On a machine with large amounts of RAM, e.g. 64 GB, picking a 1 or 2 GB buffer size may actually slow `sort` down when reading from files while speeding it up when reading from standard input. The author has not experimented with enough systems to make a universal recommendation, but a bit of experimentation on any specific system should help. [GNU sort](https://www.gnu.org/software/coreutils/manual/coreutils.html#sort-invocation) has additional options when optimum performance is needed.
 
 ### Turn off locale sensitive sorting when not needed
@@ -156,6 +158,8 @@ Locale sensitive sorting can be turned off when not needed. This is done by sett
 
 The `tsv-sort-fast` script can be used the same way as the `tsv-sort` script shown earlier.
 
+A sample implementation of this script can be found in the [extras/scripts](../extras/scripts) directory.
+
 ## Enable bash-completion
 
 Bash command completion is quite handy for command line tools. Command names complete by default, already useful. Adding completion of command options is even better. As an example, with bash completion turned on, enter the command name, then a single dash (-):
@@ -172,7 +176,7 @@ Now type 'r', then TAB, and the command will complete up to `$ tsv-select --rest
 
 Enabling bash completion is a bit more involved than other packages, but still not too hard. It will often be necessary to install a package. The way to do this is system specific. A good source of instructions can be found at the [bash-completion GitHub repository](https://github.com/scop/bash-completion). Mac users may find the MacPorts [How to use bash-completion](https://trac.macports.org/wiki/howto/bash-completion) guide useful. Procedures for Homebrew are similar, but the details differ a bit.
 
-After enabling bash-completion, add completions for the tsv-utils package. Completions are available in the `bash_completion/tsv-utils` file. One way to add them is to 'source' the file from the `~/.bash_completion` file. A line like the following will do this.
+After enabling bash-completion, add completions for the tsv-utils package. Completions are available in the `bash_completion/tsv-utils` file in the repository. This file is also included with the prebuilt binary release packages. One way to add them is to 'source' the file from the `~/.bash_completion` file. A line like the following will achieve this:
 ```
 if [ -r ~/tsv-utils/bash_completion/tsv-utils ]; then
     . ~/tsv-utils/bash_completion/tsv-utils

--- a/extras/scripts/tsv-sort
+++ b/extras/scripts/tsv-sort
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020, eBay Inc.
+# Initially written by Jon Degenhardt
+#
+# License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
+#
+# -------------------------------------------------------------
+#
+# This file contains a sample implementation of the 'tsv-sort' script
+# described on the Tips and Tricks page in the eBay tsv-utils repository:
+# https://github.com/eBay/tsv-utils/blob/master/docs/TipsAndTricks.md
+#
+
+command_name="sort"
+mac_gnu_name="gsort"
+
+if [ "$(uname)" == "Darwin" ] && type $mac_gnu_name &>/dev/null ; then
+   command_name=$mac_gnu_name
+fi
+if [ "$1" == "--help" ]; then
+    script_name=$(basename $0)
+    echo ""
+    echo "$script_name runs '$command_name' using TAB as the field delimiter and the buffer"
+    echo "size set to 2G. All arguments are forwared to '$command_name'. Example:"
+    echo ""
+    echo "    tsv-sort data.tsv -k1,1 -k3,3"
+    echo ""
+    echo "This sorts data.tsv using the 1st and 3rd fields as keys."
+    echo "Run '$command_name --help' for more information."
+    echo ""
+    exit 0
+fi
+$command_name -t $'\t' --buffer-size=2G "$@"

--- a/extras/scripts/tsv-sort-fast
+++ b/extras/scripts/tsv-sort-fast
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020, eBay Inc.
+# Initially written by Jon Degenhardt
+#
+# License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
+#
+# -------------------------------------------------------------
+#
+# This file contains a sample implementation of the 'tsv-sort-fast' script
+# described on the Tips and Tricks page in the eBay tsv-utils repository:
+# https://github.com/eBay/tsv-utils/blob/master/docs/TipsAndTricks.md
+#
+
+command_name="sort"
+mac_gnu_name="gsort"
+
+if [ "$(uname)" == "Darwin" ] && type $mac_gnu_name &>/dev/null ; then
+   command_name=$mac_gnu_name
+fi
+if [ "$1" == "--help" ]; then
+    script_name=$(basename $0)
+    echo ""
+    echo "$script_name runs '$command_name' with:"
+    echo "  * TAB as the field delimiter."
+    echo "  * The buffer size set to 2G."
+    echo "  * Locale sensitive sorting turned off."
+    echo ""
+    echo "All arguments are forwarded to '$command_name'. Example:"
+    echo ""
+    echo "    tsv-sort-fast data.tsv -k1,1 -k3,3"
+    echo ""
+    echo "This sorts data.tsv using the 1st and 3rd fields as keys."
+    echo "Run '$command_name --help' for more information."
+    echo ""
+    echo "Turning off locale specific sorting is a meaningful change."
+    echo "Alphabetic entries are no longer sorted in a locale and Unicode"
+    echo "aware fashion. Instead sorting is based on the underlying byte"
+    echo "sequences. The advantage is that it is dramatically faster. The"
+    echo "typical speedup is between 2 and 10 times. Use with care."
+    exit 0
+fi
+(LC_ALL=C $command_name -t $'\t' --buffer-size=2G "$@")

--- a/makefile
+++ b/makefile
@@ -113,6 +113,7 @@ package:
 	mkdir $(PKG_DIR)
 	cp -pr $(CURDIR)/bin $(PKG_DIR)
 	cp -pr $(CURDIR)/bash_completion $(PKG_DIR)
+	cp -pr $(CURDIR)/extras $(PKG_DIR)
 	cp -pr $(CURDIR)/LICENSE.txt $(PKG_DIR)
 	cp -pr $(buildtools_dir)/ReleasePackageReadme.txt $(PKG_DIR)
 	tar -czf $(TAR_FILE) $(PKG_DIR)


### PR DESCRIPTION
This PR adds to to repository sample implementations of the `tsv-sort` and `tsv-sort-fast` scripts described on the Tips and Tricks page. These scripts are in the `extras/scripts` directory. They will be included in the pre-built binary packages starting with the next release.

This PR also includes several small documentation updates.