### PR TITLE
tsv-split: Default output file suffix to input file extension.

### DIFF
--- a/tsv-split/tests/gold/error_tests_1.txt
+++ b/tsv-split/tests/gold/error_tests_1.txt
@@ -75,28 +75,28 @@ Run 'ulimit -Sn NUM' to change the soft limit.
 
 ====[tsv-split -l 3 ../input1x5.txt]====
 ====[tsv-split -l 3 ../input1x5.txt]====
-Error [tsv-split]: Output file already exists. Use '--a|append' to append to existing files. File: 'part_0.tsv'.
-==> ./tsvsplit_workdir/part_0.tsv <==
+Error [tsv-split]: Output file already exists. Use '--a|append' to append to existing files. File: 'part_0.txt'.
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -v 15017 -n 3 ../input1x5.txt]====
 ====[tsv-split -v 15017 -n 3 ../input1x5.txt]====
-Error [tsv-split]: One or more output files already exist. Use '--a|append' to append to existing files. File: 'part_0.tsv'.
-==> ./tsvsplit_workdir/part_0.tsv <==
+Error [tsv-split]: One or more output files already exist. Use '--a|append' to append to existing files. File: 'part_0.txt'.
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 2
 
 ====[tsv-split -s -n 11 -k 3 ../input4x18.tsv]====

--- a/tsv-split/tests/gold/key_assignment_tests.txt
+++ b/tsv-split/tests/gold/key_assignment_tests.txt
@@ -3443,36 +3443,36 @@ blanc	2038	Голубь	0
 Grünspan	2071	Pipit de Godlewski	3
 
 ====[cat ../input4x58.tsv | tsv-split -s -n 101 -k 3]====
-==> ./tsvsplit_workdir/part_000.tsv <==
+==> ./tsvsplit_workdir/part_000 <==
 dorado	2045	Лебедь	2
 
-==> ./tsvsplit_workdir/part_004.tsv <==
+==> ./tsvsplit_workdir/part_004 <==
 Blutrot	2142	tüpfelsumpfhuhn	1
 Blutrot	2142	tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_005.tsv <==
+==> ./tsvsplit_workdir/part_005 <==
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 
-==> ./tsvsplit_workdir/part_011.tsv <==
+==> ./tsvsplit_workdir/part_011 <==
 púrpura	2088	Macuco	1
 púrpura	2119	Macuco	4
 
-==> ./tsvsplit_workdir/part_014.tsv <==
+==> ./tsvsplit_workdir/part_014 <==
 blutrot	2121	Воробей	4
 
-==> ./tsvsplit_workdir/part_016.tsv <==
+==> ./tsvsplit_workdir/part_016 <==
 Grünspan	2145	Pipit de Godlewski	4
 Grünspan	2082	Pipit de Godlewski	2
 Grünspan	2053	Pipit de Godlewski	4
 Grünspan	2071	Pipit de Godlewski	3
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028 <==
 rouge	2135	Marreca-cabocla	1
 café	2019	Marreca-cabocla	1
 rouge	2037	Marreca-cabocla	0
 
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032 <==
 blutrot	2142	Tüpfelsumpfhuhn	1
 blutrot	2118	Tüpfelsumpfhuhn	4
 blutrot	2117	Tüpfelsumpfhuhn	0
@@ -3480,19 +3480,19 @@ blutrot	2143	Tüpfelsumpfhuhn	4
 blutrot	2149	Tüpfelsumpfhuhn	1
 blutrot	2120	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_033.tsv <==
+==> ./tsvsplit_workdir/part_033 <==
 grünspan	2145	PIPIT DE GODLEWSKI	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 
-==> ./tsvsplit_workdir/part_035.tsv <==
+==> ./tsvsplit_workdir/part_035 <==
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
-==> ./tsvsplit_workdir/part_037.tsv <==
+==> ./tsvsplit_workdir/part_037 <==
 schneeweiß	2117	Porrón Islándico	4
 schneeweiß	2121	Porrón Islándico	1
 
-==> ./tsvsplit_workdir/part_051.tsv <==
+==> ./tsvsplit_workdir/part_051 <==
 zitronengelb	2136	Macreuse à bec jaune	3
 zitronengelb	2083	Macreuse à bec jaune	4
 púrpura	2070	Macreuse à bec jaune	2
@@ -3500,7 +3500,7 @@ púrpura	2092	Macreuse à bec jaune	4
 púrpura	2093	Macreuse à bec jaune	4
 púrpura	2145	Macreuse à bec jaune	2
 
-==> ./tsvsplit_workdir/part_055.tsv <==
+==> ./tsvsplit_workdir/part_055 <==
 Indigo	2056	Голубь	1
 Indigo	2141	Голубь	1
 blanc	2137	Голубь	2
@@ -3508,15 +3508,15 @@ blanc	2109	Голубь	3
 Indigo	2138	Голубь	4
 blanc	2038	Голубь	0
 
-==> ./tsvsplit_workdir/part_068.tsv <==
+==> ./tsvsplit_workdir/part_068 <==
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070 <==
 rouge	2132	Löffelente	4
 rouge	2146	Löffelente	1
 
-==> ./tsvsplit_workdir/part_072.tsv <==
+==> ./tsvsplit_workdir/part_072 <==
 marrón	2102	Weißwangengans	1
 noir	2082	Weißwangengans	1
 noir	2094	Weißwangengans	4
@@ -3524,59 +3524,59 @@ noir	2094	Weißwangengans	4
 noir	2115	Weißwangengans	2
 marrón	2034	Weißwangengans	1
 
-==> ./tsvsplit_workdir/part_080.tsv <==
+==> ./tsvsplit_workdir/part_080 <==
 Cerise	2076	Malvasía Cabeciblanca	4
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 Cerise	2119	Malvasía Cabeciblanca	4
 
-==> ./tsvsplit_workdir/part_087.tsv <==
+==> ./tsvsplit_workdir/part_087 <==
 café	2088	Purpurreiher	2
 Orange-red	2089	Purpurreiher	1
 café	2062	Purpurreiher	4
 café	2100	Purpurreiher	2
 café	2041	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_093.tsv <==
+==> ./tsvsplit_workdir/part_093 <==
 c-1	c-2	c-3	c-4
 
 ====[cat ../input4x58.tsv | tsv-split -s -n 101 -k 3 -H]====
-==> ./tsvsplit_workdir/part_000.tsv <==
+==> ./tsvsplit_workdir/part_000 <==
 c-1	c-2	c-3	c-4
 dorado	2045	Лебедь	2
 
