### PR TITLE
tsv-select: Restrict max excluded field number.

### DIFF
--- a/tsv-select/tests/gold/basic_tests_1.txt
+++ b/tsv-select/tests/gold/basic_tests_1.txt
@@ -1010,6 +1010,39 @@ AA	CC	DD	EE	BB
 ßsß	äaä	ÖOÖ	öoö	ÄAÄ
 last-row	done
 
+====[tsv-select -e 1048576 input1.tsv]====
+f1	f2	f3	f4
+1	ggg	UUU	101
+	f1-empty	CCC	5734
+3	ßßß	SSS	 7
+4	sss	f4-empty	
+5	ÀBC		1367
+6			f23-empty
+7	 	 	f23-space
+8	0.0	Z	1931
+
+====[tsv-select -e 5-1048576 input1.tsv]====
+f1	f2	f3	f4
+1	ggg	UUU	101
+	f1-empty	CCC	5734
+3	ßßß	SSS	 7
+4	sss	f4-empty	
+5	ÀBC		1367
+6			f23-empty
+7	 	 	f23-space
+8	0.0	Z	1931
+
+====[tsv-select -e 4-1048576 input1.tsv]====
+f1	f2	f3
+1	ggg	UUU
+	f1-empty	CCC
+3	ßßß	SSS
+4	sss	f4-empty
+5	ÀBC	
+6		
+7	 	 
+8	0.0	Z
+
 ====[tsv-select -f 1 --delimiter ^  input_2plus_hat_delim.tsv]====
 f1
 abc

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -66,6 +66,18 @@ Error [tsv-select]: Not enough fields in line. File: input_3plus_fields.tsv,  Li
 ====[tsv-select -e 1-1000 -f 2000-1000 input1.tsv]====
 [tsv-select] Error processing command line arguments: '--f|fields' and '--e|exclude' have overlapping fields.
 
+====[tsv-select -e 1048577 input1.tsv]====
+[tsv-select] Error processing command line arguments: Maximum allowed '--e|exclude' field number is 1048576.
+
+====[tsv-select -e 1048578 input1.tsv]====
+[tsv-select] Error processing command line arguments: Maximum allowed '--e|exclude' field number is 1048576.
+
+====[tsv-select -e 4-1048577 input1.tsv]====
+[tsv-select] Error processing command line arguments: Maximum allowed '--e|exclude' field number is 1048576.
+
+====[tsv-select -e 4-1048578 input1.tsv]====
+[tsv-select] Error processing command line arguments: Maximum allowed '--e|exclude' field number is 1048576.
+
 ====[tsv-select -f 1 input1_dos.tsv]====
 Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -130,6 +130,10 @@ runtest ${prog} "-e 4-10 input_3plus_fields.tsv" ${basic_tests_1}
 runtest ${prog} "-e 1 -f 3 --rest last input_3plus_fields.tsv" ${basic_tests_1}
 runtest ${prog} "-e 1 -f 3 --rest first input_3plus_fields.tsv" ${basic_tests_1}
 
+runtest ${prog} "-e 1048576 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 5-1048576 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-e 4-1048576 input1.tsv" ${basic_tests_1}
+
 # Alternate delimiter
 runtest ${prog} "-f 1 --delimiter ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
 runtest ${prog} "-f 2 -d ^  input_2plus_hat_delim.tsv" ${basic_tests_1}
@@ -234,6 +238,10 @@ runtest ${prog} "-e 7,10 -f 1,3,8-14 input1.tsv" ${error_tests_1}
 runtest ${prog} "-e 7,10 -f 1,3,8-14 input1.tsv" ${error_tests_1}
 runtest ${prog} "-e 1-1000 -f 2000-1000 input1.tsv" ${error_tests_1}
 
+runtest ${prog} "-e 1048577 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 1048578 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 4-1048577 input1.tsv" ${error_tests_1}
+runtest ${prog} "-e 4-1048578 input1.tsv" ${error_tests_1}
 
 # Windows line ending detection
 runtest ${prog} "-f 1 input1_dos.tsv" ${error_tests_1}


### PR DESCRIPTION
An update the recently added `tsv-select --exclude` operation. The implementation allocates memory up to the maximum excluded field. Users have no way to know this, but might casually enter arbitrarily large numbers if they want to ensure trimming the all fields beyond a certain number.

This PR limits the max excluded field to 1048576 (more than 1 million fields). This is certainly a large number of fields for TSV files, and should ensure the common case works well. The limit can be increased if use-cases arise.