### PR TITLE
tsv-filter: Filter on field length

### DIFF
--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -92,10 +92,6 @@ _tsv_append()
 }
 complete -F _tsv_append tsv-append
 
-
-
-
-
 _tsv_filter()
 {
     local cur prev opts

--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -92,17 +92,21 @@ _tsv_append()
 }
 complete -F _tsv_append tsv-append
 
+
+
+
+
 _tsv_filter()
 {
     local cur prev opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-options --version --header --or --invert --delimiter --empty --not-empty --blank --not-blank --is-numeric --is-finite --is-nan --is-infinity --le --lt --ge --gt --eq --ne --str-le --str-lt --str-ge --str-gt --str-eq --istr-eq --str-ne --istr-ne --str-in-fld --istr-in-fld --str-not-in-fld --istr-not-in-fld --regex --iregex --not-regex --not-iregex --ff-le --ff-lt --ff-ge --ff-gt --ff-eq --ff-ne --ff-str-eq --ff-istr-eq --ff-str-ne --ff-istr-ne --ff-absdiff-le --ff-absdiff-gt ff-reldiff-le --ff-reldiff-gt"
+    opts="--help --help-verbose --help-options --version --header --or --invert --delimiter --empty --not-empty --blank --not-blank --is-numeric --is-finite --is-nan --is-infinity --le --lt --ge --gt --eq --ne --str-le --str-lt --str-ge --str-gt --str-eq --istr-eq --str-ne --istr-ne --str-in-fld --istr-in-fld --str-not-in-fld --istr-not-in-fld --regex --iregex --not-regex --not-iregex --char-len-le --char-len-lt --char-len-ge --char-len-gt --char-len-eq --char-len-ne --byte-len-le --byte-len-lt --byte-len-ge --byte-len-gt --byte-len-eq --byte-len-ne --ff-le --ff-lt --ff-ge --ff-gt --ff-eq --ff-ne --ff-str-eq --ff-istr-eq --ff-str-ne --ff-istr-ne --ff-absdiff-le --ff-absdiff-gt ff-reldiff-le --ff-reldiff-gt"
 
     # Options requiring an argument or precluding other options
     case $prev in
-         -h|--help|--help-verbose|--help-options|-V|--version|-d|--delimiter|--le|--lt|--ge|--gt|--eq|--ne|--str-le|--str-lt|--str-ge|--str-gt|--str-eq|--istr-eq|--str-ne|--istr-ne|--str-in-fld|--istr-in-fld|--str-not-in-fld|--istr-not-in-fld|--regex|--iregex|--not-regex|--not-iregex|--ff-le|--ff-lt|--ff-ge|--ff-gt|--ff-eq|--ff-ne|--ff-str-eq|--ff-istr-eq|--ff-str-ne|--ff-istr-ne|--ff-absdiff-le|--ff-absdiff-gt|ff-reldiff-le|--ff-reldiff-gt)
+         -h|--help|--help-verbose|--help-options|-V|--version|-d|--delimiter|--le|--lt|--ge|--gt|--eq|--ne|--str-le|--str-lt|--str-ge|--str-gt|--str-eq|--istr-eq|--str-ne|--istr-ne|--str-in-fld|--istr-in-fld|--str-not-in-fld|--istr-not-in-fld|--regex|--iregex|--not-regex|--not-iregex|--char-len-le|--char-len-lt|--char-len-ge|--char-len-gt|--char-len-eq|--char-len-ne|--byte-len-le|--byte-len-lt|--byte-len-ge|--byte-len-gt|--byte-len-eq|--byte-len-ne|--ff-le|--ff-lt|--ff-ge|--ff-gt|--ff-eq|--ff-ne|--ff-str-eq|--ff-istr-eq|--ff-str-ne|--ff-istr-ne|--ff-absdiff-le|--ff-absdiff-gt|ff-reldiff-le|--ff-reldiff-gt)
 
           return
           ;;

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -147,6 +147,20 @@ Regular expression tests:
 * `--not-regex FIELD:REGEX` - FIELD does not match regular expression.
 * `--not-iregex FIELD:REGEX` - FIELD does not match regular expression, case-insensitive.
 