-==> ./tsvsplit_workdir/part_004.tsv <==
+==> ./tsvsplit_workdir/part_004 <==
 c-1	c-2	c-3	c-4
 Blutrot	2142	tüpfelsumpfhuhn	1
 Blutrot	2142	tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_005.tsv <==
+==> ./tsvsplit_workdir/part_005 <==
 c-1	c-2	c-3	c-4
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 
-==> ./tsvsplit_workdir/part_011.tsv <==
+==> ./tsvsplit_workdir/part_011 <==
 c-1	c-2	c-3	c-4
 púrpura	2088	Macuco	1
 púrpura	2119	Macuco	4
 
-==> ./tsvsplit_workdir/part_014.tsv <==
+==> ./tsvsplit_workdir/part_014 <==
 c-1	c-2	c-3	c-4
 blutrot	2121	Воробей	4
 
-==> ./tsvsplit_workdir/part_016.tsv <==
+==> ./tsvsplit_workdir/part_016 <==
 c-1	c-2	c-3	c-4
 Grünspan	2145	Pipit de Godlewski	4
 Grünspan	2082	Pipit de Godlewski	2
 Grünspan	2053	Pipit de Godlewski	4
 Grünspan	2071	Pipit de Godlewski	3
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028 <==
 c-1	c-2	c-3	c-4
 rouge	2135	Marreca-cabocla	1
 café	2019	Marreca-cabocla	1
 rouge	2037	Marreca-cabocla	0
 
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032 <==
 c-1	c-2	c-3	c-4
 blutrot	2142	Tüpfelsumpfhuhn	1
 blutrot	2118	Tüpfelsumpfhuhn	4
@@ -3585,22 +3585,22 @@ blutrot	2143	Tüpfelsumpfhuhn	4
 blutrot	2149	Tüpfelsumpfhuhn	1
 blutrot	2120	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_033.tsv <==
+==> ./tsvsplit_workdir/part_033 <==
 c-1	c-2	c-3	c-4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 
-==> ./tsvsplit_workdir/part_035.tsv <==
+==> ./tsvsplit_workdir/part_035 <==
 c-1	c-2	c-3	c-4
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
-==> ./tsvsplit_workdir/part_037.tsv <==
+==> ./tsvsplit_workdir/part_037 <==
 c-1	c-2	c-3	c-4
 schneeweiß	2117	Porrón Islándico	4
 schneeweiß	2121	Porrón Islándico	1
 
-==> ./tsvsplit_workdir/part_051.tsv <==
+==> ./tsvsplit_workdir/part_051 <==
 c-1	c-2	c-3	c-4
 zitronengelb	2136	Macreuse à bec jaune	3
 zitronengelb	2083	Macreuse à bec jaune	4
@@ -3609,7 +3609,7 @@ púrpura	2092	Macreuse à bec jaune	4
 púrpura	2093	Macreuse à bec jaune	4
 púrpura	2145	Macreuse à bec jaune	2
 
-==> ./tsvsplit_workdir/part_055.tsv <==
+==> ./tsvsplit_workdir/part_055 <==
 c-1	c-2	c-3	c-4
 Indigo	2056	Голубь	1
 Indigo	2141	Голубь	1
@@ -3618,17 +3618,17 @@ blanc	2109	Голубь	3
 Indigo	2138	Голубь	4
 blanc	2038	Голубь	0
 
-==> ./tsvsplit_workdir/part_068.tsv <==
+==> ./tsvsplit_workdir/part_068 <==
 c-1	c-2	c-3	c-4
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070 <==
 c-1	c-2	c-3	c-4
 rouge	2132	Löffelente	4
 rouge	2146	Löffelente	1
 
-==> ./tsvsplit_workdir/part_072.tsv <==
+==> ./tsvsplit_workdir/part_072 <==
 c-1	c-2	c-3	c-4
 marrón	2102	Weißwangengans	1
 noir	2082	Weißwangengans	1
@@ -3637,13 +3637,13 @@ noir	2094	Weißwangengans	4
 noir	2115	Weißwangengans	2
 marrón	2034	Weißwangengans	1
 
-==> ./tsvsplit_workdir/part_080.tsv <==
+==> ./tsvsplit_workdir/part_080 <==
 c-1	c-2	c-3	c-4
 Cerise	2076	Malvasía Cabeciblanca	4
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 Cerise	2119	Malvasía Cabeciblanca	4
 
-==> ./tsvsplit_workdir/part_087.tsv <==
+==> ./tsvsplit_workdir/part_087 <==
 c-1	c-2	c-3	c-4
 café	2088	Purpurreiher	2
 Orange-red	2089	Purpurreiher	1
@@ -3652,36 +3652,36 @@ café	2100	Purpurreiher	2
 café	2041	Purpurreiher	4
 
 ====[cat ../input4x58.tsv | tsv-split -s -n 101 -k 3 -I]====
-==> ./tsvsplit_workdir/part_000.tsv <==
+==> ./tsvsplit_workdir/part_000 <==
 dorado	2045	Лебедь	2
 
-==> ./tsvsplit_workdir/part_004.tsv <==
+==> ./tsvsplit_workdir/part_004 <==
 Blutrot	2142	tüpfelsumpfhuhn	1
 Blutrot	2142	tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_005.tsv <==
+==> ./tsvsplit_workdir/part_005 <==
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 
-==> ./tsvsplit_workdir/part_011.tsv <==
+==> ./tsvsplit_workdir/part_011 <==
 púrpura	2088	Macuco	1
 púrpura	2119	Macuco	4
 
-==> ./tsvsplit_workdir/part_014.tsv <==
+==> ./tsvsplit_workdir/part_014 <==
 blutrot	2121	Воробей	4
 
-==> ./tsvsplit_workdir/part_016.tsv <==
+==> ./tsvsplit_workdir/part_016 <==
 Grünspan	2145	Pipit de Godlewski	4
 Grünspan	2082	Pipit de Godlewski	2
 Grünspan	2053	Pipit de Godlewski	4
 Grünspan	2071	Pipit de Godlewski	3
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028 <==
 rouge	2135	Marreca-cabocla	1
 café	2019	Marreca-cabocla	1
 rouge	2037	Marreca-cabocla	0
 
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032 <==
 blutrot	2142	Tüpfelsumpfhuhn	1
 blutrot	2118	Tüpfelsumpfhuhn	4
 blutrot	2117	Tüpfelsumpfhuhn	0
@@ -3689,19 +3689,19 @@ blutrot	2143	Tüpfelsumpfhuhn	4
 blutrot	2149	Tüpfelsumpfhuhn	1
 blutrot	2120	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_033.tsv <==
+==> ./tsvsplit_workdir/part_033 <==
 grünspan	2145	PIPIT DE GODLEWSKI	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 
