### PR TITLE
tsv-select --exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The tools work like traditional Unix command line utilities such as `cut`, `sort
 
 The rest of this section contains descriptions of each tool. Click on the links below to jump directly to one of the tools. Full documentation is available in the [tool reference](docs/ToolReference.md).
 
-* [tsv-filter](#tsv-filter) - Filter lines using numeric, string and regular expression comparisons against individual fields. (This description also provides an introduction to features found throughout the toolkit.)
+* [tsv-filter](#tsv-filter) - Filter lines using numeric, string and regular expression comparisons against individual fields. This description also provides an introduction to features found throughout the toolkit.
 * [tsv-select](#tsv-select) - Keep a subset of columns (fields). Like `cut`, but with field reordering.
 * [tsv-uniq](#tsv-uniq) - Filter out duplicate lines using either the full line or individual fields as a key.
 * [tsv-summarize](#tsv-summarize) - Summary statistics on selected fields, against the full data set or grouped by key.

--- a/README.md
+++ b/README.md
@@ -167,9 +167,29 @@ See the [tsv-filter reference](docs/ToolReference.md#tsv-filter-reference) for m
 
 ### tsv-select
 
-A version of the Unix `cut` utility with the additional ability to re-order the fields. It also helps with header lines by keeping only the header from the first file (`--header` option). The following command writes fields [4, 2, 9, 10, 11] from a pair of files to stdout:
+A version of the Unix `cut` utility with the additional ability to re-order the fields. The following command writes fields [4, 2, 9, 10, 11] from a pair of files to stdout:
 ```
 $ tsv-select -f 4,2,9-11 file1.tsv file2.tsv
+```
+
+Fields can be listed more than once, and fields not listed can be output using the `--rest` option. When working with multiple files, the `--header` option can be used to retain only the header from the first file.
+
+Examples:
+```
+$ # Output fields 2 and 1, in that order
+$ tsv-select -f 2,1 data.tsv
+
+$ # Move field 7 to the start of the line
+$ tsv-select -f 7 --rest last data.tsv
+
+$ # Move field 1 to the end of the line
+$ tsv-select -f 1 --rest first data.tsv
+
+$ # Output a range of fields in reverse order
+$ tsv-select -f 30-3 data.tsv
+
+$ # Multiple files with header lines. Keep only one header.
+$ tsv-select data*.tsv -H --fields 1,2,4-7,14
 ```
 
 See the [tsv-select reference](docs/ToolReference.md#tsv-select-reference) for details.

--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -206,16 +206,16 @@ _tsv_select()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --version --header --fields --rest --delimiter"
+    opts="--help --version --header --fields --exclude --rest --delimiter"
 
     # Options requiring an argument or precluding other options
     # Options with a restricted set of arguments (ie. -r|--rest) have their own case clause.
     case $prev in
-        -h|--help|-V|--version|-f|--fields|-d|--delimiter)
+        -h|--help|-V|--version|-f|--fields|-e|--exclude|-d|--delimiter)
             return
             ;;
         -r|--rest)
-            COMPREPLY=( $(compgen -W "none first last" -- ${cur}) )
+            COMPREPLY=( $(compgen -W "first last" -- ${cur}) )
             return
             ;;
     esac

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -263,7 +263,7 @@ Fields numbers start with one. They are comma separated, and ranges can be used.
 * `--V|version` - Print version information and exit.
 * `--H|header` - Treat the first line of each file as a header.
 * `--f|fields <field-list>` - (Required) Fields to extract. Fields are output in the order listed.
-* `--r|rest none|first|last` - Location for remaining fields. Default: none
+* `--r|rest first|last` - Location for remaining fields. Default: none
 * `--d|delimiter CHR` - Character to use as field delimiter. Default: TAB. (Single byte UTF-8 characters only.)
 
 **Examples:**

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -269,7 +269,7 @@ Fields numbers start with one. They are comma separated, and ranges can be used.
 **Examples:**
 ```
 $ # Output fields 2 and 1, in that order
-$ tsv-select -f 2,1 --rest first data.tsv
+$ tsv-select -f 2,1 data.tsv
 
 $ # Move field 1 to the end of the line
 $ tsv-select -f 1 --rest first data.tsv

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -252,7 +252,7 @@ _**Tip:**_ Bash completion is very helpful when using commands like `tsv-filter`
 
 ## tsv-select reference
 
-**Synopsis:** tsv-select -f <field-list> [options] [file...]
+**Synopsis:** tsv-select [options] [file...]
 
 tsv-select reads files or standard input and writes specified fields to standard output in the order listed. Similar to `cut` with the ability to reorder fields.
 