+Field length tests
+* `--char-len-le FIELD:NUM` - FIELD character length <= NUM.
+* `--char-len-lt FIELD:NUM` - FIELD character length < NUM.
+* `--char-len-ge FIELD:NUM` - FIELD character length >= NUM.
+* `--char-len-gt FIELD:NUM` - FIELD character length > NUM.
+* `--char-len-eq FIELD:NUM` - FIELD character length == NUM.
+* `--char-len-ne FIELD:NUM` - FIELD character length != NUM.
+* `--byte-len-le FIELD:NUM` - FIELD byte length <= NUM.
+* `--byte-len-lt FIELD:NUM` - FIELD byte length < NUM.
+* `--byte-len-ge FIELD:NUM` - FIELD byte length >= NUM.
+* `--byte-len-gt FIELD:NUM` - FIELD byte length > NUM.
+* `--byte-len-eq FIELD:NUM` - FIELD byte length == NUM.
+* `--byte-len-ne FIELD:NUM` - FIELD byte length != NUM.
+
 Field to field comparisons:
 * `--ff-le FIELD1:FIELD2` - FIELD1 <= FIELD2 (numeric).
 * `--ff-lt FIELD1:FIELD2` - FIELD1 <  FIELD2 (numeric).

--- a/tsv-filter/profile_data/collect_profile_data.sh
+++ b/tsv-filter/profile_data/collect_profile_data.sh
@@ -51,6 +51,18 @@ $prog profile_data_2.tsv --ne 2:622 --ne 2:642 --ne 2:649 > /dev/null
 $prog profile_data_2.tsv --or --eq 3:16 --gt 4:570 --ge 3:140 --le 3:3 --lt 2:510 > /dev/null
 
 ## Most of the other operators start here
+$prog profile_data_3.tsv --char-len-le 3:7 > /dev/null
+$prog profile_data_3.tsv --char-len-lt 3:9 > /dev/null
+$prog profile_data_3.tsv --char-len-ge 3:10 > /dev/null
+$prog profile_data_3.tsv --char-len-gt 3:8 > /dev/null
+$prog profile_data_3.tsv --char-len-eq 3:11 > /dev/null
+$prog profile_data_3.tsv --char-len-ne 3:12 > /dev/null
+$prog profile_data_3.tsv --byte-len-le 3:7 > /dev/null
+$prog profile_data_3.tsv --byte-len-lt 3:9 > /dev/null
+$prog profile_data_3.tsv --byte-len-ge 3:10 > /dev/null
+$prog profile_data_3.tsv --byte-len-gt 3:8 > /dev/null
+$prog profile_data_3.tsv --byte-len-eq 3:11 > /dev/null
+$prog profile_data_3.tsv --byte-len-ne 3:12 > /dev/null
 $prog profile_data_5.tsv --ff-eq 2:3 > /dev/null
 $prog profile_data_5.tsv --ff-ne 3:4 > /dev/null
 $prog profile_data_5.tsv --ff-le 3:2 > /dev/null

--- a/tsv-filter/tests/gold/basic_tests_1.txt
+++ b/tsv-filter/tests/gold/basic_tests_1.txt
@@ -714,6 +714,449 @@ F1	F2	F3	F4
 100	102	abc	AbC
 100	103	abc	AbC
 