-==> ./tsvsplit_workdir/part_035.tsv <==
+==> ./tsvsplit_workdir/part_035 <==
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
-==> ./tsvsplit_workdir/part_037.tsv <==
+==> ./tsvsplit_workdir/part_037 <==
 schneeweiß	2117	Porrón Islándico	4
 schneeweiß	2121	Porrón Islándico	1
 
-==> ./tsvsplit_workdir/part_051.tsv <==
+==> ./tsvsplit_workdir/part_051 <==
 zitronengelb	2136	Macreuse à bec jaune	3
 zitronengelb	2083	Macreuse à bec jaune	4
 púrpura	2070	Macreuse à bec jaune	2
@@ -3709,7 +3709,7 @@ púrpura	2092	Macreuse à bec jaune	4
 púrpura	2093	Macreuse à bec jaune	4
 púrpura	2145	Macreuse à bec jaune	2
 
-==> ./tsvsplit_workdir/part_055.tsv <==
+==> ./tsvsplit_workdir/part_055 <==
 Indigo	2056	Голубь	1
 Indigo	2141	Голубь	1
 blanc	2137	Голубь	2
@@ -3717,15 +3717,15 @@ blanc	2109	Голубь	3
 Indigo	2138	Голубь	4
 blanc	2038	Голубь	0
 
-==> ./tsvsplit_workdir/part_068.tsv <==
+==> ./tsvsplit_workdir/part_068 <==
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070 <==
 rouge	2132	Löffelente	4
 rouge	2146	Löffelente	1
 
-==> ./tsvsplit_workdir/part_072.tsv <==
+==> ./tsvsplit_workdir/part_072 <==
 marrón	2102	Weißwangengans	1
 noir	2082	Weißwangengans	1
 noir	2094	Weißwangengans	4
@@ -3733,12 +3733,12 @@ noir	2094	Weißwangengans	4
 noir	2115	Weißwangengans	2
 marrón	2034	Weißwangengans	1
 
-==> ./tsvsplit_workdir/part_080.tsv <==
+==> ./tsvsplit_workdir/part_080 <==
 Cerise	2076	Malvasía Cabeciblanca	4
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 Cerise	2119	Malvasía Cabeciblanca	4
 
-==> ./tsvsplit_workdir/part_087.tsv <==
+==> ./tsvsplit_workdir/part_087 <==
 café	2088	Purpurreiher	2
 Orange-red	2089	Purpurreiher	1
 café	2062	Purpurreiher	4
@@ -3746,117 +3746,117 @@ café	2100	Purpurreiher	2
 café	2041	Purpurreiher	4
 
 ====[cat ../input4x58.tsv | tsv-split -v 15017 -n 101 -k 1,3 -- - ../input4x18.tsv]====
-==> ./tsvsplit_workdir/part_000.tsv <==
+==> ./tsvsplit_workdir/part_000 <==
 café	2088	Purpurreiher	2
 café	2062	Purpurreiher	4
 café	2100	Purpurreiher	2
 café	2041	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_001.tsv <==
+==> ./tsvsplit_workdir/part_001 <==
 Indigo	2056	Голубь	1
 Indigo	2141	Голубь	1
 Indigo	2138	Голубь	4
 
-==> ./tsvsplit_workdir/part_003.tsv <==
+==> ./tsvsplit_workdir/part_003 <==
 dorado	2045	Лебедь	2
 
-==> ./tsvsplit_workdir/part_008.tsv <==
+==> ./tsvsplit_workdir/part_008 <==
 rouge	2135	Marreca-cabocla	1
 rouge	2037	Marreca-cabocla	0
 
-==> ./tsvsplit_workdir/part_009.tsv <==
+==> ./tsvsplit_workdir/part_009 <==
 türkis	2097	Голубь	2
 
-==> ./tsvsplit_workdir/part_010.tsv <==
+==> ./tsvsplit_workdir/part_010 <==
 blutrot	2093	Araqua-pintado	2
 
-==> ./tsvsplit_workdir/part_011.tsv <==
+==> ./tsvsplit_workdir/part_011 <==
 púrpura	2088	Macuco	1
 púrpura	2119	Macuco	4
 
-==> ./tsvsplit_workdir/part_015.tsv <==
+==> ./tsvsplit_workdir/part_015 <==
 c-1	c-2	c-3	c-4
 c-1	c-2	c-3	c-4
 
-==> ./tsvsplit_workdir/part_023.tsv <==
+==> ./tsvsplit_workdir/part_023 <==
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 blutrot	2121	Воробей	4
 
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027 <==
 marrón	2121	Marreca-cabocla	2
 
-==> ./tsvsplit_workdir/part_034.tsv <==
+==> ./tsvsplit_workdir/part_034 <==
 café	2019	Marreca-cabocla	1
 
-==> ./tsvsplit_workdir/part_037.tsv <==
+==> ./tsvsplit_workdir/part_037 <==
 blanc	2137	Голубь	2
 blanc	2109	Голубь	3
 blanc	2038	Голубь	0
 
-==> ./tsvsplit_workdir/part_040.tsv <==
+==> ./tsvsplit_workdir/part_040 <==
 ébène	2142	Орёл	2
 
-==> ./tsvsplit_workdir/part_041.tsv <==
+==> ./tsvsplit_workdir/part_041 <==
 schneeweiß	2117	Porrón Islándico	4
 schneeweiß	2121	Porrón Islándico	1
 jaune	2104	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_042.tsv <==
+==> ./tsvsplit_workdir/part_042 <==
 rouge	2132	Löffelente	4
 rouge	2146	Löffelente	1
 
-==> ./tsvsplit_workdir/part_048.tsv <==
+==> ./tsvsplit_workdir/part_048 <==
 noir	2082	Weißwangengans	1
 noir	2094	Weißwangengans	4
 noir	2115	Weißwangengans	2
 
-==> ./tsvsplit_workdir/part_049.tsv <==
+==> ./tsvsplit_workdir/part_049 <==
 Grünspan	2105	Macuco	0
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050 <==
 dorado	2147	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_055.tsv <==
+==> ./tsvsplit_workdir/part_055 <==
 Grünspan	2100	Purpurreiher	1
 
-==> ./tsvsplit_workdir/part_058.tsv <==
+==> ./tsvsplit_workdir/part_058 <==
 Grünspan	2145	Pipit de Godlewski	4
 Grünspan	2082	Pipit de Godlewski	2
 Grünspan	2053	Pipit de Godlewski	4
 Grünspan	2071	Pipit de Godlewski	3
 
