### PR TITLE
Experimental named field support in tsv-filter

### DIFF
--- a/common/src/tsv_utils/common/fieldlist.d
+++ b/common/src/tsv_utils/common/fieldlist.d
@@ -99,8 +99,8 @@
    and space characters are both terminator characters for field-lists. Some examples:
 
    $(CONSOLE
-       $ tsv-filter -H --le 3:100                        # Field 3 < 100
-       $ tsv-filter -H --le elapsed_time:100             # 'elapsed_time' field < 100
+       $ tsv-filter -H --lt 3:100                        # Field 3 < 100
+       $ tsv-filter -H --lt elapsed_time:100             # 'elapsed_time' field < 100
        $ tsv-summarize -H --quantile '*_time:0.25,0.75'  # 1st and 3rd quantiles for time fields
    )
 
@@ -134,7 +134,7 @@
 
        * [makeFieldListOptionHandler] - Returns a delegate that can be passed to
          std.getopt for parsing numeric field-lists. It was part of the original code
-         supporting numeric field-lists. Note that delegate passed to std.getopt do
+         supporting numeric field-lists. Note that delegates passed to std.getopt do
          not have access to the header line of the input file, so the technique can
          only be used for numeric field-lists.
     )
@@ -150,9 +150,9 @@
 
        * [isNumericFieldGroupWithHyphenFirstOrLast] - Determines if a field-group is a
          valid numeric field-group, except for having a leading or trailing hyphen.
-         This test is used to provide better error messages. A field-group that does
-         not pass either [isNumericFieldGroup] or
-         [isNumericFieldGroupWithHyphenFirstOrLast] is processed as named field-group.
+         This test is used to provide better error messages. A field-group that does not
+         pass either [isNumericFieldGroup] or [isNumericFieldGroupWithHyphenFirstOrLast]
+         is processed as a named field-group.
 
        * [namedFieldGroupToRegex] - Generates regexes for matching field names in a
          field group to field names in the header line. One regex is generated for a

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -364,17 +364,20 @@ bool ffRelDiffGT(const char[][] fields, size_t index1, size_t index2, double val
 /* CmdOptionHandler delegate signature - This is the call made to process the command
  * line option arguments after the header line has been read.
  */
-alias CmdOptionHandler1 = void delegate(ref FieldsPredicate[] tests, ref size_t maxFieldIndex);
-alias CmdOptionHandler = void delegate(ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields);
+alias CmdOptionHandler = void delegate(ref FieldsPredicate[] tests, ref size_t maxFieldIndex,
+                                       bool hasHeader, string[] headerFields);
 
 
-CmdOptionHandler1 makeFieldUnaryOptionHandler(FieldUnaryPredicate predicateFn, string option, string optionVal)
+CmdOptionHandler makeFieldUnaryOptionHandler(FieldUnaryPredicate predicateFn, string option, string optionVal)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldUnaryOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldUnaryOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal);
 }
 
 void fieldUnaryOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldUnaryPredicate fn, string option, string optionVal)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldUnaryPredicate fn, string option, string optionVal)
 {
     import std.range : enumerate;
     import std.typecons : Yes, No;
@@ -395,14 +398,16 @@ void fieldUnaryOptionHandler(
     }
 }
 
-
-CmdOptionHandler1 makeFieldVsNumberOptionHandler(FieldVsNumberPredicate predicateFn, string option, string optionVal)
+CmdOptionHandler makeFieldVsNumberOptionHandler(FieldVsNumberPredicate predicateFn, string option, string optionVal)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldVsNumberOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldVsNumberOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal);
 }
 
 void fieldVsNumberOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldVsNumberPredicate fn, string option, string optionVal)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldVsNumberPredicate fn, string option, string optionVal)
 {
     import std.range : enumerate;
     import std.typecons : Yes, No;
@@ -446,14 +451,16 @@ void fieldVsNumberOptionHandler(
     }
 }
 
-
-CmdOptionHandler1 makeFieldVsStringOptionHandler(FieldVsStringPredicate predicateFn, string option, string optionVal)
+CmdOptionHandler makeFieldVsStringOptionHandler(FieldVsStringPredicate predicateFn, string option, string optionVal)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldVsStringOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldVsStringOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal);
 }
 
 void fieldVsStringOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldVsStringPredicate fn, string option, string optionVal)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldVsStringPredicate fn, string option, string optionVal)
 {
     import std.range : enumerate;
     import std.typecons : Yes, No;
@@ -487,13 +494,16 @@ void fieldVsStringOptionHandler(
  * case-insensitive comparison will be done on lower-cased values.
  */
 
-CmdOptionHandler1 makeFieldVsIStringOptionHandler(FieldVsIStringPredicate predicateFn, string option, string optionVal)
+CmdOptionHandler makeFieldVsIStringOptionHandler(FieldVsIStringPredicate predicateFn, string option, string optionVal)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldVsIStringOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldVsIStringOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal);
 }
 
 void fieldVsIStringOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldVsIStringPredicate fn, string option, string optionVal)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldVsIStringPredicate fn, string option, string optionVal)
 {
     import std.range : enumerate;
     import std.typecons : Yes, No;
@@ -523,14 +533,16 @@ void fieldVsIStringOptionHandler(
     }
 }
 
-CmdOptionHandler1 makeFieldVsRegexOptionHandler(FieldVsRegexPredicate predicateFn, string option, string optionVal, bool caseSensitive)
+CmdOptionHandler makeFieldVsRegexOptionHandler(FieldVsRegexPredicate predicateFn, string option, string optionVal, bool caseSensitive)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldVsRegexOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal, caseSensitive);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldVsRegexOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal, caseSensitive);
 }
 
 void fieldVsRegexOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldVsRegexPredicate fn, string option, string optionVal,
