### PR TITLE
tsv-filter field lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ $ tsv-filter -H --str-eq 2:red --ge 3:1850 --lt 3:1950 data.tsv | tsv-pretty | h
 114  red    1931   1412
 ```
 
+Field lists can be used to specify multiple fields at once. The following command tests that fields 1-30 are all less than 100:
+```
+$ tsv-filter --lt 1-30:100 data.tsv
+```
+
 `tsv-filter` is the most widely applicable of the tools, as dataset pruning is a common task. It is stream oriented, so it can handle arbitrarily large files. It is fast, quite a bit faster than other tools the author has tried. This makes it ideal for preparing data for applications like R and Pandas. It is also convenient for quickly answering simple questions about a dataset. For example, to count the number of records with a non-zero value in field 4, use the command:
 ```
 $ tsv-filter --ne 4:0 file.tsv | wc -l

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -108,58 +108,58 @@ Filter lines of tab-delimited files via comparison tests against fields. Multipl
 **Tests:**
 
 Empty and blank field tests:
-* `--empty FIELD` - True if field is empty (no characters)
-* `--not-empty FIELD` - True if field is not empty.
-* `--blank FIELD` - True if field is empty or all whitespace.
-* `--not-blank FIELD` - True if field contains a non-whitespace character.
+* `--empty <field-list>` - True if field is empty (no characters)
+* `--not-empty <field-list>` - True if field is not empty.
+* `--blank <field-list>` - True if field is empty or all whitespace.
+* `--not-blank <field-list>` - True if field contains a non-whitespace character.
 
 Numeric type tests:
-* `--is-numeric FIELD` - True if the field can be interpreted as a number.
-* `--is-finite FIELD` - True if the field can be interpreted as a number, and it is not NaN or infinity.
-* `--is-nan FIELD` - True if the field is NaN (including: "nan", "NaN", "NAN").
-* `--is-infinity FIELD` - True if the field is infinity (including: "inf", "INF", "-inf", "-INF")
+* `--is-numeric <field-list>` - True if the field can be interpreted as a number.
+* `--is-finite <field-list>` - True if the field can be interpreted as a number, and it is not NaN or infinity.
+* `--is-nan <field-list>` - True if the field is NaN (including: "nan", "NaN", "NAN").
+* `--is-infinity <field-list>` - True if the field is infinity (including: "inf", "INF", "-inf", "-INF")
 
 Numeric comparisons:
-* `--le FIELD:NUM` - FIELD <= NUM (numeric).
-* `--lt FIELD:NUM` - FIELD <  NUM (numeric).
-* `--ge FIELD:NUM` - FIELD >= NUM (numeric).
-* `--gt FIELD:NUM` - FIELD >  NUM (numeric).
-* `--eq FIELD:NUM` - FIELD == NUM (numeric).
-* `--ne FIELD:NUM` - FIELD != NUM (numeric).
+* `--le <field-list>:NUM` - FIELD <= NUM (numeric).
+* `--lt <field-list>:NUM` - FIELD <  NUM (numeric).
+* `--ge <field-list>:NUM` - FIELD >= NUM (numeric).
+* `--gt <field-list>:NUM` - FIELD >  NUM (numeric).
+* `--eq <field-list>:NUM` - FIELD == NUM (numeric).
+* `--ne <field-list>:NUM` - FIELD != NUM (numeric).
 
 String comparisons:
-* `--str-le FIELD:STR` - FIELD <= STR (string).
-* `--str-lt FIELD:STR` - FIELD <  STR (string).
-* `--str-ge FIELD:STR` - FIELD >= STR (string).
-* `--str-gt FIELD:STR` - FIELD >  STR (string).
-* `--str-eq FIELD:STR` - FIELD == STR (string).
-* `--istr-eq FIELD:STR` - FIELD == STR (string, case-insensitive).
-* `--str-ne FIELD:STR` - FIELD != STR (string).
-* `--istr-ne FIELD:STR` - FIELD != STR (string, case-insensitive).
-* `--str-in-fld FIELD:STR` - FIELD contains STR (substring search).
-* `--istr-in-fld FIELD:STR` - FIELD contains STR (substring search, case-insensitive).
-* `--str-not-in-fld FIELD:STR` - FIELD does not contain STR (substring search).
-* `--istr-not-in-fld FIELD:STR` - FIELD does not contain STR (substring search, case-insensitive).
+* `--str-le <field-list>:STR` - FIELD <= STR (string).
+* `--str-lt <field-list>:STR` - FIELD <  STR (string).
+* `--str-ge <field-list>:STR` - FIELD >= STR (string).
+* `--str-gt <field-list>:STR` - FIELD >  STR (string).
+* `--str-eq <field-list>:STR` - FIELD == STR (string).
+* `--istr-eq <field-list>:STR` - FIELD == STR (string, case-insensitive).
+* `--str-ne <field-list>:STR` - FIELD != STR (string).
+* `--istr-ne <field-list>:STR` - FIELD != STR (string, case-insensitive).
+* `--str-in-fld <field-list>:STR` - FIELD contains STR (substring search).
+* `--istr-in-fld <field-list>:STR` - FIELD contains STR (substring search, case-insensitive).
+* `--str-not-in-fld <field-list>:STR` - FIELD does not contain STR (substring search).
+* `--istr-not-in-fld <field-list>:STR` - FIELD does not contain STR (substring search, case-insensitive).
 
 Regular expression tests:
-* `--regex FIELD:REGEX` - FIELD matches regular expression.
-* `--iregex FIELD:REGEX` - FIELD matches regular expression, case-insensitive.
-* `--not-regex FIELD:REGEX` - FIELD does not match regular expression.
-* `--not-iregex FIELD:REGEX` - FIELD does not match regular expression, case-insensitive.
+* `--regex <field-list>:REGEX` - FIELD matches regular expression.
+* `--iregex <field-list>:REGEX` - FIELD matches regular expression, case-insensitive.
+* `--not-regex <field-list>:REGEX` - FIELD does not match regular expression.
+* `--not-iregex <field-list>:REGEX` - FIELD does not match regular expression, case-insensitive.
 
 Field length tests
-* `--char-len-le FIELD:NUM` - FIELD character length <= NUM.
-* `--char-len-lt FIELD:NUM` - FIELD character length < NUM.
-* `--char-len-ge FIELD:NUM` - FIELD character length >= NUM.
-* `--char-len-gt FIELD:NUM` - FIELD character length > NUM.
-* `--char-len-eq FIELD:NUM` - FIELD character length == NUM.
-* `--char-len-ne FIELD:NUM` - FIELD character length != NUM.
-* `--byte-len-le FIELD:NUM` - FIELD byte length <= NUM.
-* `--byte-len-lt FIELD:NUM` - FIELD byte length < NUM.
-* `--byte-len-ge FIELD:NUM` - FIELD byte length >= NUM.
-* `--byte-len-gt FIELD:NUM` - FIELD byte length > NUM.
-* `--byte-len-eq FIELD:NUM` - FIELD byte length == NUM.
-* `--byte-len-ne FIELD:NUM` - FIELD byte length != NUM.
+* `--char-len-le <field-list>:NUM` - FIELD character length <= NUM.
+* `--char-len-lt <field-list>:NUM` - FIELD character length < NUM.
+* `--char-len-ge <field-list>:NUM` - FIELD character length >= NUM.
+* `--char-len-gt <field-list>:NUM` - FIELD character length > NUM.
+* `--char-len-eq <field-list>:NUM` - FIELD character length == NUM.
+* `--char-len-ne <field-list>:NUM` - FIELD character length != NUM.
+* `--byte-len-le <field-list>:NUM` - FIELD byte length <= NUM.
+* `--byte-len-lt <field-list>:NUM` - FIELD byte length < NUM.
+* `--byte-len-ge <field-list>:NUM` - FIELD byte length >= NUM.
+* `--byte-len-gt <field-list>:NUM` - FIELD byte length > NUM.
+* `--byte-len-eq <field-list>:NUM` - FIELD byte length == NUM.
+* `--byte-len-ne <field-list>:NUM` - FIELD byte length != NUM.
 
 Field to field comparisons:
 * `--ff-le FIELD1:FIELD2` - FIELD1 <= FIELD2 (numeric).
@@ -195,6 +195,20 @@ $ tsv-filter --header --str-eq 3:foo --str-in-fld 4:bar data.tsv
 
 $ # Field 3 == field 4 (numeric test)
 $ tsv-filter --header --ff-eq 3:4 data.tsv