-==> ./tsvsplit_workdir/part_059.tsv <==
+==> ./tsvsplit_workdir/part_059 <==
 Orange-red	2089	Purpurreiher	1
 
-==> ./tsvsplit_workdir/part_062.tsv <==
+==> ./tsvsplit_workdir/part_062 <==
 zitronengelb	2136	Macreuse à bec jaune	3
 zitronengelb	2083	Macreuse à bec jaune	4
 
-==> ./tsvsplit_workdir/part_065.tsv <==
+==> ./tsvsplit_workdir/part_065 <==
 красный	2049	Weißwangengans	3
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069 <==
 Blutrot	2142	tüpfelsumpfhuhn	1
 Blutrot	2142	tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070 <==
 marrón	2102	Weißwangengans	1
 marrón	2034	Weißwangengans	1
 
-==> ./tsvsplit_workdir/part_077.tsv <==
+==> ./tsvsplit_workdir/part_077 <==
 rouge	2058	Pipit de Godlewski	4
 
-==> ./tsvsplit_workdir/part_080.tsv <==
+==> ./tsvsplit_workdir/part_080 <==
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082 <==
 púrpura	2070	Macreuse à bec jaune	2
 púrpura	2092	Macreuse à bec jaune	4
 púrpura	2093	Macreuse à bec jaune	4
 púrpura	2145	Macreuse à bec jaune	2
 
-==> ./tsvsplit_workdir/part_085.tsv <==
+==> ./tsvsplit_workdir/part_085 <==
 blutrot	2142	Tüpfelsumpfhuhn	1
 blutrot	2118	Tüpfelsumpfhuhn	4
 blutrot	2117	Tüpfelsumpfhuhn	0
@@ -3865,166 +3865,166 @@ blutrot	2149	Tüpfelsumpfhuhn	1
 blutrot	2120	Tüpfelsumpfhuhn	1
 jaune	2090	Weißwangengans	4
 
-==> ./tsvsplit_workdir/part_086.tsv <==
+==> ./tsvsplit_workdir/part_086 <==
 pechschwarz	2079	Araqua-pintado	1
 
-==> ./tsvsplit_workdir/part_090.tsv <==
+==> ./tsvsplit_workdir/part_090 <==
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 blutrot	2137	Marreca-cabocla	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 
-==> ./tsvsplit_workdir/part_092.tsv <==
+==> ./tsvsplit_workdir/part_092 <==
 Cerise	2076	Malvasía Cabeciblanca	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 Cerise	2119	Malvasía Cabeciblanca	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 fumée	2129	Löffelente	0
 
-==> ./tsvsplit_workdir/part_096.tsv <==
+==> ./tsvsplit_workdir/part_096 <==
 jaune	2058	Purpurreiher	2
 jaune	2097	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_098.tsv <==
+==> ./tsvsplit_workdir/part_098 <==
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 
 ====[cat ../input4x58.tsv | tsv-split -v 15017 -n 101 -k 1,3 -H -- - ../input4x18.tsv]====
-==> ./tsvsplit_workdir/part_000.tsv <==
+==> ./tsvsplit_workdir/part_000 <==
 c-1	c-2	c-3	c-4
 café	2088	Purpurreiher	2
 café	2062	Purpurreiher	4
 café	2100	Purpurreiher	2
 café	2041	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_001.tsv <==
+==> ./tsvsplit_workdir/part_001 <==
 c-1	c-2	c-3	c-4
 Indigo	2056	Голубь	1
 Indigo	2141	Голубь	1
 Indigo	2138	Голубь	4
 
-==> ./tsvsplit_workdir/part_003.tsv <==
+==> ./tsvsplit_workdir/part_003 <==
 c-1	c-2	c-3	c-4
 dorado	2045	Лебедь	2
 
-==> ./tsvsplit_workdir/part_008.tsv <==
+==> ./tsvsplit_workdir/part_008 <==
 c-1	c-2	c-3	c-4
 rouge	2135	Marreca-cabocla	1
 rouge	2037	Marreca-cabocla	0
 
-==> ./tsvsplit_workdir/part_009.tsv <==
+==> ./tsvsplit_workdir/part_009 <==
 c-1	c-2	c-3	c-4
 türkis	2097	Голубь	2
 
-==> ./tsvsplit_workdir/part_010.tsv <==
+==> ./tsvsplit_workdir/part_010 <==
 c-1	c-2	c-3	c-4
 blutrot	2093	Araqua-pintado	2
 
-==> ./tsvsplit_workdir/part_011.tsv <==
+==> ./tsvsplit_workdir/part_011 <==
 c-1	c-2	c-3	c-4
 púrpura	2088	Macuco	1
 púrpura	2119	Macuco	4
 
-==> ./tsvsplit_workdir/part_023.tsv <==
+==> ./tsvsplit_workdir/part_023 <==
 c-1	c-2	c-3	c-4
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 blutrot	2121	Воробей	4
 
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027 <==
 c-1	c-2	c-3	c-4
 marrón	2121	Marreca-cabocla	2
 
-==> ./tsvsplit_workdir/part_034.tsv <==
+==> ./tsvsplit_workdir/part_034 <==
 c-1	c-2	c-3	c-4
 café	2019	Marreca-cabocla	1
 
-==> ./tsvsplit_workdir/part_037.tsv <==
+==> ./tsvsplit_workdir/part_037 <==
 c-1	c-2	c-3	c-4
 blanc	2137	Голубь	2
 blanc	2109	Голубь	3
 blanc	2038	Голубь	0
 
-==> ./tsvsplit_workdir/part_040.tsv <==
+==> ./tsvsplit_workdir/part_040 <==
 c-1	c-2	c-3	c-4
 ébène	2142	Орёл	2
 
-==> ./tsvsplit_workdir/part_041.tsv <==
+==> ./tsvsplit_workdir/part_041 <==
 c-1	c-2	c-3	c-4
 schneeweiß	2117	Porrón Islándico	4
 schneeweiß	2121	Porrón Islándico	1
 jaune	2104	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_042.tsv <==
+==> ./tsvsplit_workdir/part_042 <==
 c-1	c-2	c-3	c-4
 rouge	2132	Löffelente	4
 rouge	2146	Löffelente	1
 
-==> ./tsvsplit_workdir/part_048.tsv <==
+==> ./tsvsplit_workdir/part_048 <==
 c-1	c-2	c-3	c-4
 noir	2082	Weißwangengans	1
 noir	2094	Weißwangengans	4
 noir	2115	Weißwangengans	2
 
-==> ./tsvsplit_workdir/part_049.tsv <==
+==> ./tsvsplit_workdir/part_049 <==
 c-1	c-2	c-3	c-4
 Grünspan	2105	Macuco	0
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050 <==
 c-1	c-2	c-3	c-4
 dorado	2147	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_055.tsv <==