-    bool caseSensitive)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldVsRegexPredicate fn, string option, string optionVal, bool caseSensitive)
 {
     import std.range : enumerate;
     import std.typecons : Yes, No;
@@ -572,13 +584,16 @@ void fieldVsRegexOptionHandler(
 }
 
 
-CmdOptionHandler1 makeFieldVsFieldOptionHandler(FieldVsFieldPredicate predicateFn, string option, string optionVal)
+CmdOptionHandler makeFieldVsFieldOptionHandler(FieldVsFieldPredicate predicateFn, string option, string optionVal)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldVsFieldOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldVsFieldOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal);
 }
 
 void fieldVsFieldOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldVsFieldPredicate fn, string option, string optionVal)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldVsFieldPredicate fn, string option, string optionVal)
 {
     immutable valSplit = findSplit(optionVal, ":");
 
@@ -613,13 +628,16 @@ void fieldVsFieldOptionHandler(
 }
 
 
-CmdOptionHandler1 makeFieldFieldNumOptionHandler(FieldFieldNumPredicate predicateFn, string option, string optionVal)
+CmdOptionHandler makeFieldFieldNumOptionHandler(FieldFieldNumPredicate predicateFn, string option, string optionVal)
 {
-    return (ref FieldsPredicate[] tests, ref size_t maxFieldIndex) => fieldFieldNumOptionHandler(tests, maxFieldIndex, predicateFn, option, optionVal);
+    return
+        (ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields)
+        => fieldFieldNumOptionHandler(tests, maxFieldIndex, hasHeader, headerFields, predicateFn, option, optionVal);
 }
 
 void fieldFieldNumOptionHandler(
-    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, FieldFieldNumPredicate fn, string option, string optionVal)
+    ref FieldsPredicate[] tests, ref size_t maxFieldIndex, bool hasHeader, string[] headerFields,
+    FieldFieldNumPredicate fn, string option, string optionVal)
 {
     size_t field1;
     size_t field2;
@@ -692,6 +710,8 @@ struct TsvFilterOptions
     auto processArgs (ref string[] cmdArgs)
     {
         import std.algorithm : each;
+        import std.array : split;
+        import std.conv: to;
         import std.getopt;
         import std.path : baseName, stripExtension;
         import tsv_utils.common.getopt_inorder;
@@ -703,7 +723,7 @@ struct TsvFilterOptions
          * option text from the option processing.
          */
 
-        CmdOptionHandler1[] cmdLineTestOptions;
+        CmdOptionHandler[] cmdLineTestOptions;
 
         void handlerFldEmpty(string option, string value)    { cmdLineTestOptions ~= makeFieldUnaryOptionHandler(&fldEmpty,    option, value); }
         void handlerFldNotEmpty(string option, string value) { cmdLineTestOptions ~= makeFieldUnaryOptionHandler(&fldNotEmpty, option, value); }
@@ -887,7 +907,11 @@ struct TsvFilterOptions
             ReadHeader readHeader = hasHeader ? Yes.readHeader : No.readHeader;
             inputSources = inputSourceRange(filepaths, readHeader);
 
-            cmdLineTestOptions.each!(dg => dg(tests, maxFieldIndex));
+            string[] headerFields;
+
+            if (hasHeader) headerFields = inputSources.front.header.split(delim).to!(string[]);
+
+            cmdLineTestOptions.each!(dg => dg(tests, maxFieldIndex, hasHeader, headerFields));
         }
         catch (Exception e)
         {

--- a/tsv-filter/tests/gold/basic_tests_1.txt
+++ b/tsv-filter/tests/gold/basic_tests_1.txt
@@ -1549,6 +1549,62 @@ Mixed13	a-雪	षिषिषि	abcd
 Mixed14	ab-雪	षिषिषिषि	abc
 Mixed15	abc-雪	षिषिषिषिषि	ab
 
+====[tsv-filter --header --char-len-ge Text*:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed5	a-雪	abcde	abcd
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+
+====[tsv-filter --header --byte-len-ge Text*:3 input_unicode.tsv]====
+Language	Text 1	Text 2	Text 3
+English	snow storm	soccer player	town hall
+Chinese (Simplified)	雪风暴	足球运动员	市政厅
+Chinese (Traditional)	雪風暴	足球運動員	市政廳
+French	Tempête de neige	joueur de foot	mairie
+Georgian	თოვლის ქარიშხალი	ფეხბურთის მოთამაშე	მუნიციპალიტეტი
+German	Schneesturm	Fußballspieler	Rathaus
+Greek	Χιονοθύελλα	ποδοσφαιριστής	Δημαρχείο
+Japanese	吹雪	サッカー選手	町役場
+Russian	Снежная буря	футболист	ратуша
+Spanish	Tormenta de nieve	jugador de fútbol	Ayuntamiento
+Vietnamese	Bão tuyết	cầuthủ bóng đá	Thị trấn
+Mixed5	a-雪	abcde	abcd
+Mixed6	ab-雪	雪	abc
+Mixed9	a-雪	雪雪雪雪	abcd
+Mixed10	ab-雪	雪雪雪雪雪	abc
+Mixed13	a-雪	षिषिषि	abcd
+Mixed14	ab-雪	षिषिषिषि	abc
+
+====[tsv-filter --header --char-len-lt 'Text\ 2:3' input_unicode.tsv] ====
+Language	Text 1	Text 2	Text 3
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+
+====[tsv-filter --header --char-len-lt 'Text\ 2 3' input_unicode.tsv] ====
+Language	Text 1	Text 2	Text 3
+Mixed1	a-雪	a	abcd
+Mixed2	ab-雪雪	ab	abc
+Mixed6	ab-雪	雪	abc
+Mixed7	abc-雪	雪雪	ab
+Mixed11	abc-雪	षि	ab
+Mixed12	abcd-雪	षिषि	a
+
 ====Field list tests===
 
 ====[tsv-filter --header --ge 4-6:25 input4.tsv]====
@@ -1889,6 +1945,221 @@ F1	F2	F3	F4
 -999.99	1000	x	x
 999.99	-1000	x	x
 
+====[tsv-filter --header --ff-eq F1:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+100	100	abc	AbC
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+100	100		AbC
+100	100	abc	
+
+====[tsv-filter --header --ff-ne F1:2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --ff-le F1:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --ff-lt F1:2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --ff-ge F1:2 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+100	100	abc	AbC
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+
+====[tsv-filter --header --ff-gt F1:2 input1.tsv]====
+F1	F2	F3	F4
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --ff-str-eq F3:4 input1.tsv]====
+F1	F2	F3	F4
+-1	-0.1	abc def	abc def
+100	101		
+
+====[tsv-filter --header --ff-str-ne F3:4 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --ff-istr-eq F3:4 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --ff-istr-ne F3:4 input1.tsv]====
+F1	F2	F3	F4
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+
+====[tsv-filter --header --ff-absdiff-le F1:F2:0.01 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+1000	999.999	 abc	3 space prefix
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+-999.99	-1000	x	x
+
+====[tsv-filter --header --ff-absdiff-le F2:F1:0.01 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+1000	999.999	 abc	3 space prefix
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+-999.99	-1000	x	x
+
+====[tsv-filter --header --ff-absdiff-le F1:F2:0.02 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+1000	999.999	 abc	3 space prefix
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+-999.99	-1000	x	x
+-999.98	-1000	x	x
+
+====[tsv-filter --header --ff-absdiff-gt F1:F2:0.01 input2.tsv]====
+F1	F2	F3	F4
+1000	1001	abc	3 no space
+1000	999	abc 	3 space suffix 
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.98	-1000	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
+====[tsv-filter --header --ff-absdiff-gt F1:F2:0.02 input2.tsv]====
+F1	F2	F3	F4
+1000	1001	abc	3 no space
+1000	999	abc 	3 space suffix 
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
+====[tsv-filter --header --ff-reldiff-le F1:F2:1e-5 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+1000	999.999	 abc	3 space prefix
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+
+====[tsv-filter --header --ff-reldiff-le F1:F2:1e-6 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+1000	999.9999	 a 	3 space prefix&suffix 
+
+====[tsv-filter --header --ff-reldiff-le F1:F2:1e-7 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+
+====[tsv-filter --header --ff-reldiff-gt F1:F2:1e-5 input2.tsv]====
+F1	F2	F3	F4
+1000	1001	abc	3 no space
+1000	999	abc 	3 space suffix 
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.99	-1000	x	x
+-999.98	-1000	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
+====[tsv-filter --header --ff-reldiff-gt F1:F2:1e-6 input2.tsv]====
+F1	F2	F3	F4
+1000	1001	abc	3 no space
+1000	999.999	 abc	3 space prefix
+1000	999	abc 	3 space suffix 
+999.999	1000	x	x
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.99	-1000	x	x
+-999.98	-1000	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
+====[tsv-filter --header --ff-reldiff-gt F1:F2:1e-7 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.001	  	3 2-spaces
+1000	1001	abc	3 no space
+1000	999.999	 abc	3 space prefix
+1000	999	abc 	3 space suffix 
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.99	-1000	x	x
+-999.98	-1000	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
 ====No header===
 
 ====[tsv-filter --str-in-fld 2:2 input1.tsv]====
@@ -1899,6 +2170,71 @@ F1	F2	F3	F4
 
 ====[tsv-filter --str-eq 3:a input1.tsv]====
 1	1.0	a	A
+
+====[tsv-filter --eq 2:1 input1_noheader.tsv]====
+1	1.0	a	A
+
+====[tsv-filter --le 2:101 input1_noheader.tsv]====
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+
+====[tsv-filter --lt 2:101 input1_noheader.tsv]====
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+
+====[tsv-filter --empty 3 input1_noheader.tsv]====
+100	100		AbC
+100	101		
+
+====[tsv-filter --eq 1:100 --empty 3 input1_noheader.tsv]====
+100	100		AbC
+100	101		
+
+====[tsv-filter --str-eq 4:ABC input1_noheader.tsv]====
+10	10.1	abc	ABC
+
+====[tsv-filter --str-eq 3:ß input1_noheader.tsv]====
+-2	-2.0	ß	ss
+
+====[tsv-filter --regex 4:Às*C input1_noheader.tsv]====
+0.0	100.0	àßc	ÀssC
+
+====[tsv-filter --regex 4:^A[b|B]C$ input1_noheader.tsv]====
+10	10.1	abc	ABC
+100	100	abc	AbC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --ff-eq 1:2 input1_noheader.tsv]====
+1	1.0	a	A
+2	2.	b	B
+100	100	abc	AbC
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+100	100		AbC
+100	100	abc	
 
 ====OR clause tests===
 

--- a/tsv-filter/tests/gold/basic_tests_1.txt
+++ b/tsv-filter/tests/gold/basic_tests_1.txt
@@ -96,6 +96,91 @@ F1	F2	F3	F4
 100	102	abc	AbC
 100	103	abc	AbC
 
+====[tsv-filter -H --eq F2:1 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+
+====[tsv-filter -H --eq F2:1. input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+
+====[tsv-filter -H --eq F2:2 input1.tsv]====
+F1	F2	F3	F4
+2	2.	b	B
+
+====[tsv-filter -H --eq F2:-100 input1.tsv]====
+F1	F2	F3	F4
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter -H --eq F1:0 --eq F2:100 input1.tsv]====
+F1	F2	F3	F4
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+
+====[tsv-filter -H --eq F1:0 --ne F2:100 input1.tsv]====
+F1	F2	F3	F4
+0	0.0	z	AzB
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter -H --le F2:101 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+
+====[tsv-filter -H --lt F2:101 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+
+====[tsv-filter -H --ge F2:101 input1.tsv]====
+F1	F2	F3	F4
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter -H --gt F2:101 input1.tsv]====
+F1	F2	F3	F4
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter -H --ne F2:101 input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
 ====Empty and blank field tests===
 
 ====[tsv-filter --header --empty 3 input1.tsv]====
@@ -209,9 +294,67 @@ last line
 
 
 
+====[tsv-filter --header --empty F3 input1.tsv]====
+F1	F2	F3	F4
+100	100		AbC
+100	101		
+
+====[tsv-filter --header --eq F1:100 --empty F4 input1.tsv]====
+F1	F2	F3	F4
+100	100	abc	
+100	101		
+
+====[tsv-filter --header --eq F1:100 --not-empty F4 input1.tsv]====
+F1	F2	F3	F4
+100	100	abc	AbC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --not-empty F3 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+1000	1001	abc	3 no space
+1000	999.999	 abc	3 space prefix
+1000	999	abc 	3 space suffix 
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.99	-1000	x	x
+-999.98	-1000	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
+====[tsv-filter --header --blank F3 input2.tsv]====
+F1	F2	F3	F4
+1000	1000.0		3 empty
+1000	1000.0	 	3 1-space
+1000	1000.001	  	3 2-spaces
+
+====[tsv-filter --header --not-blank F3 input2.tsv]====
+F1	F2	F3	F4
+1000	1001	abc	3 no space
+1000	999.999	 abc	3 space prefix
+1000	999	abc 	3 space suffix 
+1000	999.9999	 a 	3 space prefix&suffix 
+999.999	1000	x	x
+999.999	1000.999	x	x
+1000	1001.1	x	x
+-999.99	-1000	x	x
+-999.98	-1000	x	x
+-999.99	1000	x	x
+999.99	-1000	x	x
+
 ====Short circuit tests===
 
 ====[tsv-filter --header --not-blank 1 --str-ne 1:none --eq 1:100 input_num_or_empty.tsv]====
+f1	f2	f3
+100	21	31
+100	24	33
+
+====[tsv-filter --header --not-blank f1 --str-ne 1:none --eq 1:100 input_num_or_empty.tsv]====
 f1	f2	f3
 100	21	31
 100	24	33
@@ -303,6 +446,33 @@ f1	f2
 13	.19
 14	-.20
 16	8E-17
+
+====[tsv-filter -H --is-nan f2 input_numeric_tests.tsv]====
+f1	f2
+1	nan
+2	NaN
+3	NAN
+
+====[tsv-filter -H --is-infinity f2 input_numeric_tests.tsv]====
+f1	f2
+4	inf
+5	-inf
+6	INF
+
+====[tsv-filter -H --is-numeric f2 --le f2:10 input_numeric_tests.tsv]====
+f1	f2
+5	-inf
+10	-33.5
+13	.19
+14	-.20
+16	8E-17
+
+====[tsv-filter -H --is-finite f2 --gt f2:10 input_numeric_tests.tsv]====
+f1	f2
+9	23
+11	42.5
+12	+45
+15	9e+02
 
 ====String tests===
 
@@ -560,11 +730,187 @@ F1	F2	F3	F4
 100	102	abc	AbC
 100	103	abc	AbC
 
+====[tsv-filter --header --str-eq F3:abc input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --str-eq F4:ABC input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+
+====[tsv-filter --header --str-eq F3:ß input1.tsv]====
+F1	F2	F3	F4
+-2	-2.0	ß	ss
+
+====[tsv-filter --header --str-eq F3:àßc input1.tsv]====
+F1	F2	F3	F4
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --str-ne F3:b input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --str-le F3:b input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --str-lt F3:b input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --str-ge F3:b input1.tsv]====
+F1	F2	F3	F4
+2	2.	b	B
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --str-gt F3:b input1.tsv]====
+F1	F2	F3	F4
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --str-in-fld F3:b input1.tsv]====
+F1	F2	F3	F4
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --istr-eq F4:aBc input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --istr-eq F3:ÀßC input1.tsv]====
+F1	F2	F3	F4
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --istr-ne F4:ÀSSC input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --istr-in-fld F3:b input1.tsv]====
+F1	F2	F3	F4
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+100	100	abc	
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --istr-in-fld F4:àsSC input1.tsv]====
+F1	F2	F3	F4
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --istr-not-in-fld F4:Sc input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter --header --istr-not-in-fld F4:àsSC input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
 ====[tsv-filter --header --str-in-fld '3: ' input1.tsv]====
 F1	F2	F3	F4
 -1	-0.1	abc def	abc def
 
 ====[tsv-filter --header --str-in-fld '4:abc def' input1.tsv]====
+F1	F2	F3	F4
+-1	-0.1	abc def	abc def
+
+====[tsv-filter --header --str-in-fld 'F3: ' input1.tsv]====
+F1	F2	F3	F4
+-1	-0.1	abc def	abc def
+
+====[tsv-filter --header --str-in-fld 'F4:abc def' input1.tsv]====
 F1	F2	F3	F4
 -1	-0.1	abc def	abc def
 
@@ -699,6 +1045,52 @@ F1	F2	F3	F4
 100	101		
 
 ====[tsv-filter --header --not-regex 4:z|d input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter -H --regex F4:Às*C input1.tsv]====
+F1	F2	F3	F4
+0.0	100.0	àßc	ÀssC
+
+====[tsv-filter -H --regex F4:^A[b|B]C$ input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+100	100	abc	AbC
+100	100		AbC
+100	102	abc	AbC
+100	103	abc	AbC
+
+====[tsv-filter -H --regex F1:^\-[0-9]+ input1.tsv]====
+F1	F2	F3	F4
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter -H --not-iregex F4:abc input1.tsv]====
+F1	F2	F3	F4
+1	1.0	a	A
+2	2.	b	B
+0	0.0	z	AzB
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100	abc	
+100	101		
+
+====[tsv-filter -H --not-regex F4:z|d input1.tsv]====
 F1	F2	F3	F4
 1	1.0	a	A
 2	2.	b	B

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -238,6 +238,46 @@ Error [tsv-filter]: Could not process line or field: no digits seen for input "F
   File: input1.tsv Line: 1
   Is this a header line? Use --header to skip.
 
+====[tsv-filter --ne abc:15 input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--ne abc:15]. Non-numeric field group: 'abc'. Use '--H|header' when using named field groups.
+   Expected: '--ne <field>:<val>' or '--ne <field-list>:<val> where <val> is a number.
+
+====[tsv-filter --le 1: input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--le 1:]. No value after field list.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
+
+====[tsv-filter --le 1 input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--le 1]. No value after field list.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
+
+====[tsv-filter --le :10 input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--le :10]. Empty field list: ':10'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
+
+====[tsv-filter --le : input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--le :]. Empty field list: ':'.
+   Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
+
+====[tsv-filter --empty 23g input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--empty 23g]. Non-numeric field group: '23g'. Use '--H|header' when using named field groups.
+   Expected: '--empty <field>' or '--empty <field-list>'.
+
+====[tsv-filter --empty 0 input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: Invalid option: [--empty 0]. Field numbers must be greater than zero: '0'.
+   Expected: '--empty <field>' or '--empty <field-list>'.
+
+====[tsv-filter --str-gt 0:abc input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: [--str-gt 0:abc]. Field numbers must be greater than zero: '0'.
+   Expected: '--str-gt <field>:<val>' or '--str-gt <field-list>:<val>' where <val> is a string.
+
+====[tsv-filter --str-eq :def input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: [--str-eq :def]. Empty field list: ':def'.
+   Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
+
+====[tsv-filter --regex :^A[b|B]C$ input1_noheader.tsv]====
+[tsv-filter] Error processing command line arguments: [--regex :^A[b|B]C$]. Empty field list: ':^A[b|B]C$'.
+   Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
+
 ====[cat input_3x2.tsv | tsv-filter --ge 2:23]====
 Error [tsv-filter]: Could not process line or field: no digits seen for input "f2".
   File: Standard Input Line: 1

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -5,18 +5,18 @@ Error test set 1
 [tsv-filter] Error processing command line arguments: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-filter --header --gt 0:10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--gt 0:10]. Field numbers must be greater than zero: '0'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--gt 0:10]. Field numbers must be greater than zero: '0'.
    Expected: '--gt <field>:<val>' or '--gt <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --lt -1:10 input1.tsv]====
 [tsv-filter] Error processing command line arguments: Missing value for argument --lt.
 
 ====[tsv-filter --header --ne abc:15 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ne abc:15]. Unexpected 'a' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: Invalid option: [--ne abc:15]. Field not found in header: 'abc'.
    Expected: '--ne <field>:<val>' or '--ne <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --eq 2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--eq 2:def'. no digits seen for input "def".
+[tsv-filter] Error processing command line arguments: Invalid option: [--eq 2:def]. no digits seen for input "def".
    Expected: '--eq <field>:<val>' or '--eq <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1000:10 input1.tsv]====
@@ -24,27 +24,27 @@ Error [tsv-filter]: Not enough fields in line. File: input1.tsv, Line: 2
 F1	F2	F3	F4
 
 ====[tsv-filter --header --le 1: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--le 1:'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--le 1:]. No value after field list.
    Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--le 1'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--le 1]. No value after field list.
    Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le :10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--le :10]. Empty field number.
+[tsv-filter] Error processing command line arguments: Invalid option: [--le :10]. Empty field list: ':10'.
    Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--le :'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--le :]. Empty field list: ':'.
    Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --empty 23g input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--empty 23g]. Unexpected 'g' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: Invalid option: [--empty 23g]. Field not found in header: '23g'.
    Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --empty 0 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--empty 0]. Field numbers must be greater than zero: '0'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--empty 0]. Field numbers must be greater than zero: '0'.
    Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --str-gt 0:abc input1.tsv]====
@@ -55,11 +55,11 @@ F1	F2	F3	F4
 [tsv-filter] Error processing command line arguments: Missing value for argument --str-lt.
 
 ====[tsv-filter --header --str-ne abc:a22 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--str-ne abc:a22]. Unexpected 'a' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: [--str-ne abc:a22]. Field not found in header: 'abc'.
    Expected: '--str-ne <field>:<val>' or '--str-ne <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--str-eq 2.2:def]. Unexpected '.' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: [--str-eq 2.2:def]. Field not found in header: '2.2'.
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 0:def input1.tsv]====
@@ -67,19 +67,19 @@ F1	F2	F3	F4
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq :def input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--str-eq :def]. Empty field number.
+[tsv-filter] Error processing command line arguments: [--str-eq :def]. Empty field list: ':def'.
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq 2:'.
+[tsv-filter] Error processing command line arguments: [--str-eq 2:]. No value after field list.
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--str-eq :'.
+[tsv-filter] Error processing command line arguments: [--str-eq :]. Empty field list: ':'.
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--istr-eq 2.2:def]. Unexpected '.' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: [--istr-eq 2.2:def]. Field not found in header: '2.2'.
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 0:def input1.tsv]====
@@ -87,19 +87,19 @@ F1	F2	F3	F4
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq :def input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--istr-eq :def]. Empty field number.
+[tsv-filter] Error processing command line arguments: [--istr-eq :def]. Empty field list: ':def'.
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq 2:'.
+[tsv-filter] Error processing command line arguments: [--istr-eq 2:]. No value after field list.
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--istr-eq :'.
+[tsv-filter] Error processing command line arguments: [--istr-eq :]. Empty field list: ':'.
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --regex z:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--regex z:^A[b|B]C$]. Unexpected 'z' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: [--regex z:^A[b|B]C$]. Field not found in header: 'z'.
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 0:^A[b|B]C$ input1.tsv]====
@@ -107,19 +107,19 @@ F1	F2	F3	F4
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex :^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--regex :^A[b|B]C$]. Empty field number.
+[tsv-filter] Error processing command line arguments: [--regex :^A[b|B]C$]. Empty field list: ':^A[b|B]C$'.
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 3: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex 3:'.
+[tsv-filter] Error processing command line arguments: [--regex 3:]. No value after field list.
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--regex :'.
+[tsv-filter] Error processing command line arguments: [--regex :]. Empty field list: ':'.
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex a:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--iregex a:^A[b|B]C$]. Unexpected 'a' when converting from type string to type long
+[tsv-filter] Error processing command line arguments: [--iregex a:^A[b|B]C$]. Field not found in header: 'a'.
    Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 0:^A[b|B]C$ input1.tsv]====
