### PR TITLE
Directory cat

### DIFF
--- a/buildtools/dircat.d
+++ b/buildtools/dircat.d
@@ -1,0 +1,137 @@
+/**
+This tool concatenates all the files in a directory, with a line at the start of each
+new file giving the name of the file. This is used for testing tools generating
+multiple output files. It is similar to 'tail -n +1 dir/*'. The main difference is
+that it assembles files in the same order on all platforms, a characteristic
+necessary for testing.
+
+Copyright (c) 2020, eBay Inc.
+Initially written by Jon Degenhardt
+
+License: Boost License 1.0 (http://boost.org/LICENSE_1_0.txt)
+
+*/
+module buildtools.dircat;
+
+import std.range;
+import std.stdio;
+import std.typecons : tuple;
+
+version(unittest)
+{
+    // When running unit tests, use main from -main compiler switch.
+}
+else
+{
+    int main(string[] cmdArgs)
+    {
+        /* When running in DMD code coverage mode, turn on report merging. */
+        version(D_Coverage) version(DigitalMars)
+        {
+            import core.runtime : dmd_coverSetMerge;
+            dmd_coverSetMerge(true);
+        }
+
+        DirCatOptions cmdopt;
+        auto r = cmdopt.processArgs(cmdArgs);
+        if (!r[0]) return r[1];
+
+        try concatenateDirectoryFiles(cmdopt);
+        catch (Exception e)
+        {
+            stderr.writefln("Error [%s]: %s", cmdopt.programName, e.msg);
+            return 1;
+        }
+        return 0;
+    }
+}
+
+auto helpText = q"EOS
+Synopsis: dircat [options] <directory>
+
+This tool concatenates all files in a directory, writing the contents to
+standard output. The contents of each file is preceded with a line
+containing the path of the file.
+
+The current features are very simple. The directory must contain only
+regular files. It is an error if the directory contains subdirectories
+or symbolic links.
+
+Exit status is '0' on success, '1' if an error occurred.
+
+Options:
+EOS";
+
+struct DirCatOptions
+{
+    string programName;
+    string dir;                          // Required argument
+
+    /* Returns a tuple. First value is true if command line arguments were successfully
+     * processed and execution should continue, or false if an error occurred or the user
+     * asked for help. If false, the second value is the appropriate exit code (0 or 1).
+     *
+     * Returning true (execution continues) means args have been validated and derived
+     * values calculated.
+     */
+    auto processArgs (ref string[] cmdArgs)
+    {
+        import std.getopt;
+        import std.path : baseName, stripExtension;
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
+
+        try
+        {
+            auto r = getopt(cmdArgs);
+
+            if (r.helpWanted)
+            {
+                defaultGetoptPrinter(helpText, r.options);
+                return tuple(false, 0);
+            }
+
+            /* Get the directory path. Should be the one command line arg remaining. */
+            if (cmdArgs.length == 2) dir = cmdArgs[1];
+            else if (cmdArgs.length < 2) throw new Exception("A directory is required.");
+            else throw new Exception("Unexpected arguments.");
+        }
+        catch (Exception exc)
+        {
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
+            return tuple(false, 1);
+        }
+        return tuple(true, 0);
+    }
+}
+
+void concatenateDirectoryFiles(DirCatOptions cmdopt)
+{
+    import std.algorithm : copy, sort;
+    import std.conv : to;
+    import std.exception : enforce;
+    import std.file : dirEntries, DirEntry, exists, isDir, SpanMode;
+    import std.format : format;
+    import std.path;
+
+    string[] filepaths;
+
+    enforce(cmdopt.dir.exists, format("Directory '%s' does not exist.", cmdopt.dir));
+    enforce(cmdopt.dir.isDir, format("File path '%s' is not a directory.", cmdopt.dir));
+
+    foreach (DirEntry de; dirEntries(cmdopt.dir, SpanMode.shallow))
+    {
+        enforce(!de.isDir, format("Directory member '%s' is a directory.", de.name));
+        enforce(!de.isSymlink, format("Directory member '%s' is a symbolic link.", de.name));
+        enforce(de.isFile, format("Directory member '%s' is not a file.", de.name));
+
+        filepaths ~= de.name;
+    }
+    filepaths.sort;
+    foreach (filenum, path; filepaths)
+    {
+        if (filenum > 0) writeln;
+        writefln("==> %s <==", path);
+        path.File.byChunk(1024L * 128L).copy(stdout.lockingTextWriter);
+    }
+}

--- a/buildtools/makefile
+++ b/buildtools/makefile
@@ -1,7 +1,7 @@
 DCOMPILER = dmd
 DFLAGS =
 