+==> ./tsvsplit_workdir/part_055 <==
 c-1	c-2	c-3	c-4
 Grünspan	2100	Purpurreiher	1
 
-==> ./tsvsplit_workdir/part_058.tsv <==
+==> ./tsvsplit_workdir/part_058 <==
 c-1	c-2	c-3	c-4
 Grünspan	2145	Pipit de Godlewski	4
 Grünspan	2082	Pipit de Godlewski	2
 Grünspan	2053	Pipit de Godlewski	4
 Grünspan	2071	Pipit de Godlewski	3
 
-==> ./tsvsplit_workdir/part_059.tsv <==
+==> ./tsvsplit_workdir/part_059 <==
 c-1	c-2	c-3	c-4
 Orange-red	2089	Purpurreiher	1
 
-==> ./tsvsplit_workdir/part_062.tsv <==
+==> ./tsvsplit_workdir/part_062 <==
 c-1	c-2	c-3	c-4
 zitronengelb	2136	Macreuse à bec jaune	3
 zitronengelb	2083	Macreuse à bec jaune	4
 
-==> ./tsvsplit_workdir/part_065.tsv <==
+==> ./tsvsplit_workdir/part_065 <==
 c-1	c-2	c-3	c-4
 красный	2049	Weißwangengans	3
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069 <==
 c-1	c-2	c-3	c-4
 Blutrot	2142	tüpfelsumpfhuhn	1
 Blutrot	2142	tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070 <==
 c-1	c-2	c-3	c-4
 marrón	2102	Weißwangengans	1
 marrón	2034	Weißwangengans	1
 
-==> ./tsvsplit_workdir/part_077.tsv <==
+==> ./tsvsplit_workdir/part_077 <==
 c-1	c-2	c-3	c-4
 rouge	2058	Pipit de Godlewski	4
 
-==> ./tsvsplit_workdir/part_080.tsv <==
+==> ./tsvsplit_workdir/part_080 <==
 c-1	c-2	c-3	c-4
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082 <==
 c-1	c-2	c-3	c-4
 púrpura	2070	Macreuse à bec jaune	2
 púrpura	2092	Macreuse à bec jaune	4
 púrpura	2093	Macreuse à bec jaune	4
 púrpura	2145	Macreuse à bec jaune	2
 
-==> ./tsvsplit_workdir/part_085.tsv <==
+==> ./tsvsplit_workdir/part_085 <==
 c-1	c-2	c-3	c-4
 blutrot	2142	Tüpfelsumpfhuhn	1
 blutrot	2118	Tüpfelsumpfhuhn	4
@@ -4034,18 +4034,18 @@ blutrot	2149	Tüpfelsumpfhuhn	1
 blutrot	2120	Tüpfelsumpfhuhn	1
 jaune	2090	Weißwangengans	4
 
-==> ./tsvsplit_workdir/part_086.tsv <==
+==> ./tsvsplit_workdir/part_086 <==
 c-1	c-2	c-3	c-4
 pechschwarz	2079	Araqua-pintado	1
 
-==> ./tsvsplit_workdir/part_090.tsv <==
+==> ./tsvsplit_workdir/part_090 <==
 c-1	c-2	c-3	c-4
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 blutrot	2137	Marreca-cabocla	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 
-==> ./tsvsplit_workdir/part_092.tsv <==
+==> ./tsvsplit_workdir/part_092 <==
 c-1	c-2	c-3	c-4
 Cerise	2076	Malvasía Cabeciblanca	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
@@ -4053,125 +4053,125 @@ Cerise	2119	Malvasía Cabeciblanca	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 fumée	2129	Löffelente	0
 
-==> ./tsvsplit_workdir/part_096.tsv <==
+==> ./tsvsplit_workdir/part_096 <==
 c-1	c-2	c-3	c-4
 jaune	2058	Purpurreiher	2
 jaune	2097	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_098.tsv <==
+==> ./tsvsplit_workdir/part_098 <==
 c-1	c-2	c-3	c-4
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 
 ====[cat ../input4x58.tsv | tsv-split -v 15017 -n 101 -k 1,3 -I -- - ../input4x18.tsv]====
-==> ./tsvsplit_workdir/part_000.tsv <==
+==> ./tsvsplit_workdir/part_000 <==
 café	2088	Purpurreiher	2
 café	2062	Purpurreiher	4
 café	2100	Purpurreiher	2
 café	2041	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_001.tsv <==
+==> ./tsvsplit_workdir/part_001 <==
 Indigo	2056	Голубь	1
 Indigo	2141	Голубь	1
 Indigo	2138	Голубь	4
 
-==> ./tsvsplit_workdir/part_003.tsv <==
+==> ./tsvsplit_workdir/part_003 <==
 dorado	2045	Лебедь	2
 
-==> ./tsvsplit_workdir/part_008.tsv <==
+==> ./tsvsplit_workdir/part_008 <==
 rouge	2135	Marreca-cabocla	1
 rouge	2037	Marreca-cabocla	0
 
-==> ./tsvsplit_workdir/part_009.tsv <==
+==> ./tsvsplit_workdir/part_009 <==
 türkis	2097	Голубь	2
 
-==> ./tsvsplit_workdir/part_010.tsv <==
+==> ./tsvsplit_workdir/part_010 <==
 blutrot	2093	Araqua-pintado	2
 
-==> ./tsvsplit_workdir/part_011.tsv <==
+==> ./tsvsplit_workdir/part_011 <==
 púrpura	2088	Macuco	1
 púrpura	2119	Macuco	4
 
-==> ./tsvsplit_workdir/part_023.tsv <==
+==> ./tsvsplit_workdir/part_023 <==
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 blutrot	2121	Воробей	4
 
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027 <==
 marrón	2121	Marreca-cabocla	2
 
-==> ./tsvsplit_workdir/part_034.tsv <==
+==> ./tsvsplit_workdir/part_034 <==
 café	2019	Marreca-cabocla	1
 
-==> ./tsvsplit_workdir/part_037.tsv <==
+==> ./tsvsplit_workdir/part_037 <==
 blanc	2137	Голубь	2
 blanc	2109	Голубь	3
 blanc	2038	Голубь	0
 
-==> ./tsvsplit_workdir/part_040.tsv <==
+==> ./tsvsplit_workdir/part_040 <==
 ébène	2142	Орёл	2
 
-==> ./tsvsplit_workdir/part_041.tsv <==
+==> ./tsvsplit_workdir/part_041 <==
 schneeweiß	2117	Porrón Islándico	4
 schneeweiß	2121	Porrón Islándico	1
 jaune	2104	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_042.tsv <==
