### PR TITLE
Prefer enforce to throw

### DIFF
--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -1821,6 +1821,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     assertThrown("0-3".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("3-0".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("-2-4".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
+    assertThrown("2--4".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
 
     assertThrown("".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown(" ".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
@@ -1831,6 +1832,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     assertThrown("0-3".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("3-0".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("-2-4".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
+    assertThrown("2--4".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
 
     /* Value out of range cases. */
     assertThrown("65536".parseFieldRange!ushort);   // One more than ushort max.

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -1665,6 +1665,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
 {
     import std.algorithm : findSplit;
     import std.conv : to;
+    import std.exception : enforce;
     import std.format : format;
     import std.range : iota;
     import std.traits : Signed;
@@ -1675,15 +1676,13 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     static if (convertToZero) alias S = Signed!T;
     else alias S = T;
 
-    if (fieldRange.length == 0) throw new Exception("Empty field number.");
+    enforce(fieldRange.length != 0, "Empty field number.");
 
     auto rangeSplit = findSplit(fieldRange, "-");
 
-    if (!rangeSplit[1].empty && (rangeSplit[0].empty || rangeSplit[2].empty))
-    {
-        // Range starts or ends with a dash.
-        throw new Exception(format("Incomplete ranges are not supported: '%s'", fieldRange));
-    }
+    /* Make sure the range does not start or end with a dash. */
+    enforce(rangeSplit[1].empty || (!rangeSplit[0].empty && !rangeSplit[2].empty),
+            format("Incomplete ranges are not supported: '%s'", fieldRange));
 
     S start = rangeSplit[0].to!S;
     S last = rangeSplit[1].empty ? start : rangeSplit[2].to!S;
@@ -1691,27 +1690,21 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
 
     static if (allowZero)
     {
-        if (start == 0 && !rangeSplit[1].empty)
-        {
-            throw new Exception(format("Zero cannot be used as part of a range: '%s'", fieldRange));
-        }
+        enforce(rangeSplit[1].empty || (start != 0 && last != 0),
+                format("Zero cannot be used as part of a range: '%s'", fieldRange));
     }
 
     static if (allowZero)
     {
-        if (start < 0 || last < 0)
-        {
-            throw new Exception(format("Field numbers must be non-negative integers: '%d'",
-                                       (start < 0) ? start : last));
-        }
+        enforce(start >= 0 && last >= 0,
+                format("Field numbers must be non-negative integers: '%d'",
+                       (start < 0) ? start : last));
     }
     else
     {
-        if (start < 1 || last < 1)
-        {
-            throw new Exception(format("Field numbers must be greater than zero: '%d'",
-                                       (start < 1) ? start : last));
-        }
+        enforce(start >= 1 && last >= 1,
+                format("Field numbers must be greater than zero: '%d'",
+                       (start < 1) ? start : last));
     }
 
     static if (convertToZero)
@@ -1797,6 +1790,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     assertThrown("1.0".parseFieldRange);
     assertThrown("0".parseFieldRange);
     assertThrown("0-3".parseFieldRange);
+    assertThrown("3-0".parseFieldRange);
     assertThrown("-2-4".parseFieldRange);
     assertThrown("2--4".parseFieldRange);
     assertThrown("2-".parseFieldRange);
@@ -1814,6 +1808,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     assertThrown("-1".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
     assertThrown("0".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
     assertThrown("0-3".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
+    assertThrown("3-0".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
     assertThrown("-2-4".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
     assertThrown("2--4".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
 
@@ -1824,6 +1819,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     assertThrown("-2".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("-1".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("0-3".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
+    assertThrown("3-0".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("-2-4".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
 
     assertThrown("".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
@@ -1833,6 +1829,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
     assertThrown("-2".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("-1".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("0-3".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
+    assertThrown("3-0".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown("-2-4".parseFieldRange!(long, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
 
     /* Value out of range cases. */

--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -12,6 +12,7 @@ License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
 module tsv_utils.csv2tsv;
 
 import std.stdio;
+import std.exception : enforce;
 import std.format : format;
 import std.range;
 import std.traits : Unqual;
@@ -122,35 +123,23 @@ struct Csv2tsvOptions
             }
 
             /* Consistency checks. */
-            if (csvQuoteChar == '\n' || csvQuoteChar == '\r')
-            {
-                throw new Exception ("CSV quote character cannot be newline (--q|quote).");
-            }
+            enforce(csvQuoteChar != '\n' && csvQuoteChar != '\r',
+                    "CSV quote character cannot be newline (--q|quote).");
 
-            if (csvQuoteChar == csvDelimChar)
-            {
-                throw new Exception("CSV quote and CSV field delimiter characters must be different (--q|quote, --c|csv-delim).");
-            }
+            enforce(csvQuoteChar != csvDelimChar,
+                    "CSV quote and CSV field delimiter characters must be different (--q|quote, --c|csv-delim).");
 
-            if (csvQuoteChar == tsvDelimChar)
-            {
-                throw new Exception("CSV quote and TSV field delimiter characters must be different (--q|quote, --t|tsv-delim).");
-            }
+            enforce(csvQuoteChar != tsvDelimChar,
+                    "CSV quote and TSV field delimiter characters must be different (--q|quote, --t|tsv-delim).");
 
-            if (csvDelimChar == '\n' || csvDelimChar == '\r')
-            {
-                throw new Exception ("CSV field delimiter cannot be newline (--c|csv-delim).");
-            }
+            enforce(csvDelimChar != '\n' && csvDelimChar != '\r',
+                    "CSV field delimiter cannot be newline (--c|csv-delim).");
 
-            if (tsvDelimChar == '\n' || tsvDelimChar == '\r')
-            {
-                throw new Exception ("TSV field delimiter cannot be newline (--t|tsv-delimiter).");
-            }
+            enforce(tsvDelimChar != '\n' && tsvDelimChar != '\r',
+                    "TSV field delimiter cannot be newline (--t|tsv-delim).");
 
-            if (canFind!(c => (c == '\n' || c == '\r' || c == tsvDelimChar))(tsvDelimReplacement))
-            {
-                throw new Exception ("Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).");
-            }
+            enforce(!canFind!(c => (c == '\n' || c == '\r' || c == tsvDelimChar))(tsvDelimReplacement),
+                    "Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).");
         }
         catch (Exception exc)
         {
@@ -398,13 +387,10 @@ InputLoop: while (!inputStream.empty)
         }
     }
 
-    if (currState == State.QuotedField)
-    {
-        throw new Exception(
+    enforce(currState != State.QuotedField,
             format("Invalid CSV. Improperly terminated quoted field. File: %s, Line: %d",
                    (filename == "-") ? "Standard Input" : filename,
                    currFileLineNumber + recordNum));
-    }
 
     if (fieldNum > 0) put(outputStream, '\n');    // Last line w/o terminating newline.
 }

--- a/csv2tsv/tests/gold/error_tests_1.txt
+++ b/csv2tsv/tests/gold/error_tests_1.txt
@@ -8,6 +8,36 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 ====[csv2tsv --nosuchparam input1.txt]====
 [csv2tsv] Error processing command line arguments: Unrecognized option --nosuchparam
 
+====[csv2tsv --quote $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: CSV quote character cannot be newline (--q|quote).
+
+====[csv2tsv --quote $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: CSV quote character cannot be newline (--q|quote).
+
+====[csv2tsv --csv-delim $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: CSV field delimiter cannot be newline (--c|csv-delim).
+
+====[csv2tsv --csv-delim $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: CSV field delimiter cannot be newline (--c|csv-delim).
+
+====[csv2tsv --tsv-delim $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: TSV field delimiter cannot be newline (--t|tsv-delim).
+
+====[csv2tsv --tsv-delim $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: TSV field delimiter cannot be newline (--t|tsv-delim).
+
+====[csv2tsv --replacement $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+
+====[csv2tsv --replacement $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+
+====[csv2tsv -r $'__\n__' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+
+====[csv2tsv -r $'__\r__' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+
 ====[csv2tsv -q x -c x input2.csv]====
 [csv2tsv] Error processing command line arguments: CSV quote and CSV field delimiter characters must be different (--q|quote, --c|csv-delim).
 

--- a/csv2tsv/tests/tests.sh
+++ b/csv2tsv/tests/tests.sh
@@ -67,6 +67,41 @@ echo "----------------" >> ${error_tests_1}
 
 runtest ${prog} "nosuchfile.txt" ${error_tests_1}
 runtest ${prog} "--nosuchparam input1.txt" ${error_tests_1}
+
+## The newline character doesn't pass through the runtest function
+## correctly, so the next couple tests write directly to the output file.
+##
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --quote $'\n' input2.csv]====" >> ${error_tests_1}
+${prog} --quote $'\n' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --quote $'\r' input2.csv]====" >> ${error_tests_1}
+${prog} --quote $'\r' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --csv-delim $'\n' input2.csv]====" >> ${error_tests_1}
+${prog} --csv-delim $'\n' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --csv-delim $'\r' input2.csv]====" >> ${error_tests_1}
+${prog} --csv-delim $'\r' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --tsv-delim $'\n' input2.csv]====" >> ${error_tests_1}
+${prog} --tsv-delim $'\n' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --tsv-delim $'\r' input2.csv]====" >> ${error_tests_1}
+${prog} --tsv-delim $'\r' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --replacement $'\n' input2.csv]====" >> ${error_tests_1}
+${prog} --replacement $'\n' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --replacement $'\r' input2.csv]====" >> ${error_tests_1}
+${prog} --replacement $'\r' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv -r $'__\n__' input2.csv]====" >> ${error_tests_1}
+${prog} -r $'__\n__' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv -r $'__\r__' input2.csv]====" >> ${error_tests_1}
+${prog} -r $'__\r__' input2.csv >> ${error_tests_1} 2>&1
+
+
 runtest ${prog} "-q x -c x input2.csv" ${error_tests_1}
 runtest ${prog} "-q x -t x input2.csv" ${error_tests_1}
 runtest ${prog} "-t x -r wxyz input2.csv" ${error_tests_1}

--- a/tsv-append/src/tsv_utils/tsv-append.d
+++ b/tsv-append/src/tsv_utils/tsv-append.d
@@ -10,6 +10,7 @@ License: Boost License 1.0 (http://boost.org/LICENSE_1_0.txt)
 module tsv_utils.tsv_append;
 
 import std.conv : to;
+import std.exception : enforce;
 import std.range;
 import std.stdio;
 import std.typecons : tuple;
@@ -116,8 +117,8 @@ struct TsvAppendOptions
         import std.format : format;
 
         auto valSplit = findSplit(optionVal, "=");
-        if (valSplit[0].empty || valSplit[2].empty)
-            throw new Exception(
+
+        enforce(!valSplit[0].empty && !valSplit[2].empty,
                 format("Invalid option value: '--%s %s'. Expected: '--%s <source>=<file>'.",
                        option, optionVal, option));
 

--- a/tsv-join/tests/gold/error_tests_1.txt
+++ b/tsv-join/tests/gold/error_tests_1.txt
@@ -49,6 +49,12 @@ f1	f2	f3	f4	f5
 ====[tsv-join --header -f input1.tsv -k 2,3 -d 2,0 input2.tsv]====
 [tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
 
+====[tsv-join --header -f input1.tsv -k 1 -a 2,0 input2.tsv]====
+[tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
+
+====[tsv-join --header -f input1.tsv -k 1 -a 0,2 input2.tsv]====
+[tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
+
 ====[tsv-join --header -f input1.tsv -k 2 -d 0 input2.tsv]====
 [tsv-join] Error processing command line arguments: If either --k|key-field or --d|data-field is zero both must be zero.
 

--- a/tsv-join/tests/tests.sh
+++ b/tsv-join/tests/tests.sh
@@ -199,6 +199,8 @@ runtest ${prog} "--header -f input1.tsv -k 2,0 input2.tsv" ${error_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 0,2 input2.tsv" ${error_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -d 0,2 input2.tsv" ${error_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -d 2,0 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 1 -a 2,0 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 1 -a 0,2 input2.tsv" ${error_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2 -d 0 input2.tsv" ${error_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 0 -d 2 input2.tsv" ${error_tests_1}
 

--- a/tsv-pretty/src/tsv_utils/tsv-pretty.d
+++ b/tsv-pretty/src/tsv_utils/tsv-pretty.d
@@ -9,6 +9,7 @@ License: Boost License 1.0 (http://boost.org/LICENSE_1_0.txt)
 */
 module tsv_utils.tsv_pretty;
 
+import std.exception : enforce;
 import std.range;
 import std.stdio;
 import std.typecons : Flag, Yes, No, tuple;
@@ -189,7 +190,8 @@ struct TsvPrettyOptions
             }
 
             /* Validation and derivations. */
-            if (noHeader && hasHeader) throw new Exception("Cannot specify both --H|header and --x|no-header.");
+            enforce(!(noHeader && hasHeader),
+                    "Cannot specify both --H|header and --x|no-header.");
 
             if (noHeader || hasHeader) autoDetectHeader = false;
 
@@ -198,14 +200,12 @@ struct TsvPrettyOptions
              */
             if (lookahead == 0 && autoDetectHeader)
             {
-                assert (!noHeader && !hasHeader);
-                throw new Exception("Cannot auto-detect header with zero look-ahead. Specify either '--H|header' or '--x|no-header' when using '--l|lookahead 0'.");
+                enforce(noHeader || hasHeader,
+                        "Cannot auto-detect header with zero look-ahead. Specify either '--H|header' or '--x|no-header' when using '--l|lookahead 0'.");
             }
 
-            if (autoDetectPreamble && preambleLines != 0)
-            {
-                throw new Exception("Do not use '--b|preamble NUM' and '--a|auto-preamble' together. ('--b|preamble 0' is okay.)");
-            }
+            enforce(!(autoDetectPreamble && preambleLines != 0),
+                    "Do not use '--b|preamble NUM' and '--a|auto-preamble' together. ('--b|preamble 0' is okay.)");
 
             if (emptyReplacement.length != 0) replaceEmpty = true;
             else if (replaceEmpty) emptyReplacement = "--";

--- a/tsv-pretty/tests/gold/error_tests_1.txt
+++ b/tsv-pretty/tests/gold/error_tests_1.txt
@@ -31,6 +31,9 @@ Error [tsv-pretty]: Cannot open file `no_such_file.tsv' in mode `rb' (No such fi
 ====[tsv-pretty --auto-preamble --preamble 1 input_unicode.tsv]====
 [tsv-pretty] Error processing command line arguments: Do not use '--b|preamble NUM' and '--a|auto-preamble' together. ('--b|preamble 0' is okay.)
 
+====[tsv-pretty --header --no-header input_unicode.tsv]====
+[tsv-pretty] Error processing command line arguments: Cannot specify both --H|header and --x|no-header.
+
 ====[tsv-pretty invalid_unicode.tsv]====
 Column-1       Column-2  Column-3
 white          Weiß      白

--- a/tsv-pretty/tests/tests.sh
+++ b/tsv-pretty/tests/tests.sh
@@ -696,4 +696,5 @@ runtest ${prog} "--space-between-fields 1.5 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "--max-text-width -1 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "--lookahead 0 input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "--auto-preamble --preamble 1 input_unicode.tsv" ${error_tests_1}
+runtest ${prog} "--header --no-header input_unicode.tsv" ${error_tests_1}
 runtest ${prog} "invalid_unicode.tsv" ${error_tests_1}

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -375,9 +375,9 @@ struct TsvSampleOptions
                 enforce(!hasWeightField, "--w|weight-field and --p|prob cannot be used together.");
 
                 enforce(!genRandomInorder || useDistinctSampling,
-                        "--gen-random-inorder and --p|prob can only be used together if --k|key-fields is also used."
-                        ~ "\nUse --gen-random-inorder alone to print probabilities for all lines."
-                        ~ "\nUse --p|prob and --print-random to print probabilities for lines satisfying the probability threshold.");
+                        "--gen-random-inorder and --p|prob can only be used together if --k|key-fields is also used." ~
+                        "\nUse --gen-random-inorder alone to print probabilities for all lines." ~
+                        "\nUse --p|prob and --print-random to print probabilities for lines satisfying the probability threshold.");
             }
             else if (genRandomInorder && !hasWeightField)
             {

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -11,6 +11,8 @@ License: Boost License 1.0 (http://boost.org/LICENSE_1_0.txt)
 module tsv_utils.tsv_sample;
 
 import std.array : appender, Appender, RefAppender;
+import std.exception : enforce;
+import std.format : format;
 import std.range;
 import std.stdio;
 import std.typecons : tuple, Flag;
@@ -247,7 +249,7 @@ struct TsvSampleOptions
      */
     auto processArgs(ref string[] cmdArgs)
     {
-        import std.algorithm : any, canFind, each;
+        import std.algorithm : all, canFind, each;
         import std.getopt;
         import std.math : isNaN;
         import std.path : baseName, stripExtension;
@@ -326,33 +328,27 @@ struct TsvSampleOptions
 
             if (srsWithReplacement)
             {
-                if (hasWeightField)
-                {
-                    throw new Exception("Sampling with replacement (--r|replace) does not support weights (--w|weight-field).");
-                }
-                else if (!inclusionProbability.isNaN)
-                {
-                    throw new Exception("Sampling with replacement (--r|replace) cannot be used with probabilities (--p|prob).");
-                }
-                else if (keyFields.length > 0)
-                {
-                    throw new Exception("Sampling with replacement (--r|replace) cannot be used with distinct sampling (--k|key-fields).");
-                }
-                else if (printRandom || genRandomInorder)
-                {
-                    throw new Exception("Sampling with replacement (--r|replace) does not support random value printing (--print-random, --gen-random-inorder).");
-                }
-                else if (preserveInputOrder)
-                {
-                    throw new Exception("Sampling with replacement (--r|replace) does not support input order preservation (--i|inorder option).");
-                }
+                enforce(!hasWeightField,
+                        "Sampling with replacement (--r|replace) does not support weights (--w|weight-field).");
+
+                enforce(inclusionProbability.isNaN,
+                        "Sampling with replacement (--r|replace) cannot be used with probabilities (--p|prob).");
+
+                enforce(keyFields.length == 0,
+                        "Sampling with replacement (--r|replace) cannot be used with distinct sampling (--k|key-fields).");
+
+                enforce(!printRandom && !genRandomInorder,
+                        "Sampling with replacement (--r|replace) does not support random value printing (--print-random, --gen-random-inorder).");
+
+                enforce(!preserveInputOrder,
+                        "Sampling with replacement (--r|replace) does not support input order preservation (--i|inorder option).");
             }
 
             if (keyFields.length > 0)
             {
                 /* Note: useDistinctSampling is set as part of the inclusion probability checks below. */
 
-                if (inclusionProbability.isNaN) throw new Exception("--p|prob is required when using --k|key-fields.");
+                enforce(!inclusionProbability.isNaN, "--p|prob is required when using --k|key-fields.");
 
                 if (keyFields.length == 1 && keyFields[0] == 0)
                 {
@@ -360,10 +356,8 @@ struct TsvSampleOptions
                 }
                 else
                 {
-                    if (keyFields.length > 1 && keyFields.any!(x => x == 0))
-                    {
-                        throw new Exception("Whole line as key (--k|key-fields 0) cannot be combined with multiple fields.");
-                    }
+                    enforce(keyFields.length <= 1 || keyFields.all!(x => x != 0),
+                            "Whole line as key (--k|key-fields 0) cannot be combined with multiple fields.");
 
                     keyFields.each!((ref x) => --x);  // Convert to zero-based indexing.
                 }
@@ -372,47 +366,38 @@ struct TsvSampleOptions
             /* Inclusion probability (--p|prob) is used for both Bernoulli sampling and distinct sampling. */
             if (!inclusionProbability.isNaN)
             {
-                if (inclusionProbability <= 0.0 || inclusionProbability > 1.0)
-                {
-                    import std.format : format;
-                    throw new Exception(
+                enforce(inclusionProbability > 0.0 && inclusionProbability <= 1.0,
                         format("Invalid --p|prob option: %g. Must satisfy 0.0 < prob <= 1.0.", inclusionProbability));
-                }
 
                 if (keyFields.length > 0) useDistinctSampling = true;
                 else useBernoulliSampling = true;
 
-                if (hasWeightField) throw new Exception("--w|weight-field and --p|prob cannot be used together.");
+                enforce(!hasWeightField, "--w|weight-field and --p|prob cannot be used together.");
 
-                if (genRandomInorder && !useDistinctSampling)
-                {
-                    throw new Exception("--gen-random-inorder and --p|prob can only be used together if --k|key-fields is also used.");
-                }
+                enforce(!genRandomInorder || useDistinctSampling,
+                        "--gen-random-inorder and --p|prob can only be used together if --k|key-fields is also used."
+                        ~ "\nUse --gen-random-inorder alone to print probabilities for all lines."
+                        ~ "\nUse --p|prob and --print-random to print probabilities for lines satisfying the probability threshold.");
             }
             else if (genRandomInorder && !hasWeightField)
             {
                 useBernoulliSampling = true;
             }
 
-            if (randomValueHeader.length == 0 || randomValueHeader.canFind('\n') ||
-                randomValueHeader.canFind(delim))
-            {
-                throw new Exception("--randomValueHeader must be at least one character and not contain field delimiters or newlines.");
-            }
+            enforce(randomValueHeader.length != 0 && !randomValueHeader.canFind('\n') &&
+                    !randomValueHeader.canFind(delim),
+                    "--randomValueHeader must be at least one character and not contain field delimiters or newlines.");
 
             /* Check for incompatible use of (--i|inorder) and shuffling of the full
              * data set. Sampling with replacement is also incompatible, this is
              * detected earlier. Shuffling is the default operation, so it identified
              * by eliminating the other modes of operation.
              */
-            if (preserveInputOrder &&
-                sampleSize == 0 &&
-                !useBernoulliSampling &&
-                !useDistinctSampling
-               )
-            {
-                throw new Exception("Preserving input order (--i|inorder) is not compatible with full data set shuffling. Switch to random sampling with a sample size (--n|num) to use --i|inorder.");
-            }
+            enforce(!preserveInputOrder ||
+                    sampleSize != 0 ||
+                    useBernoulliSampling ||
+                    useDistinctSampling,
+                    "Preserving input order (--i|inorder) is not compatible with full data set shuffling. Switch to random sampling with a sample size (--n|num) to use --i|inorder.");
 
             /* Compatibility mode checks:
              * - Random value printing implies compatibility-mode, otherwise user's
@@ -422,10 +407,8 @@ struct TsvSampleOptions
              *   superset of smaller probabilities. This would be confusing, so
              *   flag it as an error.
              */
-            if (compatibilityMode && useDistinctSampling)
-            {
-                throw new Exception("Distinct sampling (--k|key-fields --p|prob) does not support --compatibility-mode.");
-            }
+            enforce(!(compatibilityMode && useDistinctSampling),
+                    "Distinct sampling (--k|key-fields --p|prob) does not support --compatibility-mode.");
 
             if (printRandom || genRandomInorder) compatibilityMode = true;
 
@@ -809,13 +792,9 @@ if (isOutputRange!(OutputRange, char))
                         if (keyFieldsReordering.allFieldsFilled) break;
                     }
 
-                    if (!keyFieldsReordering.allFieldsFilled)
-                    {
-                        import std.format : format;
-                        throw new Exception(
+                    enforce(keyFieldsReordering.allFieldsFilled,
                             format("Not enough fields in line. File: %s, Line: %s",
                                    (filename == "-") ? "Standard Input" : filename, fileLineNum));
-                    }
 
                     foreach (count, key; keyFieldsReordering.outputFields.enumerate)
                     {
@@ -1779,7 +1758,6 @@ unittest
     import std.algorithm : equal, find, joiner, splitter;
     import std.array : appender;
     import std.file : rmdirRecurse;
-    import std.format : format;
     import std.path : buildPath;
     import std.range : repeat;
 
@@ -2001,7 +1979,6 @@ if (isOutputRange!(OutputRange, char))
     void testFormatValue(double value, string expected)
     {
         import std.array : appender;
-        import std.format : format;
 
         auto s = appender!string();
         s.formatRandomValue(value);
@@ -2051,7 +2028,6 @@ T getFieldValue(T, C)(const C[] line, size_t fieldIndex, C delim, string filenam
 if (isSomeChar!C)
 {
     import std.conv : ConvException, to;
-    import std.format : format;
     import tsv_utils.common.utils : getTsvFieldValue;
 
     T val;
@@ -2114,7 +2090,6 @@ version(unittest)
     void testTsvSample(string[] cmdArgs, string[][] expected)
     {
         import std.array : appender;
-        import std.format : format;
 
         assert(cmdArgs.length > 0, "[testTsvSample] cmdArgs must not be empty.");
 
@@ -2145,7 +2120,6 @@ unittest
 {
     import std.path : buildPath;
     import std.file : rmdirRecurse;
-    import std.format : format;
 
     auto testDir = makeUnittestTempDir("tsv_sample");
     scope(exit) testDir.rmdirRecurse;

--- a/tsv-sample/tests/gold/error_tests_1.txt
+++ b/tsv-sample/tests/gold/error_tests_1.txt
@@ -65,6 +65,8 @@ c-1	c-2	c-3	c-4
 
 ====[tsv-sample -H -p 0.5 --gen-random-inorder input4x50.tsv input4x15.tsv]====
 [tsv-sample] Error processing command line arguments: --gen-random-inorder and --p|prob can only be used together if --k|key-fields is also used.
+Use --gen-random-inorder alone to print probabilities for all lines.
+Use --p|prob and --print-random to print probabilities for lines satisfying the probability threshold.
 
 ====[tsv-sample -H --gen-random-inorder -d , --random-value-header abc,def input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: --randomValueHeader must be at least one character and not contain field delimiters or newlines.

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -21,6 +21,7 @@ License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
 module tsv_utils.tsv_select;   // Module name defaults to file name, but hyphens not allowed, so set it here.
 
 // Imports used by multiple routines. Others imports made in local context.
+import std.exception : enforce;
 import std.stdio;
 import std.typecons : tuple, Tuple;
 
@@ -200,10 +201,8 @@ struct TsvSelectOptions
              * Consistency checks and derivations.
              */
 
-            if (fields.length == 0 && excludedFieldsArg.length == 0)
-            {
-                throw new Exception("One of '--f|fields' or '--e|exclude' is required.");
-            }
+            enforce(fields.length != 0 || excludedFieldsArg.length != 0,
+                    "One of '--f|fields' or '--e|exclude' is required.");
 
             if (excludedFieldsArg.length > 0)
             {
@@ -212,10 +211,7 @@ struct TsvSelectOptions
                 {
                     foreach (f; fields)
                     {
-                        if (e == f)
-                        {
-                            throw new Exception("'--f|fields' and '--e|exclude' have overlapping fields.");
-                        }
+                        enforce(e != f, "'--f|fields' and '--e|exclude' have overlapping fields.");
                     }
                 }
 
@@ -233,11 +229,9 @@ struct TsvSelectOptions
                 size_t maxExcludedField = excludedFieldsArg.maxElement;
                 size_t maxAllowedExcludedField = 1024 * 1024;
 
-                if (maxExcludedField >= maxAllowedExcludedField)
-                {
-                    throw new Exception(format("Maximum allowed '--e|exclude' field number is %d.",
-                                               maxAllowedExcludedField));
-                }
+                enforce(maxExcludedField < maxAllowedExcludedField,
+                        format("Maximum allowed '--e|exclude' field number is %d.",
+                               maxAllowedExcludedField));
 
                 excludedFieldsTable.length = maxExcludedField + 1;          // Initialized to false
                 foreach (e; excludedFieldsArg) excludedFieldsTable[e] = true;
@@ -438,12 +432,9 @@ void tsvSelect(RestLocation rest)(const TsvSelectOptions cmdopt, const string[] 
             }
 
             // Finished with all fields in the line.
-            if (!fieldReordering.allFieldsFilled)
-            {
-                throw new Exception(
+            enforce(fieldReordering.allFieldsFilled,
                     format("Not enough fields in line. File: %s,  Line: %s",
                            (filename == "-") ? "Standard Input" : filename, lineNum));
-            }
 
             // Write the re-ordered line.
 


### PR DESCRIPTION
Code refactoring - Prefer `enforce` (from `std.exception`) over if-test plus `throw new Exception`. Minor, but reduces the volume of code, especially in command line argument validation.

Found one bug in the process - Field ranges ending in zero were not getting caught during command line argument checking. Only occurs in cases where zero is a valid value, and its for field ranges in reverse order so a rare case.

Added a couple missed unit tests, all in command line argument validation.