--- a/tsv-select/README.md
+++ b/tsv-select/README.md
@@ -27,6 +27,6 @@ $ # Multiple files with header lines. Keep only one header.
 $ tsv-select data*.tsv -H --fields 1,2,4-7,14
 ```
 
-Reordering fields and managing headers are useful enhancements over `cut`. However, much of the motivation for writing it was to explore the D programming language and provide a comparison point against other common approaches to this task. Code for `tsv-select` is bit more liberal with comments pointing out D programming constructs than code for the other tools. As an unexpected benefit, `tsv-select` is faster than other implementations of `cut` that are available.
+Reordering fields and managing headers are useful enhancements over `cut`. However, much of the motivation for writing `tsv-select` was to explore the D programming language and provide a comparison point against other common approaches to this task. Code for `tsv-select` is bit more liberal with comments pointing out D programming constructs than code for the other tools. As an unexpected benefit, `tsv-select` is faster than other implementations of `cut` that are available.
 
 See the [tsv-select reference](../docs/ToolReference.md#tsv-select-reference) for details.

--- a/tsv-select/README.md
+++ b/tsv-select/README.md
@@ -2,9 +2,29 @@ _Visit the eBay TSV utilities [main page](../README.md)_
 
 # tsv-select
 
-A version of the Unix `cut` utility with the additional ability to re-order the fields. It also helps with header lines by keeping only the header from the first file (`--header` option). The following command writes fields [4, 2, 9, 10, 11] from a pair of files to stdout:
+A version of the Unix `cut` utility with the additional ability to re-order the fields. The following command writes fields [4, 2, 9, 10, 11] from a pair of files to stdout:
 ```
 $ tsv-select -f 4,2,9-11 file1.tsv file2.tsv
