### PR TITLE
tsv-split: Detect invalid filename characters in --prefix and --suffix.

### DIFF
--- a/tsv-split/src/tsv_utils/tsv-split.d
+++ b/tsv-split/src/tsv_utils/tsv-split.d
@@ -451,6 +451,24 @@ struct TsvSplitOptions
              * No suffix if reading from standard input.
              */
             if (suffix == invalidFileSuffix) suffix = files[0].extension;
+
+            /* Ensure forward slash is not included in the filename prefix and suffix.
+             * Forward slash is an invalid Unix filename character. However, open file
+             * calls could match a directory path, resulting in unintended file
+             * creation.
+             *
+             * The other invalid filename character on Unix is the NULL character.
+             * However, the NULL character cannot be entered via Unix command lines,
+             * so there is no need to test for it explicitly.
+             */
+            if (prefix.canFind('/'))
+            {
+                throw new Exception("'--prefix' cannot contain forward slash characters. Use '--dir' to specify an output directory.");
+            }
+            if (suffix.canFind('/'))
+            {
+                throw new Exception("'--suffix' cannot contain forward slash characters. Use '--dir' to specify an output directory.");
+            }
         }
         catch (Exception exc)
         {

--- a/tsv-split/tests/gold/error_tests_1.txt
+++ b/tsv-split/tests/gold/error_tests_1.txt
@@ -61,6 +61,12 @@ Error [tsv-split]: Not enough fields in line. File: input4x58.tsv, Line: 1
 ====[tsv-sample -l 10 --header --header-in-only input4x58.tsv]====
 [tsv-split] Error processing command line arguments: Use only one of '--H|header' and '--I|header-in-only'.
 
+====[tsv-sample -n 2 --prefix dir/file input4x58.tsv]====
+[tsv-split] Error processing command line arguments: '--prefix' cannot contain forward slash characters. Use '--dir' to specify an output directory.
+
+====[tsv-sample -n 2 --suffix ab/cd input4x58.tsv]====
+[tsv-split] Error processing command line arguments: '--suffix' cannot contain forward slash characters. Use '--dir' to specify an output directory.
+
 ====[ulimit -Sn 5 && tsv-split -s -n 101 -k 3 --max-open-files 6 ../input4x58.tsv]====
 [tsv-split] Error processing command line arguments: '--max-open-files' value (6) greater current system limit (5).
 Run 'ulimit -n' to see the soft limit.

--- a/tsv-split/tests/tests.sh
+++ b/tsv-split/tests/tests.sh
@@ -420,6 +420,8 @@ runtest ${prog} "-l 10 -k 1 input4x58.tsv" ${error_tests_1}
 runtest ${prog} "-l 10 -n 3 input4x58.tsv" ${error_tests_1}
 runtest ${prog} "-l 10 -n 3 -k 1 input4x58.tsv" ${error_tests_1}
 runtest ${prog} "-l 10 --header --header-in-only input4x58.tsv" ${error_tests_1}
+runtest ${prog} "-n 2 --prefix dir/file input4x58.tsv" ${error_tests_1}
+runtest ${prog} "-n 2 --suffix ab/cd input4x58.tsv" ${error_tests_1}
 runtest_wdir_ulimit ${prog} "-s -n 101 -k 3 --max-open-files 6 ${testdir_relpath}/input4x58.tsv" ${error_tests_1} 5
 runtest_wdir_ulimit ${prog} "-s -n 101 -k 3 ${testdir_relpath}/input4x58.tsv" ${error_tests_1} 4
 runtest_wdir_append ${prog} "-l 3" ${error_tests_1} ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x5.txt


### PR DESCRIPTION
Detect forward slash in `--prefix` and `--suffix`.