+==> ./tsvsplit_workdir/part_042 <==
 rouge	2132	Löffelente	4
 rouge	2146	Löffelente	1
 
-==> ./tsvsplit_workdir/part_048.tsv <==
+==> ./tsvsplit_workdir/part_048 <==
 noir	2082	Weißwangengans	1
 noir	2094	Weißwangengans	4
 noir	2115	Weißwangengans	2
 
-==> ./tsvsplit_workdir/part_049.tsv <==
+==> ./tsvsplit_workdir/part_049 <==
 Grünspan	2105	Macuco	0
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050 <==
 dorado	2147	Tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_055.tsv <==
+==> ./tsvsplit_workdir/part_055 <==
 Grünspan	2100	Purpurreiher	1
 
-==> ./tsvsplit_workdir/part_058.tsv <==
+==> ./tsvsplit_workdir/part_058 <==
 Grünspan	2145	Pipit de Godlewski	4
 Grünspan	2082	Pipit de Godlewski	2
 Grünspan	2053	Pipit de Godlewski	4
 Grünspan	2071	Pipit de Godlewski	3
 
-==> ./tsvsplit_workdir/part_059.tsv <==
+==> ./tsvsplit_workdir/part_059 <==
 Orange-red	2089	Purpurreiher	1
 
-==> ./tsvsplit_workdir/part_062.tsv <==
+==> ./tsvsplit_workdir/part_062 <==
 zitronengelb	2136	Macreuse à bec jaune	3
 zitronengelb	2083	Macreuse à bec jaune	4
 
-==> ./tsvsplit_workdir/part_065.tsv <==
+==> ./tsvsplit_workdir/part_065 <==
 красный	2049	Weißwangengans	3
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069 <==
 Blutrot	2142	tüpfelsumpfhuhn	1
 Blutrot	2142	tüpfelsumpfhuhn	1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070 <==
 marrón	2102	Weißwangengans	1
 marrón	2034	Weißwangengans	1
 
-==> ./tsvsplit_workdir/part_077.tsv <==
+==> ./tsvsplit_workdir/part_077 <==
 rouge	2058	Pipit de Godlewski	4
 
-==> ./tsvsplit_workdir/part_080.tsv <==
+==> ./tsvsplit_workdir/part_080 <==
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082 <==
 púrpura	2070	Macreuse à bec jaune	2
 púrpura	2092	Macreuse à bec jaune	4
 púrpura	2093	Macreuse à bec jaune	4
 púrpura	2145	Macreuse à bec jaune	2
 
-==> ./tsvsplit_workdir/part_085.tsv <==
+==> ./tsvsplit_workdir/part_085 <==
 blutrot	2142	Tüpfelsumpfhuhn	1
 blutrot	2118	Tüpfelsumpfhuhn	4
 blutrot	2117	Tüpfelsumpfhuhn	0
@@ -4180,27 +4180,27 @@ blutrot	2149	Tüpfelsumpfhuhn	1
 blutrot	2120	Tüpfelsumpfhuhn	1
 jaune	2090	Weißwangengans	4
 
-==> ./tsvsplit_workdir/part_086.tsv <==
+==> ./tsvsplit_workdir/part_086 <==
 pechschwarz	2079	Araqua-pintado	1
 
-==> ./tsvsplit_workdir/part_090.tsv <==
+==> ./tsvsplit_workdir/part_090 <==
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 blutrot	2137	Marreca-cabocla	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 
-==> ./tsvsplit_workdir/part_092.tsv <==
+==> ./tsvsplit_workdir/part_092 <==
 Cerise	2076	Malvasía Cabeciblanca	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 Cerise	2119	Malvasía Cabeciblanca	4
 grünspan	2145	PIPIT DE GODLEWSKI	4
 fumée	2129	Löffelente	0
 
-==> ./tsvsplit_workdir/part_096.tsv <==
+==> ./tsvsplit_workdir/part_096 <==
 jaune	2058	Purpurreiher	2
 jaune	2097	Purpurreiher	4
 
-==> ./tsvsplit_workdir/part_098.tsv <==
+==> ./tsvsplit_workdir/part_098 <==
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4
 GRÜNSPAN	2145	pipit de godlewski	4