@@ -127,91 +127,111 @@ F1	F2	F3	F4
    Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex :^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--iregex :^A[b|B]C$]. Empty field number.
+[tsv-filter] Error processing command line arguments: [--iregex :^A[b|B]C$]. Empty field list: ':^A[b|B]C$'.
    Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 3: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex 3:'.
+[tsv-filter] Error processing command line arguments: [--iregex 3:]. No value after field list.
    Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--iregex :'.
+[tsv-filter] Error processing command line arguments: [--iregex :]. Empty field list: ':'.
    Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 4:abc(d|e input1.tsv 2>&1 | head -n 1]====
-[tsv-filter] Error processing command line arguments: Invalid regular expression: '--regex 4:abc(d|e'. no matching ')'
+[tsv-filter] Error processing command line arguments: [--regex 4:abc(d|e]. Invalid regular expression: no matching ')'
 
 ====[tsv-filter --header --iregex 4:abc(d|e input1.tsv 2>&1 | head -n 1]====
-[tsv-filter] Error processing command line arguments: Invalid regular expression: '--iregex 4:abc(d|e'. no matching ')'
+[tsv-filter] Error processing command line arguments: [--iregex 4:abc(d|e]. Invalid regular expression: no matching ')'
 
 ====[tsv-filter --header --not-regex 4:abc(d|e input1.tsv 2>&1 | head -n 1]====
-[tsv-filter] Error processing command line arguments: Invalid regular expression: '--not-regex 4:abc(d|e'. no matching ')'
+[tsv-filter] Error processing command line arguments: [--not-regex 4:abc(d|e]. Invalid regular expression: no matching ')'
 
 ====[tsv-filter --header --not-iregex 4:abc(d|e input1.tsv 2>&1 | head -n 1]====
-[tsv-filter] Error processing command line arguments: Invalid regular expression: '--not-iregex 4:abc(d|e'. no matching ')'
+[tsv-filter] Error processing command line arguments: [--not-iregex 4:abc(d|e]. Invalid regular expression: no matching ')'
 
 ====[tsv-filter --header --ff-gt 0:1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-gt 0:1'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--ff-gt 0:1]. Field numbers must be greater than zero: '0'.
+   Expected: '--ff-gt <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-gt 1:0 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-gt 1:0'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--ff-gt 1:0]. Field numbers must be greater than zero: '0'.
+   Expected: '--ff-gt <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-lt -1:2 input1.tsv]====
 [tsv-filter] Error processing command line arguments: Missing value for argument --ff-lt.
 
 ====[tsv-filter --header --ff-lt 1:1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-lt 1:1'. Field1 and field2 must be different fields
+[tsv-filter] Error processing command line arguments: [--ff-lt 1:1]. Invalid option: '--ff-lt 1:1'. Field1 and field2 must be different fields
+   Expected: '--ff-lt <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-ne abc:3 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-ne abc:3'. Expected: '--ff-ne <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-ne abc:3]. Field not found in header: 'abc'.
+   Expected: '--ff-ne <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-eq 2.2:4 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-eq 2.2:4'. Expected: '--ff-eq <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-eq 2.2:4]. Field not found in header: '2.2'.
+   Expected: '--ff-eq <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le 2:3.1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-le 2:3.1'. Expected: '--ff-le <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-le 2:3.1]. Non-numeric field group: '3.1'. Use '--H|header' when using named field groups.
+   Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le 2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-le 2:'. Expected: '--ff-le <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-le 2:].  Second field argument is empty.
+   Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le :10 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-le :10'. Expected: '--ff-le <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-le :10]. Empty field list: ':10'.
+   Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le : input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-le :'. Expected: '--ff-le <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-le :]. Empty field list: ':'.
+   Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-str-ne abc:3 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-str-ne abc:3'. Expected: '--ff-str-ne <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-str-ne abc:3]. Field not found in header: 'abc'.
+   Expected: '--ff-str-ne <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-str-eq 2.2:4 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-str-eq 2.2:4'. Expected: '--ff-str-eq <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-str-eq 2.2:4]. Field not found in header: '2.2'.
+   Expected: '--ff-str-eq <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:2:g input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-absdiff-le 1:2:g'. Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:2:g]. no digits seen for input "g".
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:2: input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-absdiff-le 1:2:'. Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:2:]. Number argument is empty.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:0:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-absdiff-le 1:0:0.5'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:0:0.5]. Field numbers must be greater than zero: '0'.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:1:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-absdiff-le 1:1:0.5'. Field1 and field2 must be different fields
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:1:0.5]. Invalid option: '--ff-absdiff-le 1:1:0.5'. Field1 and field2 must be different fields
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:g:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-absdiff-le 1:g:0.5'. Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:g:0.5]. Field not found in header: 'g'.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1::0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-absdiff-le 1::0.5'. Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1::0.5]. Empty field list: ':0.5'.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 0:2:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: '--ff-absdiff-le 0:2:0.5'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 0:2:0.5]. Field numbers must be greater than zero: '0'.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le g:2:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-absdiff-le g:2:0.5'. Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le g:2:0.5]. Field not found in header: 'g'.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le :2:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-absdiff-le :2:0.5'. Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le :2:0.5]. Empty field list: ':2:0.5'.
+   Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --eq 2:1 input1.tsv]====
 Error [tsv-filter]: Could not process line or field: no digits seen for input "F2".