-all: aggregate-codecov codecov-to-relative-paths diff-test-result-dirs
+all: aggregate-codecov codecov-to-relative-paths diff-test-result-dirs dircat
 
 aggregate-codecov: aggregate-codecov.d
 	$(DCOMPILER) -release -O aggregate-codecov.d
@@ -12,8 +12,12 @@ codecov-to-relative-paths: codecov-to-relative-paths.d
 diff-test-result-dirs: diff-test-result-dirs.d
 	$(DCOMPILER) -release -O diff-test-result-dirs.d
 
+dircat: dircat.d
+	$(DCOMPILER) -release -O dircat.d
+
 clean:
 	-rm aggregate-codecov
 	-rm codecov-to-relative-paths
 	-rm diff-test-result-dirs
+	-rm dircat
 	-rm *.o

--- a/tsv-split/tests/gold/key_assignment_tests.txt
+++ b/tsv-split/tests/gold/key_assignment_tests.txt
@@ -2239,6 +2239,38 @@ fumée	2113	Araqua-pintado	0
 marrón	2034	Weißwangengans	1
 fumée	2124	Araqua-pintado	0
 
+====[tsv-split -v 15017 -n 20 -k 0 --digit-width 1 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_14.txt <==
+input1x5.txt: line 2
+
+==> ./tsvsplit_workdir/part_15.txt <==
+input1x5.txt: line 4
+
+==> ./tsvsplit_workdir/part_5.txt <==
+input1x5.txt: line 5
+
+==> ./tsvsplit_workdir/part_6.txt <==
+input1x5.txt: line 1
+
+==> ./tsvsplit_workdir/part_8.txt <==
+input1x5.txt: line 3
+
+====[tsv-split -v 15017 -n 20 -k 0 -w 5 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_00005.txt <==
+input1x5.txt: line 5
+
+==> ./tsvsplit_workdir/part_00006.txt <==
+input1x5.txt: line 1
+
+==> ./tsvsplit_workdir/part_00008.txt <==
+input1x5.txt: line 3
+
+==> ./tsvsplit_workdir/part_00014.txt <==
+input1x5.txt: line 2
+
+==> ./tsvsplit_workdir/part_00015.txt <==
+input1x5.txt: line 4
+
 ====[tsv-split -s -n 101 --max-open-files 5 -k 3 ../input4x58.tsv]====
 ==> ./tsvsplit_workdir/part_000.tsv <==
 dorado	2045	Лебедь	2

--- a/tsv-split/tests/gold/lines_per_file_tests.txt
+++ b/tsv-split/tests/gold/lines_per_file_tests.txt
@@ -50,6 +50,7 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 5 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -57,6 +58,7 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 6 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -103,6 +105,7 @@ input1x5.txt: line 1
 input1x5.txt: line 5
 
 ====[tsv-split -l 4 -H ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -110,6 +113,7 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 5 -H ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -117,6 +121,7 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 6 -H ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -155,18 +160,21 @@ input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 4 -I ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 5 -I ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
 ====[tsv-split -l 6 -I ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
@@ -228,6 +236,7 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 8 ../input1x5.txt ../input1x3.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -279,6 +288,7 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 7 -H ../input1x5.txt ../input1x3.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -288,6 +298,7 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 8 -H ../input1x5.txt ../input1x3.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 1
 input1x5.txt: line 2
 input1x5.txt: line 3
@@ -329,6 +340,7 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 7 -I ../input1x5.txt ../input1x3.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4
@@ -337,6 +349,7 @@ input1x3.txt: line 2
 input1x3.txt: line 3
 
 ====[tsv-split -l 8 -I ../input1x5.txt ../input1x3.txt]====
+==> ./tsvsplit_workdir/part_000.txt <==
 input1x5.txt: line 2
 input1x5.txt: line 3
 input1x5.txt: line 4

--- a/tsv-split/tests/gold/lines_per_file_tests.txt
+++ b/tsv-split/tests/gold/lines_per_file_tests.txt
@@ -407,6 +407,38 @@ input1x5.txt: line 3
 input1x5.txt: line 4
 input1x5.txt: line 5
 
+====[tsv-split -l 1 --digit-width 1 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_0.txt <==
+input1x5.txt: line 1
+
+==> ./tsvsplit_workdir/part_1.txt <==
+input1x5.txt: line 2
+
+==> ./tsvsplit_workdir/part_2.txt <==
+input1x5.txt: line 3
+
+==> ./tsvsplit_workdir/part_3.txt <==
+input1x5.txt: line 4
+
+==> ./tsvsplit_workdir/part_4.txt <==
+input1x5.txt: line 5
+
+====[tsv-split -l 1 -w 5 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_00000.txt <==
+input1x5.txt: line 1
+
+==> ./tsvsplit_workdir/part_00001.txt <==
+input1x5.txt: line 2
+
+==> ./tsvsplit_workdir/part_00002.txt <==
+input1x5.txt: line 3
+
+==> ./tsvsplit_workdir/part_00003.txt <==
+input1x5.txt: line 4
+
+==> ./tsvsplit_workdir/part_00004.txt <==
+input1x5.txt: line 5
+
 ====[tsv-split -l 3 --append ../input1x5.txt]====
 ====[tsv-split -l 3 --append ../input1x5.txt]====
 ==> ./tsvsplit_workdir/part_000.txt <==

--- a/tsv-split/tests/gold/random_assignment_tests.txt
+++ b/tsv-split/tests/gold/random_assignment_tests.txt
@@ -649,6 +649,34 @@ input1x3.txt: line 3
 ==> ./tsvsplit_workdir/part_100.txt <==
 input1x5.txt: line 1
 
+====[tsv-split -v 15017 -n 20 --digit-width 1 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_1.txt <==
+input1x5.txt: line 1
+
+==> ./tsvsplit_workdir/part_10.txt <==
+input1x5.txt: line 4
+input1x5.txt: line 5
+
+==> ./tsvsplit_workdir/part_12.txt <==
+input1x5.txt: line 2
+
+==> ./tsvsplit_workdir/part_14.txt <==
+input1x5.txt: line 3
+
+====[tsv-split -v 15017 -n 20 -w 5 ../input1x5.txt]====
+==> ./tsvsplit_workdir/part_00001.txt <==
+input1x5.txt: line 1
+
+==> ./tsvsplit_workdir/part_00010.txt <==
+input1x5.txt: line 4
+input1x5.txt: line 5
+
+==> ./tsvsplit_workdir/part_00012.txt <==
+input1x5.txt: line 2
+
+==> ./tsvsplit_workdir/part_00014.txt <==
+input1x5.txt: line 3
+
 ====[ulimit -Sn 5 && tsv-split -v 15017 -n 101 ../input1x3.txt ../input1x5.txt]====
 ==> ./tsvsplit_workdir/part_032.txt <==
 input1x5.txt: line 2

--- a/tsv-split/tests/tests.sh
+++ b/tsv-split/tests/tests.sh
@@ -14,6 +14,20 @@ shift
 odir=$1
 echo "Testing ${prog}, output to ${odir}"
 
+## A hack for now - Know the exact relative path of the dircat program.
+dircat_prog='../../buildtools/dircat'
+
+if [ ! -e "$dircat_prog" ]; then
+    echo "Program $dircat_prog does not exist."
+    echo "Is 'cd buildtools && make' needed?."
+    exit 1
+fi
+
+if [ ! -x "$dircat_prog" ]; then
+    echo "Program $dircat_prog is not an executable."
+    exit 1
+fi
+
 ##
 ## 'runtest' is used when no files are expected, only output to standard output or
 ## standard error. This routine is used for '--help', '--version', command line error
@@ -36,8 +50,9 @@ runtest () {
 ## in tsv-utils repo. In particular, because 'tsv-split' produces multiple output
 ## files, having a single file comparison basis is setup differently. This version
 ## of 'runtest' generates a directory with multiple files, then concatenates the
-## result files using 'tail -n +1'. This concatenates all files with a header line
-## giving the file name between.
+## result files using 'dircat' from the 'buildtools' directory. This concatenates
+## all files with a header line giving the file name between. The result is similar
+## to 'tail -n +1', but more consistent across platforms.
 ##
 ## For consistency with the other tsv-utils test scripts, this routine takes the
 ## same three arguments as the standard 'runtest' scripts. A fourth logical
@@ -82,7 +97,7 @@ runtest_wdir () {
 
     mkdir -p ${output_dir}
     ( cd ${workdir} && ${prog} --DRT-covopt="dstpath:../" ${args} >> ${testdir_relpath}/${output_file} 2>&1 )
-    tail -n +1 ${output_dir}/* >> ${output_file} 2>&1
+    ${dircat_prog} ${output_dir} >> ${output_file} 2>&1
 
     rm -rf ${workdir}
 
@@ -118,7 +133,7 @@ runtest_wdir_append () {
         shift
     done
     
-    tail -n +1 ${workdir}/* >> ${output_file} 2>/dev/null
+    ${dircat_prog} ${workdir} >> ${output_file} 2>/dev/null
     rm -rf ${workdir}
 
     return 0
@@ -144,7 +159,7 @@ runtest_wdir_ulimit () {
     rm -rf ${workdir}
     mkdir -p ${workdir}
     ( cd ${workdir} && ulimit -Sn ${ulimit_max_open_files} && ${prog} --DRT-covopt="dstpath:../" ${args} >> ${testdir_relpath}/${output_file} 2>&1 )
-    tail -n +1 ${output_dir}/* >> ${output_file} 2>/dev/null
+    ${dircat_prog} ${output_dir} >> ${output_file} 2>/dev/null
 
     rm -rf ${workdir}
 

--- a/tsv-split/tests/tests.sh
+++ b/tsv-split/tests/tests.sh
@@ -248,6 +248,9 @@ runtest_wdir ${prog} "-l 3 --prefix pre ${testdir_relpath}/input1x5.txt" ${lines
 runtest_wdir ${prog} "-l 3 --dir odir ${testdir_relpath}/input1x5.txt" ${lines_per_file_tests} odir
 runtest_wdir ${prog} "-l 3 --dir odir --prefix pre_ --suffix _post ${testdir_relpath}/input1x5.txt" ${lines_per_file_tests} odir
 
+runtest_wdir ${prog} "-l 1 --digit-width 1 ${testdir_relpath}/input1x5.txt" ${lines_per_file_tests}
+runtest_wdir ${prog} "-l 1 -w 5 ${testdir_relpath}/input1x5.txt" ${lines_per_file_tests}
+
 runtest_wdir_append ${prog} "-l 3 --append" ${lines_per_file_tests} ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x5.txt
 runtest_wdir_append ${prog} "-H -l 3 -a" ${lines_per_file_tests} ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x3.txt
 runtest_wdir_append ${prog} "-I -l 3 --append" ${lines_per_file_tests} ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x3.txt
@@ -310,6 +313,9 @@ runtest_wdir ${prog} "-v 15017 -n 101 --max-open-files 11 ${testdir_relpath}/inp
 runtest_wdir ${prog} "-v 15017 -n 101 --max-open-files 12 ${testdir_relpath}/input1x3.txt ${testdir_relpath}/input1x5.txt" ${random_assignment_tests}
 runtest_wdir ${prog} "-v 15017 -n 101 --max-open-files 13 ${testdir_relpath}/input1x3.txt ${testdir_relpath}/input1x5.txt" ${random_assignment_tests}
 
+runtest_wdir ${prog} "-v 15017 -n 20 --digit-width 1 ${testdir_relpath}/input1x5.txt" ${random_assignment_tests}
+runtest_wdir ${prog} "-v 15017 -n 20 -w 5 ${testdir_relpath}/input1x5.txt" ${random_assignment_tests}
+
 runtest_wdir_ulimit ${prog} "-v 15017 -n 101 ${testdir_relpath}/input1x3.txt ${testdir_relpath}/input1x5.txt" ${random_assignment_tests} 5
 runtest_wdir_ulimit ${prog} "-v 15017 -n 101 --max-open-files 5 ${testdir_relpath}/input1x3.txt ${testdir_relpath}/input1x5.txt" ${random_assignment_tests} 5
 runtest_wdir_ulimit ${prog} "-v 15017 -n 101 ${testdir_relpath}/input1x3.txt ${testdir_relpath}/input1x5.txt" ${random_assignment_tests} 6
@@ -362,6 +368,9 @@ runtest_wdir ${prog} "-H -s -n 2 -k 1 --dir odir ${testdir_relpath}/input4x58.ts
 runtest_wdir ${prog} "-H -s -n 2 -k 1 --prefix pre_ --dir odir ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests} odir
 runtest_wdir ${prog} "-H -s -n 2 -k 1 --suffix _suf --dir odir ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests} odir
 runtest_wdir ${prog} "-H -s -n 2 -k 1 --prefix pre_ --suffix _suf --dir odir ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests} odir
+
+runtest_wdir ${prog} "-v 15017 -n 20 -k 0 --digit-width 1 ${testdir_relpath}/input1x5.txt" ${key_assignment_tests}
+runtest_wdir ${prog} "-v 15017 -n 20 -k 0 -w 5 ${testdir_relpath}/input1x5.txt" ${key_assignment_tests}
 
 runtest_wdir ${prog} "-s -n 101 --max-open-files 5 -k 3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 runtest_wdir ${prog} "-s -n 101 --max-open-files 6 -k 3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}


### PR DESCRIPTION
Adds a new build/test tool, `dircat` that concatenates the files in a directory into a single output stream. Each file's contents is preceded by the filename. This is needed for `tsv-split` command line testing.

It is similar to using `tail -n +1` on a directory, which is what `tsv-split` command line tests did before. However, this had problems with inconsistent file listing orders on different platforms, causing trouble for CI testing. Having a standalone tool addresses this problem.

This PR also contains updates to `tsv-split` command line testing, including a few tests that were dropped earlier due to platform consistency issues.