+====Character and Byte Length tests===
+
+====[tsv-filter --header --char-len-eq 3:0 input1.tsv]====
+F1	F2	F3	F4
+100	100		AbC
+100	101		
+
+====[tsv-filter --header --char-len-eq 3:1 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+
+====[tsv-filter --header --char-len-eq 3:2 input1.tsv]====
+F1	F2	F3	F4
+
+====[tsv-filter --header --char-len-ne 3:0 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --char-len-ne 3:1 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --char-len-ne 3:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --char-len-le 4:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+-2	-2.0	ß	ss
+100	100	abc	
+100	101		
+
+====[tsv-filter --header --char-len-lt 4:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+100	100	abc	
+100	101		
+
+====[tsv-filter --header --char-len-gt 4:2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --char-len-ge 4:2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --byte-len-eq 3:0 input1.tsv]====
+F1	F2	F3	F4
+100	100		AbC
+100	101		
+
+====[tsv-filter --header --byte-len-eq 3:1 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+0	0.0	z	AzB
+
+====[tsv-filter --header --byte-len-eq 3:2 input1.tsv]====
+F1	F2	F3	F4
+-2	-2.0	ß	ss
+
+====[tsv-filter --header --byte-len-ne 3:0 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --byte-len-ne 3:1 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --byte-len-ne 3:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --byte-len-le 4:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+-2	-2.0	ß	ss
+100	100	abc	
+100	101		
+
+====[tsv-filter --header --byte-len-lt 4:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+100	100	abc	
+100	101		
+
+====[tsv-filter --header --byte-len-gt 4:2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --byte-len-ge 4:2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --char-len-le 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed3	abc-雪	abc	ab
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed8	abcd-雪	雪雪雪	a
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+Mixed13	a-雪	षिषिषि	abcd
+Mixed16	abcd-雪	aषि雪	a
+
+====[tsv-filter --header --char-len-lt 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+
+====[tsv-filter --header --char-len-ge 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed3	abc-雪	abc	ab
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed8	abcd-雪	雪雪雪	a
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+Mixed16	abcd-雪	aषि雪	a
+
+====[tsv-filter --header --char-len-gt 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+
+====[tsv-filter --header --char-len-eq 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Mixed3	abc-雪	abc	ab
+Mixed8	abcd-雪	雪雪雪	a
+Mixed13	a-雪	षिषिषि	abcd
+Mixed16	abcd-雪	aषि雪	a
+
+====[tsv-filter --header --char-len-ne 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+
+====[tsv-filter --header --byte-len-le 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed3	abc-雪	abc	ab
+Mixed6	ab-雪	雪	abc
+
+====[tsv-filter --header --byte-len-lt 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+
+====[tsv-filter --header --byte-len-ge 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed3	abc-雪	abc	ab
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed8	abcd-雪	雪雪雪	a
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+Mixed16	abcd-雪	aषि雪	a
+
+====[tsv-filter --header --byte-len-gt 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed7	abc-雪	雪雪	ab
+Mixed8	abcd-雪	雪雪雪	a
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+Mixed16	abcd-雪	aषि雪	a
+
+====[tsv-filter --header --byte-len-eq 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Mixed3	abc-雪	abc	ab
+Mixed6	ab-雪	雪	abc
+
+====[tsv-filter --header --byte-len-ne 3:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed7	abc-雪	雪雪	ab
+Mixed8	abcd-雪	雪雪雪	a
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+Mixed16	abcd-雪	aषि雪	a
+
+====[tsv-filter --header --char-len-lt 1:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+
+====[tsv-filter --header --char-len-le 2:2 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+Japanese	吹雪	サッカー選手	町役場
+
+====[tsv-filter --header --char-len-ge 4:2 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed3	abc-雪	abc	ab
+Mixed5	a-雪	abcde	abcd
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed11	abc-雪	षि	ab
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+
 ====Field vs Field===
 
 ====[tsv-filter --header --ff-eq 1:2 input1.tsv]====

--- a/tsv-filter/tests/input_unicode.tsv
+++ b/tsv-filter/tests/input_unicode.tsv
@@ -1,0 +1,28 @@
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed3	abc-雪	abc	ab
+Mixed4	abcd-雪雪	abcd	a
+Mixed5	a-雪	abcde	abcd
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed8	abcd-雪	雪雪雪	a
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+Mixed15	abc-雪	षिषिषिषिषि	ab
+Mixed16	abcd-雪	aषि雪	a

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -144,6 +144,52 @@ runtest ${prog} "--header --regex 1:^\-[0-9]+ input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --not-iregex 4:abc input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --not-regex 4:z|d input1.tsv" ${basic_tests_1}
 
+echo "" >> ${basic_tests_1}; echo "====Character and Byte Length tests===" >> ${basic_tests_1}
+
+runtest ${prog} "--header --char-len-eq 3:0 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-eq 3:1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-eq 3:2 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --char-len-ne 3:0 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ne 3:1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ne 3:2 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --char-len-le 4:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-lt 4:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-gt 4:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ge 4:2 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --byte-len-eq 3:0 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-eq 3:1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-eq 3:2 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --byte-len-ne 3:0 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-ne 3:1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-ne 3:2 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --byte-len-le 4:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-lt 4:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-gt 4:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-ge 4:2 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --char-len-le 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-lt 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ge 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-gt 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-eq 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ne 3:3 input_unicode.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --byte-len-le 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-lt 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-ge 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-gt 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-eq 3:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-ne 3:3 input_unicode.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --char-len-lt 1:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-le 2:2 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ge 4:2 input_unicode.tsv" ${basic_tests_1}
+
 # Field vs Field tests
 echo "" >> ${basic_tests_1}; echo "====Field vs Field===" >> ${basic_tests_1}
 


### PR DESCRIPTION
In `tsv-filter`, add character and byte length filters. Example:
```
# Restrict field 3 to 40 or fewer characters
$ tsv-filter --char-len-le 3:40 data.tsv

# Restrict field 3 to 40 or fewer bytes
$ tsv-filter --byte-len-le 3:40 data.tsv
```