--- a/tsv-filter/tests/input1_noheader.tsv
+++ b/tsv-filter/tests/input1_noheader.tsv
@@ -1,0 +1,15 @@
+1	1.0	a	A
+2	2.	b	B
+10	10.1	abc	ABC
+100	100	abc	AbC
+0	0.0	z	AzB
+-1	-0.1	abc def	abc def
+-2	-2.0	ß	ss
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+-0.0	-100.0	àßc	ÀSSC
+100	100		AbC
+100	100	abc	
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -251,6 +251,16 @@ runtest ${prog} "--header --char-len-lt 1:3 input_unicode.tsv" ${basic_tests_1}
 runtest ${prog} "--header --char-len-le 2:2 input_unicode.tsv" ${basic_tests_1}
 runtest ${prog} "--header --char-len-ge 4:2 input_unicode.tsv" ${basic_tests_1}
 
+# Character and byte length tests: Named fields
+runtest ${prog} "--header --char-len-ge Text*:3 input_unicode.tsv" ${basic_tests_1}
+runtest ${prog} "--header --byte-len-ge Text*:3 input_unicode.tsv" ${basic_tests_1}
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-filter --header --char-len-lt 'Text\ 2:3' input_unicode.tsv] ====" >> ${basic_tests_1}
+${prog} --header --char-len-lt 'Text\ 2:3' input_unicode.tsv >> ${basic_tests_1}
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-filter --header --char-len-lt 'Text\ 2 3' input_unicode.tsv] ====" >> ${basic_tests_1}
+${prog} --header --char-len-lt 'Text\ 2 3' input_unicode.tsv >> ${basic_tests_1}
+
 # Field List tests
 echo "" >> ${basic_tests_1}; echo "====Field list tests===" >> ${basic_tests_1}
 runtest ${prog} "--header --ge 4-6:25 input4.tsv" ${basic_tests_1}