+```
+
+Field lists:
+
+Field lists can be used to run the same test on multiple fields. For example:
+```
+$ # Test that fields 1-10 are not blank
+$ tsv-filter --not-blank 1-10 data.tsv
+
+$ # Test that fields 1-5 are not zero
+$ tsv-filter --ne 1-5:0
+
+$ # Test that fields 1-5, 7, and 10-20 are less than 100
+$ tsv-filter --lt 1-5,7,10-20:100
 ```
 
 Regular expressions:

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -135,6 +135,12 @@ tests if field 3 is less than 500. A more complete example:
 This outputs all lines from file data.tsv where field 1 is greater than 50 and less
 than 100, and field 2 is less than or equal to 1000. The header is also output.
 
+Field lists can be used to specify multiple fields at once. For example:
+
+  tsv-filter --not-blank 1-10 --str-ne 1,2,5:'--' data.tsv
+
+tests that fields 1-10 are not blank and fields 1,2,5 are not "--".
+
 Tests available include:
   * Test if a field is empty (no characters) or blank (empty or whitespace only).
   * Test if a field is interpretable as a number, a finite number, NaN, or Infinity.
@@ -751,54 +757,54 @@ struct TsvFilterOptions
                 std.getopt.config.caseInsensitive,
                 "d|delimiter",     "CHR  Field delimiter. Default: TAB. (Single byte UTF-8 characters only.)", &delim,
 
-                "empty",           "FIELD       True if field is empty.", &handlerFldEmpty,
-                "not-empty",       "FIELD       True if field is not empty.", &handlerFldNotEmpty,
-                "blank",           "FIELD       True if field is empty or all whitespace.", &handlerFldBlank,
-                "not-blank",       "FIELD       True if field contains a non-whitespace character.", &handlerFldNotBlank,
+                "empty",           "<field-list>       True if FIELD is empty.", &handlerFldEmpty,
+                "not-empty",       "<field-list>       True if FIELD is not empty.", &handlerFldNotEmpty,
+                "blank",           "<field-list>       True if FIELD is empty or all whitespace.", &handlerFldBlank,
+                "not-blank",       "<field-list>       True if FIELD contains a non-whitespace character.", &handlerFldNotBlank,
 
-                "is-numeric",      "FIELD       True if field is interpretable as a number.", &handlerFldIsNumeric,
-                "is-finite",       "FIELD       True if field is interpretable as a number and is not NaN or infinity.", &handlerFldIsFinite,
-                "is-nan",          "FIELD       True if field is NaN.", &handlerFldIsNaN,
-                "is-infinity",     "FIELD       True if field is infinity.", &handlerFldIsInfinity,
+                "is-numeric",      "<field-list>       True if FIELD is interpretable as a number.", &handlerFldIsNumeric,
+                "is-finite",       "<field-list>       True if FIELD is interpretable as a number and is not NaN or infinity.", &handlerFldIsFinite,
+                "is-nan",          "<field-list>       True if FIELD is NaN.", &handlerFldIsNaN,
+                "is-infinity",     "<field-list>       True if FIELD is infinity.", &handlerFldIsInfinity,
 
-                "le",              "FIELD:NUM   FIELD <= NUM (numeric).", &handlerNumLE,
-                "lt",              "FIELD:NUM   FIELD <  NUM (numeric).", &handlerNumLT,
-                "ge",              "FIELD:NUM   FIELD >= NUM (numeric).", &handlerNumGE,
-                "gt",              "FIELD:NUM   FIELD >  NUM (numeric).", &handlerNumGT,
-                "eq",              "FIELD:NUM   FIELD == NUM (numeric).", &handlerNumEQ,
-                "ne",              "FIELD:NUM   FIELD != NUM (numeric).", &handlerNumNE,
+                "le",              "<field-list>:NUM   FIELD <= NUM (numeric).", &handlerNumLE,
+                "lt",              "<field-list>:NUM   FIELD <  NUM (numeric).", &handlerNumLT,
+                "ge",              "<field-list>:NUM   FIELD >= NUM (numeric).", &handlerNumGE,
+                "gt",              "<field-list>:NUM   FIELD >  NUM (numeric).", &handlerNumGT,
+                "eq",              "<field-list>:NUM   FIELD == NUM (numeric).", &handlerNumEQ,
+                "ne",              "<field-list>:NUM   FIELD != NUM (numeric).", &handlerNumNE,
 
-                "str-le",          "FIELD:STR   FIELD <= STR (string).", &handlerStrLE,
-                "str-lt",          "FIELD:STR   FIELD <  STR (string).", &handlerStrLT,
-                "str-ge",          "FIELD:STR   FIELD >= STR (string).", &handlerStrGE,
-                "str-gt",          "FIELD:STR   FIELD >  STR (string).", &handlerStrGT,
-                "str-eq",          "FIELD:STR   FIELD == STR (string).", &handlerStrEQ,
-                "istr-eq",         "FIELD:STR   FIELD == STR (string, case-insensitive).", &handlerIStrEQ,
-                "str-ne",          "FIELD:STR   FIELD != STR (string).", &handlerStrNE,
-                "istr-ne",         "FIELD:STR   FIELD != STR (string, case-insensitive).", &handlerIStrNE,
-                "str-in-fld",      "FIELD:STR   FIELD contains STR (substring search).", &handlerStrInFld,
-                "istr-in-fld",     "FIELD:STR   FIELD contains STR (substring search, case-insensitive).", &handlerIStrInFld,
-                "str-not-in-fld",  "FIELD:STR   FIELD does not contain STR (substring search).", &handlerStrNotInFld,
-                "istr-not-in-fld", "FIELD:STR   FIELD does not contain STR (substring search, case-insensitive).", &handlerIStrNotInFld,
+                "str-le",          "<field-list>:STR   FIELD <= STR (string).", &handlerStrLE,
+                "str-lt",          "<field-list>:STR   FIELD <  STR (string).", &handlerStrLT,
+                "str-ge",          "<field-list>:STR   FIELD >= STR (string).", &handlerStrGE,
+                "str-gt",          "<field-list>:STR   FIELD >  STR (string).", &handlerStrGT,
+                "str-eq",          "<field-list>:STR   FIELD == STR (string).", &handlerStrEQ,
+                "istr-eq",         "<field-list>:STR   FIELD == STR (string, case-insensitive).", &handlerIStrEQ,
+                "str-ne",          "<field-list>:STR   FIELD != STR (string).", &handlerStrNE,
+                "istr-ne",         "<field-list>:STR   FIELD != STR (string, case-insensitive).", &handlerIStrNE,
+                "str-in-fld",      "<field-list>:STR   FIELD contains STR (substring search).", &handlerStrInFld,
+                "istr-in-fld",     "<field-list>:STR   FIELD contains STR (substring search, case-insensitive).", &handlerIStrInFld,
+                "str-not-in-fld",  "<field-list>:STR   FIELD does not contain STR (substring search).", &handlerStrNotInFld,
+                "istr-not-in-fld", "<field-list>:STR   FIELD does not contain STR (substring search, case-insensitive).", &handlerIStrNotInFld,
 
-                "regex",           "FIELD:REGEX   FIELD matches regular expression.", &handlerRegexMatch,
-                "iregex",          "FIELD:REGEX   FIELD matches regular expression, case-insensitive.", &handlerIRegexMatch,
-                "not-regex",       "FIELD:REGEX   FIELD does not match regular expression.", &handlerRegexNotMatch,
-                "not-iregex",      "FIELD:REGEX   FIELD does not match regular expression, case-insensitive.", &handlerIRegexNotMatch,
+                "regex",           "<field-list>:REGEX   FIELD matches regular expression.", &handlerRegexMatch,
+                "iregex",          "<field-list>:REGEX   FIELD matches regular expression, case-insensitive.", &handlerIRegexMatch,
+                "not-regex",       "<field-list>:REGEX   FIELD does not match regular expression.", &handlerRegexNotMatch,
+                "not-iregex",      "<field-list>:REGEX   FIELD does not match regular expression, case-insensitive.", &handlerIRegexNotMatch,
 
-                "char-len-le",     "FIELD:NUM   character-length(FIELD) <= NUM.", &handlerCharLenLE,
-                "char-len-lt",     "FIELD:NUM   character-length(FIELD) < NUM.", &handlerCharLenLT,
-                "char-len-ge",     "FIELD:NUM   character-length(FIELD) >= NUM.", &handlerCharLenGE,
-                "char-len-gt",     "FIELD:NUM   character-length(FIELD) > NUM.", &handlerCharLenGT,
-                "char-len-eq",     "FIELD:NUM   character-length(FIELD) == NUM.", &handlerCharLenEQ,
-                "char-len-ne",     "FIELD:NUM   character-length(FIELD) != NUM.", &handlerCharLenNE,
+                "char-len-le",     "<field-list>:NUM   character-length(FIELD) <= NUM.", &handlerCharLenLE,
+                "char-len-lt",     "<field-list>:NUM   character-length(FIELD) < NUM.", &handlerCharLenLT,
+                "char-len-ge",     "<field-list>:NUM   character-length(FIELD) >= NUM.", &handlerCharLenGE,
+                "char-len-gt",     "<field-list>:NUM   character-length(FIELD) > NUM.", &handlerCharLenGT,
+                "char-len-eq",     "<field-list>:NUM   character-length(FIELD) == NUM.", &handlerCharLenEQ,
+                "char-len-ne",     "<field-list>:NUM   character-length(FIELD) != NUM.", &handlerCharLenNE,
 
-                "byte-len-le",     "FIELD:NUM   byte-length(FIELD) <= NUM.", &handlerByteLenLE,
-                "byte-len-lt",     "FIELD:NUM   byte-length(FIELD) < NUM.", &handlerByteLenLT,
-                "byte-len-ge",     "FIELD:NUM   byte-length(FIELD) >= NUM.", &handlerByteLenGE,
-                "byte-len-gt",     "FIELD:NUM   byte-length(FIELD) > NUM.", &handlerByteLenGT,
-                "byte-len-eq",     "FIELD:NUM   byte-length(FIELD) == NUM.", &handlerByteLenEQ,
-                "byte-len-ne",     "FIELD:NUM   byte-length(FIELD) != NUM.", &handlerByteLenNE,
+                "byte-len-le",     "<field-list>:NUM   byte-length(FIELD) <= NUM.", &handlerByteLenLE,
+                "byte-len-lt",     "<field-list>:NUM   byte-length(FIELD) < NUM.", &handlerByteLenLT,
+                "byte-len-ge",     "<field-list>:NUM   byte-length(FIELD) >= NUM.", &handlerByteLenGE,
+                "byte-len-gt",     "<field-list>:NUM   byte-length(FIELD) > NUM.", &handlerByteLenGT,
+                "byte-len-eq",     "<field-list>:NUM   byte-length(FIELD) == NUM.", &handlerByteLenEQ,
+                "byte-len-ne",     "<field-list>:NUM   byte-length(FIELD) != NUM.", &handlerByteLenNE,
 
                 "ff-le",           "FIELD1:FIELD2   FIELD1 <= FIELD2 (numeric).", &handlerFFLE,
                 "ff-lt",           "FIELD1:FIELD2   FIELD1 <  FIELD2 (numeric).", &handlerFFLT,

--- a/tsv-filter/tests/gold/basic_tests_1.txt
+++ b/tsv-filter/tests/gold/basic_tests_1.txt
@@ -1157,6 +1157,129 @@ Mixed13	a-雪	षिषिषि	abcd
 Mixed14	ab-雪	षिषिषिषि	abc
 Mixed15	abc-雪	षिषिषिषिषि	ab
 
+====Field list tests===
+
+====[tsv-filter --header --ge 4-6:25 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+3	cde	de	35	45	55	bcdef	10	25
+5	ad		30	35	25	bcdef	40	15
+
+====[tsv-filter --header --gt 4-6:25 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+3	cde	de	35	45	55	bcdef	10	25
+
+====[tsv-filter --header --eq 6-4,8:0 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+9			0	0	0		0	0
+
+====[tsv-filter --header --ne 4-6,8-9:0 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+1	abc	def	10	20	30	ghi	40	50
+2	abcd	abc	20	5	35	bcd	15	40
+3	cde	de	35	45	55	bcdef	10	25
+4	aadd	aabdd	10	30	15	abd	25	25
+5	ad		30	35	25	bcdef	40	15
+6			-10	-5	-25		-15	-30
+8	bd		10	20	40	bcd	15	25
+10	ABCD	ABC	20	5	35	BCD	15	40
+11	AADD	AABDD	10	30	15	ABD	25	25
+
+====[tsv-filter --header --or --eq 4-6,8-9:0 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+7	bcf	cc	-20	-50	0	abc	0	-5
+9			0	0	0		0	0
+
+====[tsv-filter --header --lt 4,5:0 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+6			-10	-5	-25		-15	-30
+7	bcf	cc	-20	-50	0	abc	0	-5
+
+====[tsv-filter --header --lt 4,5:-1 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+6			-10	-5	-25		-15	-30
+7	bcf	cc	-20	-50	0	abc	0	-5
+
+====[tsv-filter --header --char-len-ge 2-7:2 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+1	abc	def	10	20	30	ghi	40	50
+3	cde	de	35	45	55	bcdef	10	25
+4	aadd	aabdd	10	30	15	abd	25	25
+11	AADD	AABDD	10	30	15	ABD	25	25
+
+====[tsv-filter --header --blank 2,3 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+6			-10	-5	-25		-15	-30
+9			0	0	0		0	0
+
+====[tsv-filter --header --empty 2,3,7 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+6			-10	-5	-25		-15	-30
+9			0	0	0		0	0
+
+====[tsv-filter --header --str-eq 4-6:0 input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+9			0	0	0		0	0
+
+====[tsv-filter --header --str-in-fld 2-3,7:ab input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+
+====[tsv-filter --header --str-in-fld 2-3:ab input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+2	abcd	abc	20	5	35	bcd	15	40
+
+====[tsv-filter --header --str-not-in-fld 2-3:ab input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+3	cde	de	35	45	55	bcdef	10	25
+5	ad		30	35	25	bcdef	40	15
+6			-10	-5	-25		-15	-30
+7	bcf	cc	-20	-50	0	abc	0	-5
+8	bd		10	20	40	bcd	15	25
+9			0	0	0		0	0
+10	ABCD	ABC	20	5	35	BCD	15	40
+11	AADD	AABDD	10	30	15	ABD	25	25
+
+====[tsv-filter --header --or --istr-eq 2-3:abc input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+1	abc	def	10	20	30	ghi	40	50
+2	abcd	abc	20	5	35	bcd	15	40
+10	ABCD	ABC	20	5	35	BCD	15	40
+
+====[tsv-filter --header --or --istr-eq 2-3:ABC input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+1	abc	def	10	20	30	ghi	40	50
+2	abcd	abc	20	5	35	bcd	15	40
+10	ABCD	ABC	20	5	35	BCD	15	40
+
+====[tsv-filter --header --istr-in-fld 2-3:ab input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+2	abcd	abc	20	5	35	bcd	15	40
+10	ABCD	ABC	20	5	35	BCD	15	40
+
+====[tsv-filter --header --or --regex 2-3,7:^.*b.*d$ input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+2	abcd	abc	20	5	35	bcd	15	40
+4	aadd	aabdd	10	30	15	abd	25	25
+8	bd		10	20	40	bcd	15	25
+
+====[tsv-filter --header --not-regex 2-3,7:^.*b.*d$ input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+1	abc	def	10	20	30	ghi	40	50
+3	cde	de	35	45	55	bcdef	10	25
+5	ad		30	35	25	bcdef	40	15
+6			-10	-5	-25		-15	-30
+7	bcf	cc	-20	-50	0	abc	0	-5
+9			0	0	0		0	0
+10	ABCD	ABC	20	5	35	BCD	15	40
+11	AADD	AABDD	10	30	15	ABD	25	25
+
+====[tsv-filter --header --or --iregex 7,3,2:^.*b.*d$ input4.tsv]====
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+2	abcd	abc	20	5	35	bcd	15	40
+4	aadd	aabdd	10	30	15	abd	25	25
+8	bd		10	20	40	bcd	15	25
+10	ABCD	ABC	20	5	35	BCD	15	40
+11	AADD	AABDD	10	30	15	ABD	25	25
+
 ====Field vs Field===
 
 ====[tsv-filter --header --ff-eq 1:2 input1.tsv]====

--- a/tsv-filter/tests/gold/error_tests_1.2081.txt
+++ b/tsv-filter/tests/gold/error_tests_1.2081.txt
@@ -5,107 +5,138 @@ Error test set 1
 Error [tsv-filter]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-filter --header --gt 0:10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--gt 0:10'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--gt 0:10]. Field numbers must be greater than zero: '0'
+   Expected: '--gt <field>:<val>' or '--gt <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --lt -1:10 input1.tsv]====
 [tsv-filter] Error processing command line arguments: Missing value for argument --lt.
 
 ====[tsv-filter --header --ne abc:15 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--ne abc:15'. Expected: '--ne <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: [--ne abc:15]. Unexpected 'a' when converting from type string to type long
+   Expected: '--ne <field>:<val>' or '--ne <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --eq 2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--eq 2:def'. Expected: '--eq <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--eq 2:def'. no digits seen
+   Expected: '--eq <field>:<val>' or '--eq <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1000:10 input1.tsv]====
 Error [tsv-filter]: Not enough fields in line. File: input1.tsv, Line: 2
 F1	F2	F3	F4
 
 ====[tsv-filter --header --le 1: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: 'le 1:'. Expected: 'le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--le 1:'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: 'le 1'. Expected: 'le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--le 1'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le :10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--le :10'. Expected: '--le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: [--le :10]. Empty field number.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: 'le :'. Expected: 'le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--le :'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --empty 23g input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid value in option: '--empty 23g'. Expected: '--empty <field>' where field is a 1-upped integer.
+[tsv-filter] Error processing command line arguments: [--empty 23g]. Unexpected 'g' when converting from type string to type long
+   Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --empty 0 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--empty 0'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--empty 0]. Field numbers must be greater than zero: '0'
+   Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --str-gt 0:abc input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-gt 0:abc'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--str-gt 0:abc]. Field numbers must be greater than zero: '0'
+   Expected: '--str-gt <field>:<val>' or '--str-gt <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-lt -1:ABC input1.tsv]====
 [tsv-filter] Error processing command line arguments: Missing value for argument --str-lt.
 
 ====[tsv-filter --header --str-ne abc:a22 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-ne abc:a22'. Expected: '--str-ne <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--str-ne abc:a22]. Unexpected 'a' when converting from type string to type long
+   Expected: '--str-ne <field>:<val>' or '--str-ne <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-eq 2.2:def'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--str-eq 2.2:def]. Unexpected '.' when converting from type string to type long
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 0:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 0:def'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--str-eq 0:def]. Field numbers must be greater than zero: '0'
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq :def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-eq :def'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--str-eq :def]. Empty field number.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 2:'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 2:'.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq :'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq :'.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--istr-eq 2.2:def'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--istr-eq 2.2:def]. Unexpected '.' when converting from type string to type long
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 0:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 0:def'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--istr-eq 0:def]. Field numbers must be greater than zero: '0'
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq :def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--istr-eq :def'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--istr-eq :def]. Empty field number.
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 2:'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 2:'.
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq :'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq :'.
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --regex z:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--regex z:^A[b|B]C$'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--regex z:^A[b|B]C$]. Unexpected 'z' when converting from type string to type long
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 0:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex 0:^A[b|B]C$'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--regex 0:^A[b|B]C$]. Field numbers must be greater than zero: '0'
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex :^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--regex :^A[b|B]C$'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--regex :^A[b|B]C$]. Empty field number.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 3: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex 3:'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--regex 3:'.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex :'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--regex :'.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex a:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--iregex a:^A[b|B]C$'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--iregex a:^A[b|B]C$]. Unexpected 'a' when converting from type string to type long
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 0:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 0:^A[b|B]C$'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--iregex 0:^A[b|B]C$]. Field numbers must be greater than zero: '0'
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex :^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--iregex :^A[b|B]C$'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--iregex :^A[b|B]C$]. Empty field number.
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 3: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 3:'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 3:'.
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex :'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--iregex :'.
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --ff-gt 0:1 input1.tsv]====
 [tsv-filter] Error processing command line arguments: Invalid option: '--ff-gt 0:1'. Zero is not a valid field index.

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -5,107 +5,138 @@ Error test set 1
 Error [tsv-filter]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-filter --header --gt 0:10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--gt 0:10'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--gt 0:10]. Field numbers must be greater than zero: '0'
+   Expected: '--gt <field>:<val>' or '--gt <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --lt -1:10 input1.tsv]====
 [tsv-filter] Error processing command line arguments: Missing value for argument --lt.
 
 ====[tsv-filter --header --ne abc:15 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--ne abc:15'. Expected: '--ne <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: [--ne abc:15]. Unexpected 'a' when converting from type string to type long
+   Expected: '--ne <field>:<val>' or '--ne <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --eq 2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--eq 2:def'. Expected: '--eq <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--eq 2:def'. no digits seen for input "def".
+   Expected: '--eq <field>:<val>' or '--eq <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1000:10 input1.tsv]====
 Error [tsv-filter]: Not enough fields in line. File: input1.tsv, Line: 2
 F1	F2	F3	F4
 
 ====[tsv-filter --header --le 1: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: 'le 1:'. Expected: 'le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--le 1:'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: 'le 1'. Expected: 'le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--le 1'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le :10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--le :10'. Expected: '--le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: [--le :10]. Empty field number.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: 'le :'. Expected: 'le <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid option: '--le :'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --empty 23g input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid value in option: '--empty 23g'. Expected: '--empty <field>' where field is a 1-upped integer.
+[tsv-filter] Error processing command line arguments: [--empty 23g]. Unexpected 'g' when converting from type string to type long
+   Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --empty 0 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--empty 0'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--empty 0]. Field numbers must be greater than zero: '0'
+   Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --str-gt 0:abc input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-gt 0:abc'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--str-gt 0:abc]. Field numbers must be greater than zero: '0'
+   Expected: '--str-gt <field>:<val>' or '--str-gt <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-lt -1:ABC input1.tsv]====
 [tsv-filter] Error processing command line arguments: Missing value for argument --str-lt.
 
 ====[tsv-filter --header --str-ne abc:a22 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-ne abc:a22'. Expected: '--str-ne <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--str-ne abc:a22]. Unexpected 'a' when converting from type string to type long
+   Expected: '--str-ne <field>:<val>' or '--str-ne <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-eq 2.2:def'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--str-eq 2.2:def]. Unexpected '.' when converting from type string to type long
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 0:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 0:def'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--str-eq 0:def]. Field numbers must be greater than zero: '0'
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq :def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-eq :def'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--str-eq :def]. Empty field number.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 2:'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 2:'.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq :'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq :'.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--istr-eq 2.2:def'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--istr-eq 2.2:def]. Unexpected '.' when converting from type string to type long
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 0:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 0:def'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--istr-eq 0:def]. Field numbers must be greater than zero: '0'
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq :def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--istr-eq :def'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: [--istr-eq :def]. Empty field number.
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 2:'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 2:'.
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq :'. Expected: '--istr-eq <field>:<val>' where <field> is a number and <val> is a string.
+[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq :'.
+   Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --regex z:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--regex z:^A[b|B]C$'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--regex z:^A[b|B]C$]. Unexpected 'z' when converting from type string to type long
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 0:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex 0:^A[b|B]C$'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--regex 0:^A[b|B]C$]. Field numbers must be greater than zero: '0'
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex :^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--regex :^A[b|B]C$'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--regex :^A[b|B]C$]. Empty field number.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 3: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex 3:'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--regex 3:'.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex :'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--regex :'.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex a:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--iregex a:^A[b|B]C$'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--iregex a:^A[b|B]C$]. Unexpected 'a' when converting from type string to type long
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 0:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 0:^A[b|B]C$'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--iregex 0:^A[b|B]C$]. Field numbers must be greater than zero: '0'
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex :^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--iregex :^A[b|B]C$'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: [--iregex :^A[b|B]C$]. Empty field number.
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 3: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 3:'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 3:'.
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex :'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid option: '--iregex :'.
+   Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --ff-gt 0:1 input1.tsv]====
 [tsv-filter] Error processing command line arguments: Invalid option: '--ff-gt 0:1'. Zero is not a valid field index.

--- a/tsv-filter/tests/input4.tsv
+++ b/tsv-filter/tests/input4.tsv
@@ -1,0 +1,12 @@
+line	2_apha	3_apha	4_num	5_num	6_num	7_alpha	8_num	9_num
+1	abc	def	10	20	30	ghi	40	50
+2	abcd	abc	20	5	35	bcd	15	40
+3	cde	de	35	45	55	bcdef	10	25
+4	aadd	aabdd	10	30	15	abd	25	25
+5	ad		30	35	25	bcdef	40	15
+6			-10	-5	-25		-15	-30
+7	bcf	cc	-20	-50	0	abc	0	-5
+8	bd		10	20	40	bcd	15	25
+9			0	0	0		0	0
+10	ABCD	ABC	20	5	35	BCD	15	40
+11	AADD	AABDD	10	30	15	ABD	25	25

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -190,6 +190,29 @@ runtest ${prog} "--header --char-len-lt 1:3 input_unicode.tsv" ${basic_tests_1}
 runtest ${prog} "--header --char-len-le 2:2 input_unicode.tsv" ${basic_tests_1}
 runtest ${prog} "--header --char-len-ge 4:2 input_unicode.tsv" ${basic_tests_1}
 
+# Field List tests
+echo "" >> ${basic_tests_1}; echo "====Field list tests===" >> ${basic_tests_1}
+runtest ${prog} "--header --ge 4-6:25 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --gt 4-6:25 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --eq 6-4,8:0 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ne 4-6,8-9:0 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --or --eq 4-6,8-9:0 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --lt 4,5:0 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --lt 4,5:-1 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --char-len-ge 2-7:2 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --blank 2,3 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --empty 2,3,7 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-eq 4-6:0 input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-in-fld 2-3,7:ab input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-in-fld 2-3:ab input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-not-in-fld 2-3:ab input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --or --istr-eq 2-3:abc input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --or --istr-eq 2-3:ABC input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --istr-in-fld 2-3:ab input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --or --regex 2-3,7:^.*b.*d$ input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --not-regex 2-3,7:^.*b.*d$ input4.tsv" ${basic_tests_1}
+runtest ${prog} "--header --or --iregex 7,3,2:^.*b.*d$ input4.tsv" ${basic_tests_1}
+
 # Field vs Field tests
 echo "" >> ${basic_tests_1}; echo "====Field vs Field===" >> ${basic_tests_1}
 


### PR DESCRIPTION
This PR adds field list support to `tsv-filter`. This allows multiple fields to be specified using the same filter. Examples:
```
$ # Ensure that fields 1-10 are not blank
$ tsv-filter --not-blank 1-10

$ # Ensure that fields 1, 3, and 5 are not zero.
$ tsv-filter --ne 1,3,5:0

$ # Ensure that fields 1-30 are not blank and not "NA"
tsv-filter --not-blank 1-30 --str-ne 1-30:'NA'
```
Field list support is already available in most of the other tools in the `tsv-utils` toolset.