--- a/tsv-split/tests/gold/lines_per_file_tests.txt
+++ b/tsv-split/tests/gold/lines_per_file_tests.txt
@@ -2,51 +2,51 @@ Lines per file tests
 -----------------
 
 ====[tsv-split --lines-per-file 1 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_4.tsv <==
+==> ./tsvsplit_workdir/part_4.txt <==
 input1x5.txt: line 5
 
 ====[tsv-split --lines-per-file 2 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 5
 
 ====[tsv-split -l 3 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 4 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 5
 
 ====[tsv-split -l 5 ../input1x5.txt]====
@@ -64,41 +64,41 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split --lines-per-file 1 --header ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
 ====[tsv-split --lines-per-file 2 -H ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 3 -H ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
@@ -124,34 +124,34 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 1 --header-in-only ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x5.txt: line 5
 
 ====[tsv-split -l 2 -I ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 3 -I ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 5
 
 ====[tsv-split -l 4 -I ../input1x5.txt]====
@@ -173,49 +173,49 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 1 ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_4.tsv <==
+==> ./tsvsplit_workdir/part_4.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_5.tsv <==
+==> ./tsvsplit_workdir/part_5.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_6.tsv <==
+==> ./tsvsplit_workdir/part_6.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_7.tsv <==
+==> ./tsvsplit_workdir/part_7.txt <==
 input1x3.txt: line 3
 
 ====[tsv-split -l 2 ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 5
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 7 ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -224,7 +224,7 @@ input1x5.txt: line 5
 input1x3.txt: line 1
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 3
 
 ====[tsv-split -l 8 ../input1x5.txt ../input1x3.txt]====
@@ -238,42 +238,42 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 1 -H ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_4.tsv <==
+==> ./tsvsplit_workdir/part_4.txt <==
 input1x5.txt: line 1
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_5.tsv <==
+==> ./tsvsplit_workdir/part_5.txt <==
 input1x5.txt: line 1
 input1x3.txt: line 3
 
 ====[tsv-split -l 2 -H ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 1
 input1x3.txt: line 2
 input1x3.txt: line 3
@@ -297,34 +297,34 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 1 -I ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_3.tsv <==
+==> ./tsvsplit_workdir/part_3.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_4.tsv <==
+==> ./tsvsplit_workdir/part_4.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_5.tsv <==
+==> ./tsvsplit_workdir/part_5.txt <==
 input1x3.txt: line 3
 
 ====[tsv-split -l 2 -I ../input1x5.txt ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x3.txt: line 2
 input1x3.txt: line 3
 
@@ -365,22 +365,22 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 3 --prefix pre ../input1x5.txt]====
-==> ./tsvsplit_workdir/pre0.tsv <==
+==> ./tsvsplit_workdir/pre0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/pre1.tsv <==
+==> ./tsvsplit_workdir/pre1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 3 --dir odir ../input1x5.txt]====
-==> ./tsvsplit_workdir/odir/part_0.tsv <==
+==> ./tsvsplit_workdir/odir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/odir/part_1.tsv <==
+==> ./tsvsplit_workdir/odir/part_1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
@@ -396,7 +396,7 @@ input1x5.txt: line 5
 
 ====[tsv-split -l 3 --append ../input1x5.txt]====
 ====[tsv-split -l 3 --append ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -404,7 +404,7 @@ input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 input1x5.txt: line 4
@@ -413,7 +413,7 @@ input1x5.txt: line 5
 ====[tsv-split -H -l 3 -a ../input1x5.txt]====
 ====[tsv-split -H -l 3 -a ../input1x5.txt]====
 ====[tsv-split -H -l 3 -a ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -424,7 +424,7 @@ input1x5.txt: line 4
 input1x3.txt: line 2
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 input1x5.txt: line 5
@@ -432,7 +432,7 @@ input1x5.txt: line 5
 ====[tsv-split -I -l 3 --append ../input1x5.txt]====
 ====[tsv-split -I -l 3 --append ../input1x5.txt]====
 ====[tsv-split -I -l 3 --append ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
@@ -442,75 +442,75 @@ input1x5.txt: line 4
 input1x3.txt: line 2
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 5
 input1x5.txt: line 5
 
 ====[cat ../input1x5.txt | tsv-split -l 3]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0 <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1 <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[cat ../input1x5.txt | tsv-split -H -l 3]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0 <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1 <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
 ====[cat ../input1x5.txt | tsv-split -I -l 3]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0 <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1 <==
 input1x5.txt: line 5
 
 ====[cat ../input1x5.txt | tsv-split -l 3 -- - ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0 <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1 <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2 <==
 input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[cat ../input1x5.txt | tsv-split -H -l 3 -- - ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0 <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1 <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[cat ../input1x5.txt | tsv-split -I -l 3 -- - ../input1x3.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0 <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1 <==
 input1x5.txt: line 5
 input1x3.txt: line 2
 input1x3.txt: line 3

--- a/tsv-split/tests/gold/random_assignment_tests.txt
+++ b/tsv-split/tests/gold/random_assignment_tests.txt
@@ -2,88 +2,88 @@ Random assignment tests
 -----------------------
 
 ====[tsv-split --static-seed --num-files 2 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -s -n 3 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
 ====[tsv-split -s -n 5 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_4.tsv <==
+==> ./tsvsplit_workdir/part_4.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 4
 
 ====[tsv-split -s -n 10 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_9.tsv <==
+==> ./tsvsplit_workdir/part_9.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 4
 
 ====[tsv-split -s -n 11 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_02.tsv <==
+==> ./tsvsplit_workdir/part_02.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_03.tsv <==
+==> ./tsvsplit_workdir/part_03.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_05.tsv <==
+==> ./tsvsplit_workdir/part_05.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_07.tsv <==
+==> ./tsvsplit_workdir/part_07.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_09.tsv <==
+==> ./tsvsplit_workdir/part_09.txt <==
 input1x5.txt: line 4
 
 ====[tsv-split -s -n 101 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_057.tsv <==
+==> ./tsvsplit_workdir/part_057.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_073.tsv <==
+==> ./tsvsplit_workdir/part_073.txt <==
 input1x5.txt: line 3
 
 ====[tsv-split -s --num-files 2 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 2
 input1x3.txt: line 3
 input1x5.txt: line 1
@@ -91,163 +91,163 @@ input1x5.txt: line 2
 input1x5.txt: line 3
 
 ====[tsv-split -s -n 11 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_00.tsv <==
+==> ./tsvsplit_workdir/part_00.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_02.tsv <==
+==> ./tsvsplit_workdir/part_02.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_03.tsv <==
+==> ./tsvsplit_workdir/part_03.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_05.tsv <==
+==> ./tsvsplit_workdir/part_05.txt <==
 input1x3.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_07.tsv <==
+==> ./tsvsplit_workdir/part_07.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_09.tsv <==
+==> ./tsvsplit_workdir/part_09.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 
 ====[tsv-split -s -n 101 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_041.tsv <==
+==> ./tsvsplit_workdir/part_041.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_056.tsv <==
+==> ./tsvsplit_workdir/part_056.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_057.tsv <==
+==> ./tsvsplit_workdir/part_057.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_073.tsv <==
+==> ./tsvsplit_workdir/part_073.txt <==
 input1x3.txt: line 3
 
 ====[tsv-split --seed-value 15017 --num-files 2 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 3 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 2
 
 ====[tsv-split -v 15017 -n 11 ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_02.tsv <==
+==> ./tsvsplit_workdir/part_02.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_03.tsv <==
+==> ./tsvsplit_workdir/part_03.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_07.tsv <==
+==> ./tsvsplit_workdir/part_07.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 5
 
 ====[tsv-split -v 15017 -n 2 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x3.txt: line 2
 input1x3.txt: line 3
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -v 15017 -n 3 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x3.txt: line 3
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x3.txt: line 2
 input1x5.txt: line 5
 
 ====[tsv-split -v 15017 -n 101 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 2 -H ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
 ====[tsv-split -v 15017 -n 3 -H ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 3
 
 ====[tsv-split -v 15017 -n 2 -H ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x3.txt: line 1
 input1x3.txt: line 3
 input1x5.txt: line 2
@@ -255,108 +255,108 @@ input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 1
 input1x3.txt: line 2
 
 ====[tsv-split -v 15017 -n 3 -H ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 1
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x3.txt: line 1
 input1x3.txt: line 3
 
 ====[tsv-split -v 15017 -n 2 -I ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 2
 
 ====[tsv-split -v 15017 -n 3 -I ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 3
 
 ====[tsv-split -v 15017 -n 2 -I ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x3.txt: line 3
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 2
 
 ====[tsv-split -v 15017 -n 3 -I ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x3.txt: line 3
 
 ====[tsv-split -v 15017 -n 3 --prefix pre_ ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/pre_0.tsv <==
+==> ./tsvsplit_workdir/pre_0.txt <==
 input1x3.txt: line 3
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/pre_1.tsv <==
+==> ./tsvsplit_workdir/pre_1.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/pre_2.tsv <==
+==> ./tsvsplit_workdir/pre_2.txt <==
 input1x3.txt: line 2
 input1x5.txt: line 5
 
 ====[tsv-split -v 15017 -n 101 --prefix pre_ ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/pre_032.tsv <==
+==> ./tsvsplit_workdir/pre_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/pre_047.tsv <==
+==> ./tsvsplit_workdir/pre_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/pre_050.tsv <==
+==> ./tsvsplit_workdir/pre_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/pre_069.tsv <==
+==> ./tsvsplit_workdir/pre_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/pre_070.tsv <==
+==> ./tsvsplit_workdir/pre_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/pre_082.tsv <==
+==> ./tsvsplit_workdir/pre_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/pre_094.tsv <==
+==> ./tsvsplit_workdir/pre_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/pre_100.tsv <==
+==> ./tsvsplit_workdir/pre_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 3 --suffix .txt ../input1x3.txt ../input1x5.txt]====
@@ -440,32 +440,32 @@ input1x3.txt: line 3
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 3 --dir odir --prefix pre_ ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/odir/pre_0.tsv <==
+==> ./tsvsplit_workdir/odir/pre_0.txt <==
 input1x3.txt: line 3
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/odir/pre_1.tsv <==
+==> ./tsvsplit_workdir/odir/pre_1.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/odir/pre_2.tsv <==
+==> ./tsvsplit_workdir/odir/pre_2.txt <==
 input1x3.txt: line 2
 input1x5.txt: line 5
 
 ====[tsv-split -v 15017 -n 3 --dir odir --prefix pre_ ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/odir/pre_0.tsv <==
+==> ./tsvsplit_workdir/odir/pre_0.txt <==
 input1x3.txt: line 3
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/odir/pre_1.tsv <==
+==> ./tsvsplit_workdir/odir/pre_1.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/odir/pre_2.tsv <==
+==> ./tsvsplit_workdir/odir/pre_2.txt <==
 input1x3.txt: line 2
 input1x5.txt: line 5
 
@@ -525,208 +525,208 @@ input1x3.txt: line 3
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 101 --max-open-files 5 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 101 --max-open-files 6 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 101 --max-open-files 11 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 101 --max-open-files 12 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 101 --max-open-files 13 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[ulimit -Sn 5 && tsv-split -v 15017 -n 101 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[ulimit -Sn 5 && tsv-split -v 15017 -n 101 --max-open-files 5 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[ulimit -Sn 6 && tsv-split -v 15017 -n 101 ../input1x3.txt ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[tsv-split -v 15017 -n 3 --append ../input1x5.txt]====
 ====[tsv-split -v 15017 -n 3 --append ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
@@ -734,158 +734,158 @@ input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 1
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 2
 
 ====[tsv-split -v 15017 -n 3 -H --append ../input1x5.txt]====
 ====[tsv-split -v 15017 -n 3 -H --append ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 input1x5.txt: line 5
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 3
 input1x5.txt: line 3
 
 ====[tsv-split -v 15017 -n 3 -I -a ../input1x5.txt]====
 ====[tsv-split -v 15017 -n 3 -I -a ../input1x5.txt]====
-==> ./tsvsplit_workdir/part_0.tsv <==
+==> ./tsvsplit_workdir/part_0.txt <==
 input1x5.txt: line 4
 input1x5.txt: line 5
 input1x5.txt: line 4
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_1.tsv <==
+==> ./tsvsplit_workdir/part_1.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_2.tsv <==
+==> ./tsvsplit_workdir/part_2.txt <==
 input1x5.txt: line 3
 input1x5.txt: line 3
 
 ====[cat ../input1x5.txt | tsv-split -s -n 101]====
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027 <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028 <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_057.tsv <==
+==> ./tsvsplit_workdir/part_057 <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_073.tsv <==
+==> ./tsvsplit_workdir/part_073 <==
 input1x5.txt: line 3
 
 ====[cat ../input1x5.txt | tsv-split -s -n 101 -H]====
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027 <==
 input1x5.txt: line 1
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028 <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_057.tsv <==
+==> ./tsvsplit_workdir/part_057 <==
 input1x5.txt: line 1
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_073.tsv <==
+==> ./tsvsplit_workdir/part_073 <==
 input1x5.txt: line 1
 input1x5.txt: line 4
 
 ====[cat ../input1x5.txt | tsv-split -s -n 101 -I]====
-==> ./tsvsplit_workdir/part_027.tsv <==
+==> ./tsvsplit_workdir/part_027 <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_028.tsv <==
+==> ./tsvsplit_workdir/part_028 <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_057.tsv <==
+==> ./tsvsplit_workdir/part_057 <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_073.tsv <==
+==> ./tsvsplit_workdir/part_073 <==
 input1x5.txt: line 4
 
 ====[cat ../input1x5.txt | tsv-split -v 15017 -n 101 -- ../input1x3.txt -]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_050.tsv <==
+==> ./tsvsplit_workdir/part_050.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 
-==> ./tsvsplit_workdir/part_070.tsv <==
+==> ./tsvsplit_workdir/part_070.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 3
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
 ====[cat ../input1x5.txt | tsv-split -v 15017 -n 101 -H -- ../input1x3.txt -]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 1
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 1
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x3.txt: line 1
 input1x5.txt: line 3
 
 ====[cat ../input1x5.txt | tsv-split -v 15017 -n 101 -I -- ../input1x3.txt -]====
-==> ./tsvsplit_workdir/part_032.tsv <==
+==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 4
 
-==> ./tsvsplit_workdir/part_047.tsv <==
+==> ./tsvsplit_workdir/part_047.txt <==
 input1x3.txt: line 3
 
-==> ./tsvsplit_workdir/part_069.tsv <==
+==> ./tsvsplit_workdir/part_069.txt <==
 input1x3.txt: line 2
 
-==> ./tsvsplit_workdir/part_082.tsv <==
+==> ./tsvsplit_workdir/part_082.txt <==
 input1x5.txt: line 5
 
-==> ./tsvsplit_workdir/part_094.tsv <==
+==> ./tsvsplit_workdir/part_094.txt <==
 input1x5.txt: line 2
 
-==> ./tsvsplit_workdir/part_100.tsv <==
+==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 3


### PR DESCRIPTION
`tsv-split`: This PR changes the default output file suffix from ".tsv" to the extension of the first input file. The extension is empty when reading from standard input. The suffix can be customized using `--suffix`. For example, the command:
```
tsv-split --num-files 100 data.txt
```
will produce output files of form: `part_00.txt`, `part_01.txt`, ..., `part_99.txt`. Previously these output files would have ".txt" extensions.