@@ -301,10 +311,46 @@ runtest ${prog} "--header --ff-reldiff-gt 1:2:1e-5 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-reldiff-gt 1:2:1e-6 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-reldiff-gt 1:2:1e-7 input2.tsv" ${basic_tests_1}
 
+# Field vs Field tests: named field versions
+runtest ${prog} "--header --ff-eq F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-ne F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-le F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-lt F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-ge F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-gt F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-str-eq F3:4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-str-ne F3:4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-istr-eq F3:4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-istr-ne F3:4 input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --ff-absdiff-le F1:F2:0.01 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-absdiff-le F2:F1:0.01 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-absdiff-le F1:F2:0.02 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-absdiff-gt F1:F2:0.01 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-absdiff-gt F1:F2:0.02 input2.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --ff-reldiff-le F1:F2:1e-5 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-reldiff-le F1:F2:1e-6 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-reldiff-le F1:F2:1e-7 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-reldiff-gt F1:F2:1e-5 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-reldiff-gt F1:F2:1e-6 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-reldiff-gt F1:F2:1e-7 input2.tsv" ${basic_tests_1}
+
 # No Header tests
 echo "" >> ${basic_tests_1}; echo "====No header===" >> ${basic_tests_1}
 runtest ${prog} "--str-in-fld 2:2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--str-eq 3:a input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--eq 2:1 input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--le 2:101 input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--lt 2:101 input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--empty 3 input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--eq 1:100 --empty 3 input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--str-eq 4:ABC input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--str-eq 3:ß input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--regex 4:Às*C input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--regex 4:^A[b|B]C$ input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--ff-eq 1:2 input1_noheader.tsv" ${basic_tests_1}
 
 # OR clause tests
 echo "" >> ${basic_tests_1}; echo "====OR clause tests===" >> ${basic_tests_1}
