### PR TITLE
Describe differences between csv2tsv and other csv-to-tsv converters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ A strict delimited format like TSV has many advantages for data processing over 
 
 Note that many CSV files do not use escapes, and in-fact follow a strict delimited format using comma as the delimiter. Such files can be processed reliably by this toolkit and Unix tools by specifying the delimiter character. However, when there is doubt, using a `csv2tsv` converter adds reliability.
 
+`csv2tsv` differs from many csv-to-tsv conversion tools in that it produces output free of CSV escapes. Many conversion tools produce data with CSV style escapes, but switching the field delimiter from comma to TAB. Such data cannot be reliably processed by Unix tools like `cut`, `awk`, `sort`, etc.
+
+`csv2tsv` avoids escapes by replacing TAB and newline characters in the data with a single space. These characters are rare in data mining scenarios, and space is usually a good substitute in cases where they do occur. The replacement string is customizable to enable alternate handling when needed.
+
 The `csv2tsv` converter often has a second benefit: regularizing newlines. CSV files are often exported using Windows newline conventions. `csv2tsv` converts all newlines to Unix format.
 
 See [Comparing TSV and CSV formats](docs/comparing-tsv-and-csv.md) for more information on CSV escapes and other differences between CSV and TSV formats.

--- a/csv2tsv/README.md
+++ b/csv2tsv/README.md
@@ -11,6 +11,10 @@ TSV files have many advantages over CSV files for large scale data processing, b
 
 The main issue when working with CSV data is the potential for CSV escapes in the data. Standard Unix tools like `cut`, `awk`, and `sort` do not work properly if the data contains CSV escapes, and neither do eBay's TSV Utilities. The `csv2tsv` tool eliminates issues with CSV escapes, allowing the resulting data to be processed correctly by both eBay's TSV Utilities and standard Unix tools.
 
+Many csv-to-tsv conversion tools don't remove escapes. Instead they generate CSV-style escapes, producing data in CSV format except using TAB as the record delimiter rather than comma. Such data is not correctly interpreted by traditional Unix tools. 
+
+`csv2tsv` avoids escapes by replacing TAB and newline characters in the data with a single space. These characters are rare in data mining scenarios, and space is usually a good substitute in cases where they do occur. The replacement string is customizable to enable alternate handling when needed.
+
 Another useful benefit of the `csv2tsv` converter is that it normalizes newlines. Many programs generate Windows newlines when exporting in CSV format, even on Unix systems.
 
 CSV files come in different formats. See the [csv2tsv reference](../docs/ToolReference.md#csv2tsv-reference) for details of how this tool operates and the format variations handled.

--- a/docs/comparing-tsv-and-csv.md
+++ b/docs/comparing-tsv-and-csv.md
@@ -42,6 +42,15 @@ ghi	Say "hello, world!"	jkl
 
 The similarity between TSV and CSV can lead to confusion about which tools are appropriate. Furthering this confusion, it is somewhat common to have data files using comma as the field delimiter, but without comma, quote, or newlines in the data. No CSV escapes are needed in these files, with the implication that traditional Unix tools like `cut` and `awk` can be used to process these files. Such files are sometimes referred to as "simple CSV". They are equivalent to TSV files with comma as a field delimiter. Traditional Unix tools and [tsv-utils](../README.md) tools can process these files correctly by specifying the field delimiter. However, "simple csv" is a very ad hoc and ill defined notion. A simple precaution when working with these files is to run a CSV-to-TSV converter like [csv2tsv](ToolReference.md#csv2tsv-reference) prior to other processing steps.
 
+Note that many CSV-to-TSV conversion tools don't actually remove the CSV escapes. Instead these tools replace comma with TAB as the record delimiter, but still use CSV escapes to represent TAB, newline, and quote characters in the data. Such data cannot be reliably processed by Unix tools like `sort`, `awk`, and `cut`. The tsv-utils [csv2tsv](ToolReference.md#csv2tsv-reference) tool avoids escapes by replacing TAB and newline with a space (customizable). This works well in the vast majority of data mining scenarios.
+
+To see what a specific CSV-to-TSV conversion tool does, convert CSV data containing quotes, commas, TABs, newlines, and double-quoted fields. For example:
+```
+$ echo $'Line,Field1,Field2\n1,"Comma: |,|","Quote: |""|"\n"2","TAB: |\t|","Newline: |\n|"' | <csv-to-tsv-converter>
+```
+
+Approaches that generate CSV escapes will enclose a number of the output fields in double quotes.
+
 References:
 - [Wikipedia: Tab-separated values](https://en.wikipedia.org/wiki/Tab-separated_values) - Useful description of TSV format.
 - [IANA TSV specification](https://www.iana.org/assignments/media-types/text/tab-separated-values) - Formal definition of the tab-separated-values mime type.


### PR DESCRIPTION
Update descriptions to point out that many csv-to-tsv conversion solutions don't actually remove CSV escapes, and instead replace comma with TAB as the field delimiter. Describe that csv2tsv replaces TAB and newline with a space (customizable) to avoid this.