+```
+
+Fields can be listed more than once, and fields not listed can be output using the `--rest` option. When working with multiple files, the `--header` option can be used to retain only the header from the first file.
+
+Examples:
+```
+$ # Output fields 2 and 1, in that order
+$ tsv-select -f 2,1 data.tsv
+
+$ # Move field 7 to the start of the line
+$ tsv-select -f 7 --rest last data.tsv
+
+$ # Move field 1 to the end of the line
+$ tsv-select -f 1 --rest first data.tsv
+
+$ # Output a range of fields in reverse order
+$ tsv-select -f 30-3 data.tsv
+
+$ # Multiple files with header lines. Keep only one header.
+$ tsv-select data*.tsv -H --fields 1,2,4-7,14
 ```
 
 Reordering fields and managing headers are useful enhancements over `cut`. However, much of the motivation for writing it was to explore the D programming language and provide a comparison point against other common approaches to this task. Code for `tsv-select` is bit more liberal with comments pointing out D programming constructs than code for the other tools. As an unexpected benefit, `tsv-select` is faster than other implementations of `cut` that are available.

--- a/tsv-select/profile_data/collect_profile_data.sh
+++ b/tsv-select/profile_data/collect_profile_data.sh
@@ -37,5 +37,9 @@ $prog profile_data_3.tsv -H -f 5,3,1 > /dev/null
 $prog profile_data_3.tsv -H -f 1-3 > /dev/null
 $prog profile_data_3.tsv -H -f 7 > /dev/null
 $prog profile_data_3.tsv -H -f 3-6 > /dev/null
+$prog profile_data_1.tsv -H -f 5 --rest last > /dev/null
+$prog profile_data_1.tsv -H -f 1 --rest first > /dev/null
+$prog -H --exclude 1 profile_data_1.tsv profile_data_2.tsv profile_data_3.tsv -H > /dev/null
+$prog profile_data_3.tsv --exclude 2-4 > /dev/null
 
 ${ldc_profdata_tool} merge -o app.profdata profile.*.raw

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -86,7 +86,7 @@ Examples:
 Notes:
 * One of '--f|fields' or '--e|exclude' is required.
 * Fields specified by '--f|fields' and '--e|exclude' cannot overlap.
-* Each line must have all fields specfied by '--f|fields'. Otherwise
+* Each line must have all fields specified by '--f|fields'. Otherwise
   line length can vary.
 
 Options:

--- a/tsv-select/tests/gold/basic_tests_1.txt
+++ b/tsv-select/tests/gold/basic_tests_1.txt
@@ -432,6 +432,14 @@ DEF	ABC
 8
 9
 
+11
+12
+13
+14
+15
+16
+17
+
 ====[tsv-select -f 3 input_3plus_fields.tsv]====
 UUU
 CCC
@@ -441,6 +449,14 @@ sss
 
  
 
+
+
+
+B
+BB
+Ä
+ÄÄ
+ÄAÄ
 done
 
 ====[tsv-select -f 2,3 --rest first input_3plus_fields.tsv]====
@@ -452,7 +468,15 @@ done
 6	e-e		
 7	sp-sp	2020	2021	 	 
 8	empty-last	
-9	last-row	done
+9			|	next-line-6-empty	
+					
+11		
+12	C	D	A	B
+13	CC	DD	EE	AA	BB
+14	ä	Ö	ö	ß	Ä
+15	ää	ÖÖ	öö	ßß	ÄÄ
+16	äaä	ÖOÖ	öoö	ßsß	ÄAÄ
+17	last-row	done
 
 ====[tsv-select -f 1 --rest first input_3plus_fields.tsv]====
 ggg	UUU	101	1
@@ -463,7 +487,15 @@ ssssss	sss	18	16	f6	f7	f8	f9	f10	4
 		e-e	6
  	 	sp-sp	2020	2021	7
 empty-last		8
-last-row	done	9
+next-line-6-empty				|	9
+					
+		11
+A	B	C	D	12
+AA	BB	CC	DD	EE	13
+ß	Ä	ä	Ö	ö	14
+ßß	ÄÄ	ää	ÖÖ	öö	15
+ßsß	ÄAÄ	äaä	ÖOÖ	öoö	16
+last-row	done	17
 
 ====[tsv-select -f 3,1 --rest first input_3plus_fields.tsv]====
 ggg	101	UUU	1
@@ -474,7 +506,15 @@ ssssss	18	16	f6	f7	f8	f9	f10	sss	4
 	e-e		6
  	sp-sp	2020	2021	 	7
 empty-last		8
-last-row	done	9
+next-line-6-empty			|		9
+					
+		11
+A	C	D	B	12
+AA	CC	DD	EE	BB	13
+ß	ä	Ö	ö	Ä	14
+ßß	ää	ÖÖ	öö	ÄÄ	15
+ßsß	äaä	ÖOÖ	öoö	ÄAÄ	16
+last-row	done	17
 
 ====[tsv-select -f 3,1,2 --rest first input_3plus_fields.tsv]====
 101	UUU	1	ggg
@@ -485,7 +525,15 @@ SSS	3	ßßß
 e-e		6	
 sp-sp	2020	2021	 	7	 
 	8	empty-last
-done	9	last-row
+		|		9	next-line-6-empty
+					
+	11	
+C	D	B	12	A
+CC	DD	EE	BB	13	AA
+ä	Ö	ö	Ä	14	ß
+ää	ÖÖ	öö	ÄÄ	15	ßß
+äaä	ÖOÖ	öoö	ÄAÄ	16	ßsß
+done	17	last-row
 
 ====[tsv-select -f 1 --rest last input_3plus_fields.tsv]====
 1	ggg	UUU	101
@@ -496,7 +544,15 @@ done	9	last-row
 6			e-e
 7	 	 	sp-sp	2020	2021
 8	empty-last	
-9	last-row	done
+9	next-line-6-empty				|
+					
+11		
+12	A	B	C	D
+13	AA	BB	CC	DD	EE
+14	ß	Ä	ä	Ö	ö
+15	ßß	ÄÄ	ää	ÖÖ	öö
+16	ßsß	ÄAÄ	äaä	ÖOÖ	öoö
+17	last-row	done
 
 ====[tsv-select -f 1,3 --rest last input_3plus_fields.tsv]====
 1	UUU	ggg	101
@@ -507,7 +563,15 @@ done	9	last-row
 6			e-e
 7	 	 	sp-sp	2020	2021
 8		empty-last
-9	done	last-row
+9		next-line-6-empty			|
+					
+11		
+12	B	A	C	D
+13	BB	AA	CC	DD	EE
+14	Ä	ß	ä	Ö	ö
+15	ÄÄ	ßß	ää	ÖÖ	öö
+16	ÄAÄ	ßsß	äaä	ÖOÖ	öoö
+17	done	last-row
 
 ====[tsv-select -f 2,1,3 --rest last input_3plus_fields.tsv]====
 ggg	1	UUU	101
@@ -518,7 +582,15 @@ ssssss	4	sss	18	16	f6	f7	f8	f9	f10
 	6		e-e
  	7	 	sp-sp	2020	2021
 empty-last	8	
-last-row	9	done
+next-line-6-empty	9				|
+					
+	11	
+A	12	B	C	D
+AA	13	BB	CC	DD	EE
+ß	14	Ä	ä	Ö	ö
+ßß	15	ÄÄ	ää	ÖÖ	öö
+ßsß	16	ÄAÄ	äaä	ÖOÖ	öoö
+last-row	17	done
 
 ====[tsv-select -f 1 --delimiter ^  input_2plus_hat_delim.tsv]====
 f1

--- a/tsv-select/tests/gold/basic_tests_1.txt
+++ b/tsv-select/tests/gold/basic_tests_1.txt
@@ -331,6 +331,248 @@ f23-empty			6
 f23-space	 	 	7
 1931	Z	0.0	8
 
+====[tsv-select --exclude 1 input1.tsv]====
+f2	f3	f4
+ggg	UUU	101
+f1-empty	CCC	5734
+ßßß	SSS	 7
+sss	f4-empty	
+ÀBC		1367
+		f23-empty
+ 	 	f23-space
+0.0	Z	1931
+
+====[tsv-select -e 2 input1.tsv]====
+f1	f3	f4
+1	UUU	101
+	CCC	5734
+3	SSS	 7
+4	f4-empty	
+5		1367
+6		f23-empty
+7	 	f23-space
+8	Z	1931
+
+====[tsv-select -e 3 input1.tsv]====
+f1	f2	f4
+1	ggg	101
+	f1-empty	5734
+3	ßßß	 7
+4	sss	
+5	ÀBC	1367
+6		f23-empty
+7	 	f23-space
+8	0.0	1931
+
+====[tsv-select -e 4 input1.tsv]====
+f1	f2	f3
+1	ggg	UUU
+	f1-empty	CCC
+3	ßßß	SSS
+4	sss	f4-empty
+5	ÀBC	
+6		
+7	 	 
+8	0.0	Z
+
+====[tsv-select -e 1,2 input1.tsv]====
+f3	f4
+UUU	101
+CCC	5734
+SSS	 7
+f4-empty	
+	1367
+	f23-empty
+ 	f23-space
+Z	1931
+
+====[tsv-select -e 2-1 input1.tsv]====
+f3	f4
+UUU	101
+CCC	5734
+SSS	 7
+f4-empty	
+	1367
+	f23-empty
+ 	f23-space
+Z	1931
+
+====[tsv-select -e 2,3 input1.tsv]====
+f1	f4
+1	101
+	5734
+3	 7
+4	
+5	1367
+6	f23-empty
+7	f23-space
+8	1931
+
+====[tsv-select -e 4,3 input1.tsv]====
+f1	f2
+1	ggg
+	f1-empty
+3	ßßß
+4	sss
+5	ÀBC
+6	
+7	 
+8	0.0
+
+====[tsv-select -e 1,3-4 input1.tsv]====
+f2
+ggg
+f1-empty
+ßßß
+sss
+ÀBC
+
+ 
+0.0
+
+====[tsv-select -e 1-4 input1.tsv]====
+
+
+
+
+
+
+
+
+
+
+====[tsv-select -e 1-5 input1.tsv]====
+
+
+
+
+
+
+
+
+
+
+====[tsv-select -e 5-10 input1.tsv]====
+f1	f2	f3	f4
+1	ggg	UUU	101
+	f1-empty	CCC	5734
+3	ßßß	SSS	 7
+4	sss	f4-empty	
+5	ÀBC		1367
+6			f23-empty
+7	 	 	f23-space
+8	0.0	Z	1931
+
+====[tsv-select -e 1,2 --rest last input1.tsv]====
+f3	f4
+UUU	101
+CCC	5734
+SSS	 7
+f4-empty	
+	1367
+	f23-empty
+ 	f23-space
+Z	1931
+
+====[tsv-select -e 1,2 --rest first input1.tsv]====
+f3	f4
+UUU	101
+CCC	5734
+SSS	 7
+f4-empty	
+	1367
+	f23-empty
+ 	f23-space
+Z	1931
+
+====[tsv-select -e 1 -f 3 input1.tsv]====
+f3	f2	f4
+UUU	ggg	101
+CCC	f1-empty	5734
+SSS	ßßß	 7
+f4-empty	sss	
+	ÀBC	1367
+		f23-empty
+ 	 	f23-space
+Z	0.0	1931
+
+====[tsv-select -e 1 -f 3 --rest last input1.tsv]====
+f3	f2	f4
+UUU	ggg	101
+CCC	f1-empty	5734
+SSS	ßßß	 7
+f4-empty	sss	
+	ÀBC	1367
+		f23-empty
+ 	 	f23-space
+Z	0.0	1931
+
+====[tsv-select -e 1 -f 3 --rest first input1.tsv]====
+f2	f4	f3
+ggg	101	UUU
+f1-empty	5734	CCC
+ßßß	 7	SSS
+sss		f4-empty
+ÀBC	1367	
+	f23-empty	
+ 	f23-space	 
+0.0	1931	Z
+
+====[tsv-select -e 2 -f 4,1 input1.tsv]====
+f4	f1	f3
+101	1	UUU
+5734		CCC
+ 7	3	SSS
+	4	f4-empty
+1367	5	
+f23-empty	6	
+f23-space	7	 
+1931	8	Z
+
+====[tsv-select -e 2 -f 4,1 --rest first input1.tsv]====
+f3	f4	f1
+UUU	101	1
+CCC	5734	
+SSS	 7	3
+f4-empty		4
+	1367	5
+	f23-empty	6
+ 	f23-space	7
+Z	1931	8
+
+====[tsv-select -e 2,3 -f 4,1 input1.tsv]====
+f4	f1
+101	1
+5734	
+ 7	3
+	4
+1367	5
+f23-empty	6
+f23-space	7
+1931	8
+
+====[tsv-select -e 2,3 -f 4,1 --rest first input1.tsv]====
+f4	f1
+101	1
+5734	
+ 7	3
+	4
+1367	5
+f23-empty	6
+f23-space	7
+1931	8
+
+====[tsv-select -e 2,3,5 -f 4,1 input1.tsv]====
+f4	f1
+101	1
+5734	
+ 7	3
+	4
+1367	5
+f23-empty	6
+f23-space	7
+1931	8
+
 ====[tsv-select -f 1 input_1field.tsv]====
 1
 2 abc def
@@ -348,6 +590,12 @@ f23-space	 	 	7
 2 abc def
 3
 4 567 89-10
+
+====[tsv-select --exclude 1 input_1field.tsv]====
+
+
+
+
 
 ====[tsv-select -f 1 input_2fields.tsv]====
 f1
@@ -420,6 +668,24 @@ f2	f1
 def	abc
 456	123
 DEF	ABC
+
+====[tsv-select -e 1 input_2fields.tsv]====
+f2
+def
+456
+DEF
+
+====[tsv-select -e 2 input_2fields.tsv]====
+f1
+abc
+123
+ABC
+
+====[tsv-select -e 1-2 input_2fields.tsv]====
+
+
+
+
 
 ====[tsv-select -f 1 input_3plus_fields.tsv]====
 1
@@ -592,6 +858,158 @@ AA	13	BB	CC	DD	EE
 ßsß	16	ÄAÄ	äaä	ÖOÖ	öoö
 last-row	17	done
 
+====[tsv-select --exclude 1 input_3plus_fields.tsv]====
+ggg	UUU	101
+ggg	CCC	5734	52
+ßßß	SSS
+ssssss	sss	18	16	f6	f7	f8	f9	f10
+ÀBC		1367	1331	1234	4567
+		e-e
+ 	 	sp-sp	2020	2021
+empty-last	
+next-line-6-empty				|
+				
+	
+A	B	C	D
+AA	BB	CC	DD	EE
+ß	Ä	ä	Ö	ö
+ßß	ÄÄ	ää	ÖÖ	öö
+ßsß	ÄAÄ	äaä	ÖOÖ	öoö
+last-row	done
+
+====[tsv-select -e 3 input_3plus_fields.tsv]====
+1	ggg	101
+2	ggg	5734	52
+3	ßßß
+4	ssssss	18	16	f6	f7	f8	f9	f10
+5	ÀBC	1367	1331	1234	4567
+6		e-e
+7	 	sp-sp	2020	2021
+8	empty-last
+9	next-line-6-empty			|
+				
+11	
+12	A	C	D
+13	AA	CC	DD	EE
+14	ß	ä	Ö	ö
+15	ßß	ää	ÖÖ	öö
+16	ßsß	äaä	ÖOÖ	öoö
+17	last-row
+
+====[tsv-select -e 1-3 input_3plus_fields.tsv]====
+101
+5734	52
+
+18	16	f6	f7	f8	f9	f10
+1367	1331	1234	4567
+e-e
+sp-sp	2020	2021
+
+		|
+		
+
+C	D
+CC	DD	EE
+ä	Ö	ö
+ää	ÖÖ	öö
+äaä	ÖOÖ	öoö
+
+
+====[tsv-select -e 4 input_3plus_fields.tsv]====
+1	ggg	UUU
+2	ggg	CCC	52
+3	ßßß	SSS
+4	ssssss	sss	16	f6	f7	f8	f9	f10
+5	ÀBC		1331	1234	4567
+6		
+7	 	 	2020	2021
+8	empty-last	
+9	next-line-6-empty			|
+				
+11		
+12	A	B	D
+13	AA	BB	DD	EE
+14	ß	Ä	Ö	ö
+15	ßß	ÄÄ	ÖÖ	öö
+16	ßsß	ÄAÄ	ÖOÖ	öoö
+17	last-row	done
+
+====[tsv-select -e 5 input_3plus_fields.tsv]====
+1	ggg	UUU	101
+2	ggg	CCC	5734
+3	ßßß	SSS
+4	ssssss	sss	18	f6	f7	f8	f9	f10
+5	ÀBC		1367	1234	4567
+6			e-e
+7	 	 	sp-sp	2021
+8	empty-last	
+9	next-line-6-empty			|
+				
+11		
+12	A	B	C
+13	AA	BB	CC	EE
+14	ß	Ä	ä	ö
+15	ßß	ÄÄ	ää	öö
+16	ßsß	ÄAÄ	äaä	öoö
+17	last-row	done
+
+====[tsv-select -e 4-10 input_3plus_fields.tsv]====
+1	ggg	UUU
+2	ggg	CCC
+3	ßßß	SSS
+4	ssssss	sss
+5	ÀBC	
+6		
+7	 	 
+8	empty-last	
+9	next-line-6-empty	
+		
+11		
+12	A	B
+13	AA	BB
+14	ß	Ä
+15	ßß	ÄÄ
+16	ßsß	ÄAÄ
+17	last-row	done
+
+====[tsv-select -e 1 -f 3 --rest last input_3plus_fields.tsv]====
+UUU	ggg	101
+CCC	ggg	5734	52
+SSS	ßßß
+sss	ssssss	18	16	f6	f7	f8	f9	f10
+	ÀBC	1367	1331	1234	4567
+		e-e
+ 	 	sp-sp	2020	2021
+	empty-last
+	next-line-6-empty			|
+				
+	
+B	A	C	D
+BB	AA	CC	DD	EE
+Ä	ß	ä	Ö	ö
+ÄÄ	ßß	ää	ÖÖ	öö
+ÄAÄ	ßsß	äaä	ÖOÖ	öoö
+done	last-row
+
+====[tsv-select -e 1 -f 3 --rest first input_3plus_fields.tsv]====
+ggg	101	UUU
+ggg	5734	52	CCC
+ßßß	SSS
+ssssss	18	16	f6	f7	f8	f9	f10	sss
+ÀBC	1367	1331	1234	4567	
+	e-e	
+ 	sp-sp	2020	2021	 
+empty-last	
+next-line-6-empty			|	
+				
+	
+A	C	D	B
+AA	CC	DD	EE	BB
+ß	ä	Ö	ö	Ä
+ßß	ää	ÖÖ	öö	ÄÄ
+ßsß	äaä	ÖOÖ	öoö	ÄAÄ
+last-row	done
+
 ====[tsv-select -f 1 --delimiter ^  input_2plus_hat_delim.tsv]====
 f1
 abc
@@ -688,6 +1106,46 @@ abc^def^ghi
 123^456^789^
 ^abc^
 
+====[tsv-select --exclude 1 --delimiter ^  input_2plus_hat_delim.tsv]====
+f2
+def^ghi
+^
+^^
+456^789^
+abc^
+
+====[tsv-select --exclude 2 --delimiter ^  input_2plus_hat_delim.tsv]====
+f1
+abc^ghi
+^
+^^
+123^789^
+^
+
+====[tsv-select --exclude 1-2 --delimiter ^  input_2plus_hat_delim.tsv]====
+
+ghi
+
+^
+789^
+
+
+====[tsv-select --exclude 3-10 --delimiter ^  input_2plus_hat_delim.tsv]====
+f1^f2
+abc^def
+^
+^
+123^456
+^abc
+
+====[tsv-select --exclude 2 --fields 1 --rest first --delimiter ^  input_2plus_hat_delim.tsv]====
+f1
+ghi^abc
+^
+^^
+789^^123
+^
+
 ====Multi-file & stdin Tests===
 
 ====[tsv-select -f 2,1 input_3x2.tsv input_emptyfile.tsv input_3x1.tsv input_3x0.tsv input_3x3.tsv]====
@@ -736,6 +1194,24 @@ field2
 field1	field2	field3
 11567	12567	13567
 21567	22567	23567
+
+====[tsv-select --header --exclude 1 input_header1.tsv]====
+field2	field3
+12567	13567
+22567	23567
+
+====[tsv-select -H -e 2 input_header1.tsv input_header2.tsv input_header3.tsv input_header4.tsv]====
+field1	field3
+11567	13567
+21567	23567
+11987	13987
+11888	13888
+21888	23888
+
+====[tsv-select -H -e 1,2,3 input_header3.tsv input_header3.tsv input_header1.tsv]====
+
+
+
 
 Help and Version printing 1
 -----------------

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -2,10 +2,10 @@ Error test set 1
 ----------------
 
 ====[tsv-select input1.tsv]====
-[tsv-select] Error processing command line arguments: Required option --f|fields was not supplied.
+[tsv-select] Error processing command line arguments: One of '--f|fields' or '--e|exclude' is required.
 
 ====[tsv-select input1.tsv --rest last]====
-[tsv-select] Error processing command line arguments: Required option --f|fields was not supplied.
+[tsv-select] Error processing command line arguments: One of '--f|fields' or '--e|exclude' is required.
 
 ====[tsv-select input1.tsv --fields last]====
 [tsv-select] Error processing command line arguments: [--f|fields] Unexpected 'l' when converting from type string to type long
@@ -14,7 +14,7 @@ Error test set 1
 [tsv-select] Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
 
 ====[tsv-select input1.tsv -f 2 --rest elsewhere]====
-[tsv-select] Error processing command line arguments: RestOptionVal does not have a member named 'elsewhere'
+[tsv-select] Error processing command line arguments: RestOption does not have a member named 'elsewhere'
 
 ====[tsv-select -f 1 nosuchfile.tsv]====
 Error [tsv-select]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
@@ -47,6 +47,24 @@ Error [tsv-select]: Not enough fields in line. File: input_3plus_fields.tsv,  Li
 
 ====[tsv-select -f 1.1 input1.tsv]====
 [tsv-select] Error processing command line arguments: [--f|fields] Unexpected '.' when converting from type string to type long
+
+====[tsv-select -e 0 input1.tsv]====
+[tsv-select] Error processing command line arguments: [--e|exclude] Field numbers must be greater than zero: '0'
+
+====[tsv-select -e 1 -f 1 input1.tsv]====
+[tsv-select] Error processing command line arguments: '--f|fields' and '--e|exclude' have overlapping fields.
+
+====[tsv-select -e 1-5 -f 3 input1.tsv]====
+[tsv-select] Error processing command line arguments: '--f|fields' and '--e|exclude' have overlapping fields.
+
+====[tsv-select -e 7,10 -f 1,3,8-14 input1.tsv]====
+[tsv-select] Error processing command line arguments: '--f|fields' and '--e|exclude' have overlapping fields.
+
+====[tsv-select -e 7,10 -f 1,3,8-14 input1.tsv]====
+[tsv-select] Error processing command line arguments: '--f|fields' and '--e|exclude' have overlapping fields.
+
+====[tsv-select -e 1-1000 -f 2000-1000 input1.tsv]====
+[tsv-select] Error processing command line arguments: '--f|fields' and '--e|exclude' have overlapping fields.
 
 ====[tsv-select -f 1 input1_dos.tsv]====
 Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').

--- a/tsv-select/tests/input_3plus_fields.tsv
+++ b/tsv-select/tests/input_3plus_fields.tsv
@@ -6,4 +6,12 @@
 6			e-e
 7	 	 	sp-sp	2020	2021
 8	empty-last	
-9	last-row	done
+9	next-line-6-empty				|
+					
+11		
+12	A	B	C	D
+13	AA	BB	CC	DD	EE
+14	ß	Ä	ä	Ö	ö
+15	ßß	ÄÄ	ää	ÖÖ	öö
+16	ßsß	ÄAÄ	äaä	ÖOÖ	öoö
+17	last-row	done

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -18,10 +18,6 @@ runtest () {
     return 0
 }
 
-## Note: input1.tsv has duplicate values in fields 2 & 3. Tests with those fields
-## as keys that have append values need to use --allow-duplicate-keys (unless
-## testing error handling).
-
 basic_tests_1=${odir}/basic_tests_1.txt
 
 echo "Basic tests set 1" > ${basic_tests_1}

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -65,10 +65,37 @@ runtest ${prog} "-f 4,3 -r last input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 3,1,4 -r last input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 4,3,2,1 -r last input1.tsv" ${basic_tests_1}
 
+# Exclusions - Individual fields and ranges
+runtest ${prog} "--exclude 1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 3 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1,2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2-1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2,3 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 4,3 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1,3-4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1-4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1-5 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 5-10 input1.tsv" ${basic_tests_1}
+
+# Exclusions - Combined with --fields and --rest
+runtest ${prog} "-e 1,2 --rest last input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1,2 --rest first input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1 -f 3 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1 -f 3 --rest last input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1 -f 3 --rest first input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2 -f 4,1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2 -f 4,1 --rest first input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2,3 -f 4,1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2,3 -f 4,1 --rest first input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2,3,5 -f 4,1 input1.tsv" ${basic_tests_1}
+
 # 1 field file
 runtest ${prog} "-f 1 input_1field.tsv" ${basic_tests_1}
 runtest ${prog} "-f 1 --rest first input_1field.tsv" ${basic_tests_1}
 runtest ${prog} "-f 1 --rest last input_1field.tsv" ${basic_tests_1}
+runtest ${prog} "--exclude 1 input_1field.tsv" ${basic_tests_1}
 
 # 2 field file
 runtest ${prog} "-f 1 input_2fields.tsv" ${basic_tests_1}
@@ -83,6 +110,9 @@ runtest ${prog} "-f 1,2 --rest last input_2fields.tsv" ${basic_tests_1}
 runtest ${prog} "-f 2,1 input_2fields.tsv" ${basic_tests_1}
 runtest ${prog} "-f 2,1 --rest first input_2fields.tsv" ${basic_tests_1}
 runtest ${prog} "-f 2,1 --rest last input_2fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1 input_2fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 2 input_2fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1-2 input_2fields.tsv" ${basic_tests_1}
 
 # 3+ field file
 runtest ${prog} "-f 1 input_3plus_fields.tsv" ${basic_tests_1}
@@ -94,6 +124,15 @@ runtest ${prog} "-f 3,1,2 --rest first input_3plus_fields.tsv" ${basic_tests_1}
 runtest ${prog} "-f 1 --rest last input_3plus_fields.tsv" ${basic_tests_1}
 runtest ${prog} "-f 1,3 --rest last input_3plus_fields.tsv" ${basic_tests_1}
 runtest ${prog} "-f 2,1,3 --rest last input_3plus_fields.tsv" ${basic_tests_1}
+
+runtest ${prog} "--exclude 1 input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 3 input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1-3 input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 4 input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 5 input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 4-10 input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1 -f 3 --rest last input_3plus_fields.tsv" ${basic_tests_1}
+runtest ${prog} "-e 1 -f 3 --rest first input_3plus_fields.tsv" ${basic_tests_1}
 
 # Alternate delimiter
 runtest ${prog} "-f 1 --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
@@ -109,6 +148,12 @@ runtest ${prog} "-f 2 -d ^ --rest last input_2plus_hat_delim.tsv" ${basic_tests_
 runtest ${prog} "-f 2,1 -d ^ --rest last input_2plus_hat_delim.tsv" ${basic_tests_1}
 runtest ${prog} "-f 1,2 -d ^ --rest last input_2plus_hat_delim.tsv" ${basic_tests_1}
 
+runtest ${prog} "--exclude 1 --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
+runtest ${prog} "--exclude 2 --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
+runtest ${prog} "--exclude 1-2 --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
+runtest ${prog} "--exclude 3-10 --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
+runtest ${prog} "--exclude 2 --fields 1 --rest first --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
+
 echo "" >> ${basic_tests_1}; echo "====Multi-file & stdin Tests===" >> ${basic_tests_1}
 runtest ${prog} "-f 2,1 input_3x2.tsv input_emptyfile.tsv input_3x1.tsv input_3x0.tsv input_3x3.tsv" ${basic_tests_1}
 
@@ -123,6 +168,10 @@ cat input_3x2.tsv | ${prog} -f 2,1 -- input_3x3.tsv - input_3x1.tsv >> ${basic_t
 runtest ${prog} "--header -f 1 input_header1.tsv" ${basic_tests_1}
 runtest ${prog} "-H -f 2 input_header1.tsv input_header2.tsv input_header3.tsv input_header4.tsv" ${basic_tests_1}
 runtest ${prog} "-H -f 1,2,3 input_header3.tsv input_header3.tsv input_header1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --exclude 1 input_header1.tsv" ${basic_tests_1}
+runtest ${prog} "-H -e 2 input_header1.tsv input_header2.tsv input_header3.tsv input_header4.tsv" ${basic_tests_1}
+runtest ${prog} "-H -e 1,2,3 input_header3.tsv input_header3.tsv input_header1.tsv" ${basic_tests_1}
 
 ## Help and Version printing
 
@@ -181,6 +230,14 @@ runtest ${prog} "-f 1,3- input1.tsv" ${error_tests_1}
 runtest ${prog} "-f input1.tsv" ${error_tests_1}
 runtest ${prog} "-f 1, input1.tsv" ${error_tests_1}
 runtest ${prog} "-f 1.1 input1.tsv" ${error_tests_1}
+
+runtest ${prog} "-e 0 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 1 -f 1 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 1-5 -f 3 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 7,10 -f 1,3,8-14 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 7,10 -f 1,3,8-14 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 1-1000 -f 2000-1000 input1.tsv" ${error_tests_1}
+
 
 # Windows line ending detection
 runtest ${prog} "-f 1 input1_dos.tsv" ${error_tests_1}


### PR DESCRIPTION
This PR adds a new feature to `tsv-select`, the ability to exclude fields. Fields to exclude are specified with the `--e|exclude` option. Some examples:
```
$   # Drop the first field, keep everything else.
$   # Equivalent to `cut -f 2- file.tsv`
$   tsv-select --exclude 1 file.tsv

$   # Drop fields 3-10, keep everything else
$   tsv-select --exclude 3-10 file.tsv

$   # Move field 2 to the start of the line, drop fields 10-15
$   tsv-select -f 2 -e 10-15 file.tsv

$   # Move field 2 to the end, dropping fields 10-15
$   tsv-select -f 2 -rest first -e 10-15 file.tsv
```

This PR also improves performance of the `--rest` operator. This is done by bulk appending fields from the last specified field until the end of the line. The difference is dramatic for data with many fields. These performance improvements apply to `--exclude` as well, as it uses the implementation of `--rest`. Ad hoc tests on OS X indicate meaningful improvement for operations like `tsv-select -f 1 --rest first` (move first field to end of line). And `tsv-select --exclude 1` is dramatically faster than `cut -f 2-` for files with a reasonable number of fields (tested on a 29 field file against GNU `cut` on OS X). 

Documentation for `tsv-select` was also improved.