@@ -486,6 +532,18 @@ runtest ${prog} "--header --ff-absdiff-le 0:2:0.5 input1.tsv" ${error_tests_1}
 runtest ${prog} "--header --ff-absdiff-le g:2:0.5 input1.tsv" ${error_tests_1}
 runtest ${prog} "--header --ff-absdiff-le :2:0.5 input1.tsv" ${error_tests_1}
 runtest ${prog} "--eq 2:1 input1.tsv" ${error_tests_1}
+
+# No header versions targeting cases affected by named fields
+runtest ${prog} "--ne abc:15 input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--le 1: input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--le 1 input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--le :10 input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--le : input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--empty 23g input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--empty 0 input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--str-gt 0:abc input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--str-eq :def input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--regex :^A[b|B]C$ input1_noheader.tsv" ${error_tests_1}
 
 # Standard input tests
 echo "" >> ${error_tests_1}; echo "====[cat input_3x2.tsv | tsv-filter --ge 2:23]====" >> ${error_tests_1}

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -40,6 +40,19 @@ runtest ${prog} "--header --ge 2:101 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --gt 2:101 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ne 2:101 input1.tsv" ${basic_tests_1}
 
+# Numeric field tests: Named field versions
+runtest ${prog} "-H --eq F2:1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --eq F2:1. input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --eq F2:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --eq F2:-100 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --eq F1:0 --eq F2:100 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --eq F1:0 --ne F2:100 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --le F2:101 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --lt F2:101 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --ge F2:101 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --gt F2:101 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --ne F2:101 input1.tsv" ${basic_tests_1}
+
 # Empty and blank field tests
 echo "" >> ${basic_tests_1}; echo "====Empty and blank field tests===" >> ${basic_tests_1}
 
@@ -59,9 +72,18 @@ runtest ${prog} "--not-empty 1 input_onefield.txt" ${basic_tests_1}
 runtest ${prog} "--blank 1 input_onefield.txt" ${basic_tests_1}
 runtest ${prog} "--empty 1 input_onefield.txt" ${basic_tests_1}
 
+# Empty and blank fields: Named field versions
+runtest ${prog} "--header --empty F3 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --eq F1:100 --empty F4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --eq F1:100 --not-empty F4 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --not-empty F3 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --blank F3 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header --not-blank F3 input2.tsv" ${basic_tests_1}
+
 # Short circuit by order. Ensure not blank or "none" before numeric test.
 echo "" >> ${basic_tests_1}; echo "====Short circuit tests===" >> ${basic_tests_1}
 runtest ${prog} "--header --not-blank 1 --str-ne 1:none --eq 1:100 input_num_or_empty.tsv" ${basic_tests_1}
+runtest ${prog} "--header --not-blank f1 --str-ne 1:none --eq 1:100 input_num_or_empty.tsv" ${basic_tests_1}
 runtest ${prog} "--header --or --blank 1 --str-eq 1:none --eq 1:100 input_num_or_empty.tsv" ${basic_tests_1}
 runtest ${prog} "--header --invert --not-blank 1 --str-ne 1:none --eq 1:100 input_num_or_empty.tsv" ${basic_tests_1}
 runtest ${prog} "--header --invert --or --blank 1 --str-eq 1:none --eq 1:100 input_num_or_empty.tsv" ${basic_tests_1}
@@ -75,6 +97,11 @@ runtest ${prog} "-H --is-numeric 2 --gt 2:10 input_numeric_tests.tsv" ${basic_te
 runtest ${prog} "-H --is-numeric 2 --le 2:10 input_numeric_tests.tsv" ${basic_tests_1}
 runtest ${prog} "-H --is-finite 2 --gt 2:10 input_numeric_tests.tsv" ${basic_tests_1}
 runtest ${prog} "-H --is-finite 2 --le 2:10 input_numeric_tests.tsv" ${basic_tests_1}
+runtest ${prog} "-H --is-nan f2 input_numeric_tests.tsv" ${basic_tests_1}
+runtest ${prog} "-H --is-infinity f2 input_numeric_tests.tsv" ${basic_tests_1}
+runtest ${prog} "-H --is-numeric f2 --le f2:10 input_numeric_tests.tsv" ${basic_tests_1}
+runtest ${prog} "-H --is-finite f2 --gt f2:10 input_numeric_tests.tsv" ${basic_tests_1}
+
 
 # String field tests
 echo "" >> ${basic_tests_1}; echo "====String tests===" >> ${basic_tests_1}
@@ -112,12 +139,39 @@ runtest ${prog} "--header --istr-not-in-fld 3:B input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --istr-not-in-fld 4:Sc input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --istr-not-in-fld 4:àsSC input1.tsv" ${basic_tests_1}
 
+# String field tests: Named fields
+runtest ${prog} "--header --str-eq F3:abc input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-eq F4:ABC input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-eq F3:ß input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-eq F3:àßc input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-ne F3:b input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-le F3:b input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-lt F3:b input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-ge F3:b input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-gt F3:b input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --str-in-fld F3:b input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --istr-eq F4:aBc input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --istr-eq F3:ÀßC input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --istr-ne F4:ÀSSC input1.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --istr-in-fld F3:b input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --istr-in-fld F4:àsSC input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --istr-not-in-fld F4:Sc input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --istr-not-in-fld F4:àsSC input1.tsv" ${basic_tests_1}
+
 ## Can't pass single quotes to runtest
 echo "" >> ${basic_tests_1}; echo "====[tsv-filter --header --str-in-fld '3: ' input1.tsv]====" >> ${basic_tests_1}
 ${prog} --header --str-in-fld '3: ' input1.tsv >> ${basic_tests_1} 2>&1
 
 echo "" >> ${basic_tests_1}; echo "====[tsv-filter --header --str-in-fld '4:abc def' input1.tsv]====" >> ${basic_tests_1}
 ${prog} --header --str-in-fld '4:abc def' input1.tsv >> ${basic_tests_1} 2>&1
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-filter --header --str-in-fld 'F3: ' input1.tsv]====" >> ${basic_tests_1}
+${prog} --header --str-in-fld 'F3: ' input1.tsv >> ${basic_tests_1} 2>&1
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-filter --header --str-in-fld 'F4:abc def' input1.tsv]====" >> ${basic_tests_1}
+${prog} --header --str-in-fld 'F4:abc def' input1.tsv >> ${basic_tests_1} 2>&1
 
 runtest ${prog} "--header --str-in-fld 3:ß input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --str-not-in-fld 3:b input1.tsv" ${basic_tests_1}
@@ -143,6 +197,13 @@ runtest ${prog} "--header --iregex 4:ß input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --regex 1:^\-[0-9]+ input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --not-iregex 4:abc input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --not-regex 4:z|d input1.tsv" ${basic_tests_1}
+
+# Regular expression tests: named fields
+runtest ${prog} "-H --regex F4:Às*C input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --regex F4:^A[b|B]C$ input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --regex F1:^\-[0-9]+ input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --not-iregex F4:abc input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H --not-regex F4:z|d input1.tsv" ${basic_tests_1}
 
 echo "" >> ${basic_tests_1}; echo "====Character and Byte Length tests===" >> ${basic_tests_1}
 


### PR DESCRIPTION
This PR is a follow-on to PR #284. It adds named field support to `tsv-filter`. It works the same way as the support added to `tsv-select`, see PR #284 for more info.

Named field support is backward compatible with numeric fields. As with `tsv-select`, this support is not documented yet, even in the help text. Documentation will be added after named field support is added to all tools and a release performed.

This is a step towards enhancement request #25.