### PR TITLE
Experimental named field support in tsv-summarize

### DIFF
--- a/common/src/tsv_utils/common/fieldlist.d
+++ b/common/src/tsv_utils/common/fieldlist.d
@@ -335,10 +335,10 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
                         string hintMsg = "Not specifying a range? Backslash escape any hyphens in the field name.";
 
                         enforce(f0.length > 0,
-                                format("First field in range not found in header. Range: '%s'.\n%s",
+                                format("First field in range not found in file header. Range: '%s'.\n%s",
                                        fieldGroup, hintMsg));
                         enforce(f1.length > 0,
-                                format("Second field in range not found in header. Range: '%s'.\n%s",
+                                format("Second field in range not found in file header. Range: '%s'.\n%s",
                                        fieldGroup, hintMsg));
                         enforce(f0.length == 1,
                                 format("First field in range matches multiple header fields. Range: '%s'.\n%s",
@@ -361,7 +361,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
                             namedFieldRegexMatches!(T, convertToZero)(_headerFields, fieldGroupRegex[0]);
 
                         enforce(!_namedFieldMatches.empty,
-                                format("Field not found in header: '%s'.", fieldGroup));
+                                format("Field not found in file header: '%s'.", fieldGroup));
                     }
                 }
             }
@@ -573,7 +573,7 @@ if (isIntegral!T && (!allowZero || !convertToZero || !isUnsigned!T))
         catch (Exception e)
         {
             wasCaught = true;
-            assert(e.msg == "[--f|fields] Field not found in header: 'XYZ'.");
+            assert(e.msg == "[--f|fields] Field not found in file header: 'XYZ'.");
         }
         finally assert(wasCaught);
     }

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -12,7 +12,7 @@ Error test set 1
 [tsv-filter] Error processing command line arguments: Missing value for argument --lt.
 
 ====[tsv-filter --header --ne abc:15 input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: [--ne abc:15]. Field not found in header: 'abc'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--ne abc:15]. Field not found in file header: 'abc'.
    Expected: '--ne <field>:<val>' or '--ne <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --eq 2:def input1.tsv]====
@@ -40,7 +40,7 @@ F1	F2	F3	F4
    Expected: '--le <field>:<val>' or '--le <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --empty 23g input1.tsv]====
-[tsv-filter] Error processing command line arguments: Invalid option: [--empty 23g]. Field not found in header: '23g'.
+[tsv-filter] Error processing command line arguments: Invalid option: [--empty 23g]. Field not found in file header: '23g'.
    Expected: '--empty <field>' or '--empty <field-list>'.
 
 ====[tsv-filter --header --empty 0 input1.tsv]====
@@ -55,11 +55,11 @@ F1	F2	F3	F4
 [tsv-filter] Error processing command line arguments: Missing value for argument --str-lt.
 
 ====[tsv-filter --header --str-ne abc:a22 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--str-ne abc:a22]. Field not found in header: 'abc'.
+[tsv-filter] Error processing command line arguments: [--str-ne abc:a22]. Field not found in file header: 'abc'.
    Expected: '--str-ne <field>:<val>' or '--str-ne <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--str-eq 2.2:def]. Field not found in header: '2.2'.
+[tsv-filter] Error processing command line arguments: [--str-eq 2.2:def]. Field not found in file header: '2.2'.
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --str-eq 0:def input1.tsv]====
@@ -79,7 +79,7 @@ F1	F2	F3	F4
    Expected: '--str-eq <field>:<val>' or '--str-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 2.2:def input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--istr-eq 2.2:def]. Field not found in header: '2.2'.
+[tsv-filter] Error processing command line arguments: [--istr-eq 2.2:def]. Field not found in file header: '2.2'.
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --istr-eq 0:def input1.tsv]====
@@ -99,7 +99,7 @@ F1	F2	F3	F4
    Expected: '--istr-eq <field>:<val>' or '--istr-eq <field-list>:<val>' where <val> is a string.
 
 ====[tsv-filter --header --regex z:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--regex z:^A[b|B]C$]. Field not found in header: 'z'.
+[tsv-filter] Error processing command line arguments: [--regex z:^A[b|B]C$]. Field not found in file header: 'z'.
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --regex 0:^A[b|B]C$ input1.tsv]====
@@ -119,7 +119,7 @@ F1	F2	F3	F4
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex a:^A[b|B]C$ input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--iregex a:^A[b|B]C$]. Field not found in header: 'a'.
+[tsv-filter] Error processing command line arguments: [--iregex a:^A[b|B]C$]. Field not found in file header: 'a'.
    Expected: '--iregex <field>:<val>' or '--iregex <field-list>:<val>' where <val> is a regular expression.
 
 ====[tsv-filter --header --iregex 0:^A[b|B]C$ input1.tsv]====
@@ -166,11 +166,11 @@ F1	F2	F3	F4
    Expected: '--ff-lt <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-ne abc:3 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-ne abc:3]. Field not found in header: 'abc'.
+[tsv-filter] Error processing command line arguments: [--ff-ne abc:3]. Field not found in file header: 'abc'.
    Expected: '--ff-ne <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-eq 2.2:4 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-eq 2.2:4]. Field not found in header: '2.2'.
+[tsv-filter] Error processing command line arguments: [--ff-eq 2.2:4]. Field not found in file header: '2.2'.
    Expected: '--ff-eq <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le 2:3.1 input1.tsv]====
@@ -190,11 +190,11 @@ F1	F2	F3	F4
    Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-str-ne abc:3 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-str-ne abc:3]. Field not found in header: 'abc'.
+[tsv-filter] Error processing command line arguments: [--ff-str-ne abc:3]. Field not found in file header: 'abc'.
    Expected: '--ff-str-ne <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-str-eq 2.2:4 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-str-eq 2.2:4]. Field not found in header: '2.2'.
+[tsv-filter] Error processing command line arguments: [--ff-str-eq 2.2:4]. Field not found in file header: '2.2'.
    Expected: '--ff-str-eq <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:2:g input1.tsv]====
@@ -214,7 +214,7 @@ F1	F2	F3	F4
    Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1:g:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:g:0.5]. Field not found in header: 'g'.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le 1:g:0.5]. Field not found in file header: 'g'.
    Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le 1::0.5 input1.tsv]====
@@ -226,7 +226,7 @@ F1	F2	F3	F4
    Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le g:2:0.5 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-absdiff-le g:2:0.5]. Field not found in header: 'g'.
+[tsv-filter] Error processing command line arguments: [--ff-absdiff-le g:2:0.5]. Field not found in file header: 'g'.
    Expected: '--ff-absdiff-le <field1>:<field2>:<num>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-absdiff-le :2:0.5 input1.tsv]====

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -84,16 +84,16 @@ Error [tsv-select]: Not enough fields in line. File: input_3plus_fields.tsv,  Li
 [tsv-select] Error processing command line arguments: Maximum allowed '--e|exclude' field number is 1048576.
 
 ====[tsv-select -H -f no_such_field input1.tsv]====
-[tsv-select] Error processing command line arguments: [--f|fields] Field not found in header: 'no_such_field'.
+[tsv-select] Error processing command line arguments: [--f|fields] Field not found in file header: 'no_such_field'.
 
 ====[tsv-select -H -f field1,no_such_field input_header1.tsv]====
-[tsv-select] Error processing command line arguments: [--f|fields] Field not found in header: 'no_such_field'.
+[tsv-select] Error processing command line arguments: [--f|fields] Field not found in file header: 'no_such_field'.
 
 ====[tsv-select -H -f field1,no*such_field input_header1.tsv]====
-[tsv-select] Error processing command line arguments: [--f|fields] Field not found in header: 'no*such_field'.
+[tsv-select] Error processing command line arguments: [--f|fields] Field not found in file header: 'no*such_field'.
 
 ====[tsv-select -H -f field1-NoSuchField input_header1.tsv]====
-[tsv-select] Error processing command line arguments: [--f|fields] Second field in range not found in header. Range: 'field1-NoSuchField'.
+[tsv-select] Error processing command line arguments: [--f|fields] Second field in range not found in file header. Range: 'field1-NoSuchField'.
 Not specifying a range? Backslash escape any hyphens in the field name.
 
 ====[tsv-select -H -f field1-field* input_header1.tsv]====
@@ -101,13 +101,13 @@ Not specifying a range? Backslash escape any hyphens in the field name.
 Not specifying a range? Backslash escape any hyphens in the field name.
 
 ====[tsv-select -H -e no_such_field input1.tsv]====
-[tsv-select] Error processing command line arguments: [--e|exclude] Field not found in header: 'no_such_field'.
+[tsv-select] Error processing command line arguments: [--e|exclude] Field not found in file header: 'no_such_field'.
 
 ====[tsv-select -H -e field1,no*such_field input_header1.tsv]====
-[tsv-select] Error processing command line arguments: [--e|exclude] Field not found in header: 'no*such_field'.
+[tsv-select] Error processing command line arguments: [--e|exclude] Field not found in file header: 'no*such_field'.
 
 ====[tsv-select -H -e NoSuchField-field1 input_header1.tsv]====
-[tsv-select] Error processing command line arguments: [--e|exclude] First field in range not found in header. Range: 'NoSuchField-field1'.
+[tsv-select] Error processing command line arguments: [--e|exclude] First field in range not found in file header. Range: 'NoSuchField-field1'.
 Not specifying a range? Backslash escape any hyphens in the field name.
 
 ====[tsv-select -H -e field*-field1 input_header1.tsv]====

--- a/tsv-summarize/src/tsv_utils/tsv-summarize.d
+++ b/tsv-summarize/src/tsv_utils/tsv-summarize.d
@@ -1079,13 +1079,13 @@ version(unittest)
                    expectedOutput.to!string, summarizerOutput.data.to!string));
     }
 
-    void writeDataFile(string filepath, string[][] fileData)
+    void writeDataFile(string filepath, string[][] fileData, string delimiter = "\t")
     {
         import std.algorithm;
         import std.stdio;
 
         auto f = filepath.File("w");
-        foreach (record; fileData) f.writeln(record.joiner("\t"));
+        foreach (record; fileData) f.writeln(record.joiner(delimiter));
         f.close;
     }
 }
@@ -1257,6 +1257,13 @@ unittest
                     ["2b", "c|a", "a|c"],
                     ["",   "c|",  "bc|bc"]]
         );
+    testSummarizer(["unittest-sk-15-named", "-H", "--group-by", "fld3", "--values", "fld1,fld2", file1Path],
+                   file1,
+                   [["fld3", "fld1_values", "fld2_values"],
+                    ["3",  "a|c", "a|bc"],
+                    ["2b", "c|a", "a|c"],
+                    ["",   "c|",  "bc|bc"]]
+        );
 
     /* Multi-key summarizer tests.
      */
@@ -1288,6 +1295,15 @@ unittest
                     ["", "bc",  ""]]
         );
     testSummarizer(["unittest-mk-4", "-H", "--group-by", "1,2", "--values", "3,1", file1Path],
+                   file1,
+                   [["fld1", "fld2", "fld3_values", "fld1_values"],
+                    ["a", "a",  "3", "a"],
+                    ["c", "a",  "2b", "c"],
+                    ["c", "bc", "|3", "c|c"],
+                    ["a", "c",  "2b", "a"],
+                    ["",  "bc", "",   ""]]
+        );
+    testSummarizer(["unittest-mk-4-named", "-H", "--group-by", "fld1,fld2", "--values", "fld3,fld1", file1Path],
                    file1,
                    [["fld1", "fld2", "fld3_values", "fld1_values"],
                     ["a", "a",  "3", "a"],
@@ -1375,6 +1391,13 @@ unittest
                     ["c", "2b|NA|3"],
                     ["",  "NA"]]
         );
+    testSummarizer(["unittest-mis-7-named", "-H", "-g", "fld1", "--values", "fld3", "-r", "NA", file1Path],
+                   file1,
+                   [["fld1", "fld3_values"],
+                    ["a", "3|2b"],
+                    ["c", "2b|NA|3"],
+                    ["",  "NA"]]
+        );
     testSummarizer(["unittest-mis-8", "-H", "--group-by", "1", "--values", "1,2,3", "-r", "NA", file1Path],
                    file1,
                    [["fld1", "fld1_values", "fld2_values", "fld3_values"],
@@ -1446,6 +1469,11 @@ unittest
                    [["fld1_values", "fld2_values"],
                     ["a|c|c|a||c", "a|a|bc|c|bc|bc"]]
         );
+    testSummarizer(["unittest-nk-1-named", "-H", "--values", "fld1,fld2", file1Path],
+                   file1,
+                   [["fld1_values", "fld2_values"],
+                    ["a|c|c|a||c", "a|a|bc|c|bc|bc"]]
+        );
 
     /* Header variations: no header line; auto-generated header line; custom headers.
      */
@@ -1487,6 +1515,24 @@ unittest
                     ["c",  "2b"]]
         );
     testSummarizer(["unittest-hdr-6", "-H", "--group-by", "1,2", "--values", "3:FieldThreeValues", "--values", "1:FieldOneValues", file1Path],
+                   file1,
+                   [["fld1", "fld2", "FieldThreeValues", "FieldOneValues"],
+                    ["a", "a",  "3", "a"],
+                    ["c", "a",  "2b", "c"],
+                    ["c", "bc", "|3", "c|c"],
+                    ["a", "c",  "2b", "a"],
+                    ["",  "bc", "",   ""]]
+        );
+    testSummarizer(["unittest-hdr-6-named-a", "-H", "--group-by", "fld1,fld2", "--values", "fld3:FieldThreeValues", "--values", "fld1:FieldOneValues", file1Path],
+                   file1,
+                   [["fld1", "fld2", "FieldThreeValues", "FieldOneValues"],
+                    ["a", "a",  "3", "a"],
+                    ["c", "a",  "2b", "c"],
+                    ["c", "bc", "|3", "c|c"],
+                    ["a", "c",  "2b", "a"],
+                    ["",  "bc", "",   ""]]
+        );
+    testSummarizer(["unittest-hdr-6-named-b", "-H", "--group-by", "fld1,fld2", "--values", "fld3 FieldThreeValues", "--values", "fld1 FieldOneValues", file1Path],
                    file1,
                    [["fld1", "fld2", "FieldThreeValues", "FieldOneValues"],
                     ["a", "a",  "3", "a"],
@@ -1575,6 +1621,11 @@ unittest
                    [["fld2", "fld1", "fld3_values"],
                     ["b", "a", "c"]]
         );
+    testSummarizer(["unittest-3x1-3-named", "-H", "--group-by", "fld2,fld1", "--values", "fld3", file3x1Path],
+                   file3x1,
+                   [["fld2", "fld1", "fld3_values"],
+                    ["b", "a", "c"]]
+        );
     testSummarizer(["unittest-3x1-4", "--group-by", "2,1", "--values", "3", file3x1NoHeaderPath],
                    file3x1[1..$],
                    [["b", "a", "c"]]
@@ -1589,6 +1640,10 @@ unittest
 
 
     testSummarizer(["unittest-3x0-1", "-H", "--group-by", "1", "--values", "3", file3x0Path],
+                   file3x0,
+                   [["fld1", "fld3_values"]]
+        );
+    testSummarizer(["unittest-3x0-1-named", "-H", "--group-by", "fld1", "--values", "fld3", file3x0Path],
                    file3x0,
                    [["fld1", "fld3_values"]]
         );
@@ -1696,6 +1751,11 @@ unittest
                    [["fld1", "fld1_values"],
                     ["x", "x"]]
         );
+    testSummarizer(["unittest-1x1-1-named", "-H", "--group-by", "fld1", "--values", "fld1", file1x1Path],
+                   file1x1,
+                   [["fld1", "fld1_values"],
+                    ["x", "x"]]
+        );
 
     testSummarizer(["unittest-1x1-2", "--group-by", "1", "--values", "1", file1x1NoHeaderPath],
                    file1x1[1..$],
@@ -1744,8 +1804,24 @@ unittest
                    [["field1", "field1_values"]]
         );
 
-    /* Alternate delimiters. */
-    testSummarizer(["unittest-delim-1", "-H", "--values", "1,2", "--delimiter", "%", file1Path],
+    /* Alternate delimiters.
+     *
+     * Note: In current unit test setup the data is already in memory (file1).
+     * 'file1Path' points to a file with equivalent data, but not read, except if
+     * processing the header line. A data file is created for the '%' and '#'
+     * delimiter cases (these read the header), but we don't bother for the others.
+     */
+    auto file1PctDelimPath = buildPath(testDir, "file1PctDelim.tsv");
+    auto file1HashDelimPath = buildPath(testDir, "file1HashDelim.tsv");
+    writeDataFile(file1PctDelimPath, file1, "%");
+    writeDataFile(file1HashDelimPath, file1, "#");
+
+    testSummarizer(["unittest-delim-1", "-H", "--values", "1,2", "--delimiter", "%", file1PctDelimPath],
+                   file1,
+                   [["fld1_values", "fld2_values"],
+                    ["a|c|c|a||c", "a|a|bc|c|bc|bc"]]
+        );
+    testSummarizer(["unittest-delim-1-named", "-H", "--values", "fld1,fld2", "--delimiter", "%", file1PctDelimPath],
                    file1,
                    [["fld1_values", "fld2_values"],
                     ["a|c|c|a||c", "a|a|bc|c|bc|bc"]]
@@ -1755,7 +1831,12 @@ unittest
                    [["fld1_values", "fld2_values"],
                     ["a$c$c$a$$c", "a$a$bc$c$bc$bc"]]
         );
-    testSummarizer(["unittest-delim-3", "-H", "--values", "1,2", "--delimiter", "#", "--values-delimiter", ",", file1Path],
+    testSummarizer(["unittest-delim-3", "-H", "--values", "1,2", "--delimiter", "#", "--values-delimiter", ",", file1HashDelimPath],
+                   file1,
+                   [["fld1_values", "fld2_values"],
+                    ["a,c,c,a,,c", "a,a,bc,c,bc,bc"]]
+        );
+    testSummarizer(["unittest-delim-3-named", "-H", "--values", "fld1,fld2", "--delimiter", "#", "--values-delimiter", ",", file1HashDelimPath],
                    file1,
                    [["fld1_values", "fld2_values"],
                     ["a,c,c,a,,c", "a,a,bc,c,bc,bc"]]

--- a/tsv-summarize/src/tsv_utils/tsv-summarize.d
+++ b/tsv-summarize/src/tsv_utils/tsv-summarize.d
@@ -205,28 +205,28 @@ struct TsvSummarizeOptions {
                 "p|float-precision",  "NUM           'Precision' to use printing floating point numbers. Affects the number of digits printed and exponent use. Default: 12", &floatPrecision,
                 "x|exclude-missing",  "              Exclude missing (empty) fields from calculations.", &excludeMissing,
                 "r|replace-missing",  "STR           Replace missing (empty) fields with STR in calculations.", &missingValueReplacement,
-                "count",              "              Count occurrences of each unique key ('--g|group-by'), or the total number of records if no key field is specified.", &countOptionHandler,
-                "count-header",       "STR           Count occurrences of each unique key, like '--count', but use STR as the header.", &countHeaderOptionHandler,
-                "retain",             "<field-list>  Retain one copy of the field.", &operatorOptionHandler!RetainOperator,
-                "first",              "<field-list>[:STR]  First value seen.", &operatorOptionHandler!FirstOperator,
-                "last",               "<field-list>[:STR]  Last value seen.", &operatorOptionHandler!LastOperator,
-                "min",                "<field-list>[:STR]  Min value. (Numeric fields only.)", &operatorOptionHandler!MinOperator,
-                "max",                "<field-list>[:STR]  Max value. (Numeric fields only.)", &operatorOptionHandler!MaxOperator,
-                "range",              "<field-list>[:STR]  Difference between min and max values. (Numeric fields only.)", &operatorOptionHandler!RangeOperator,
-                "sum",                "<field-list>[:STR]  Sum of the values. (Numeric fields only.)", &operatorOptionHandler!SumOperator,
-                "mean",               "<field-list>[:STR]  Mean (average). (Numeric fields only.)", &operatorOptionHandler!MeanOperator,
-                "median",             "<field-list>[:STR]  Median value. (Numeric fields only. Reads all values into memory.)", &operatorOptionHandler!MedianOperator,
-                "quantile",           "<field-list>:p[,p...][:STR]  Quantiles. One or more fields, then one or more 0.0-1.0 probabilities. (Numeric fields only. Reads all values into memory.)", &quantileOperatorOptionHandler,
-                "mad",                "<field-list>[:STR]  Median absolute deviation from the median. Raw value, not scaled. (Numeric fields only. Reads all values into memory.)", &operatorOptionHandler!MadOperator,
-                "var",                "<field-list>[:STR]  Variance. (Sample variance, numeric fields only).", &operatorOptionHandler!VarianceOperator,
-                "stdev",              "<field-list>[:STR]  Standard deviation. (Sample st.dev, numeric fields only).", &operatorOptionHandler!StDevOperator,
-                "mode",               "<field-list>[:STR]  Mode. The most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeOperator,
-                "mode-count",         "<field-list>[:STR]  Count of the most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeCountOperator,
-                "unique-count",       "<field-list>[:STR]  Number of unique values. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueCountOperator,
-                "missing-count",      "<field-list>[:STR]  Number of missing (empty) fields. Not affected by '--x|exclude-missing' or '--r|replace-missing'.", &operatorOptionHandler!MissingCountOperator,
-                "not-missing-count",  "<field-list>[:STR]  Number of filled (non-empty) fields. Not affected by '--r|replace-missing'.", &operatorOptionHandler!NotMissingCountOperator,
-                "values",             "<field-list>[:STR]  All the values, separated by --v|values-delimiter. (Reads all values into memory.)", &operatorOptionHandler!ValuesOperator,
-                "unique-values",      "<field-list>[:STR]  All the unique values, separated by --v|values-delimiter. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueValuesOperator,
+                "count",              "              Count occurrences of each unique key ('--g|group-by'), or the total number of records if no key field is specified.", &addCountOptionHandler,
+                "count-header",       "STR           Count occurrences of each unique key, like '--count', but use STR as the header.", &addCountHeaderOptionHandler,
+                "retain",             "<field-list>  Retain one copy of the field.", &addOperatorOptionHandler!RetainOperator,
+                "first",              "<field-list>[:STR]  First value seen.", &addOperatorOptionHandler!FirstOperator,
+                "last",               "<field-list>[:STR]  Last value seen.", &addOperatorOptionHandler!LastOperator,
+                "min",                "<field-list>[:STR]  Min value. (Numeric fields only.)", &addOperatorOptionHandler!MinOperator,
+                "max",                "<field-list>[:STR]  Max value. (Numeric fields only.)", &addOperatorOptionHandler!MaxOperator,
+                "range",              "<field-list>[:STR]  Difference between min and max values. (Numeric fields only.)", &addOperatorOptionHandler!RangeOperator,
+                "sum",                "<field-list>[:STR]  Sum of the values. (Numeric fields only.)", &addOperatorOptionHandler!SumOperator,
+                "mean",               "<field-list>[:STR]  Mean (average). (Numeric fields only.)", &addOperatorOptionHandler!MeanOperator,
+                "median",             "<field-list>[:STR]  Median value. (Numeric fields only. Reads all values into memory.)", &addOperatorOptionHandler!MedianOperator,
+                "quantile",           "<field-list>:p[,p...][:STR]  Quantiles. One or more fields, then one or more 0.0-1.0 probabilities. (Numeric fields only. Reads all values into memory.)", &addQuantileOperatorOptionHandler,
+                "mad",                "<field-list>[:STR]  Median absolute deviation from the median. Raw value, not scaled. (Numeric fields only. Reads all values into memory.)", &addOperatorOptionHandler!MadOperator,
+                "var",                "<field-list>[:STR]  Variance. (Sample variance, numeric fields only).", &addOperatorOptionHandler!VarianceOperator,
+                "stdev",              "<field-list>[:STR]  Standard deviation. (Sample st.dev, numeric fields only).", &addOperatorOptionHandler!StDevOperator,
+                "mode",               "<field-list>[:STR]  Mode. The most frequent value. (Reads all unique values into memory.)", &addOperatorOptionHandler!ModeOperator,
+                "mode-count",         "<field-list>[:STR]  Count of the most frequent value. (Reads all unique values into memory.)", &addOperatorOptionHandler!ModeCountOperator,
+                "unique-count",       "<field-list>[:STR]  Number of unique values. (Reads all unique values into memory.)", &addOperatorOptionHandler!UniqueCountOperator,
+                "missing-count",      "<field-list>[:STR]  Number of missing (empty) fields. Not affected by '--x|exclude-missing' or '--r|replace-missing'.", &addOperatorOptionHandler!MissingCountOperator,
+                "not-missing-count",  "<field-list>[:STR]  Number of filled (non-empty) fields. Not affected by '--r|replace-missing'.", &addOperatorOptionHandler!NotMissingCountOperator,
+                "values",             "<field-list>[:STR]  All the values, separated by --v|values-delimiter. (Reads all values into memory.)", &addOperatorOptionHandler!ValuesOperator,
+                "unique-values",      "<field-list>[:STR]  All the unique values, separated by --v|values-delimiter. (Reads all unique values into memory.)", &addOperatorOptionHandler!UniqueValuesOperator,
                 );
 
             if (r.helpWanted)
@@ -255,6 +255,15 @@ struct TsvSummarizeOptions {
             cmdArgs.length = 1;
             inputSources = byLineSourceRange(filepaths);
 
+            string[] headerFields;
+
+            if (hasHeader && !inputSources.front.byLine.empty)
+            {
+                headerFields = inputSources.front.byLine.front.split(inputFieldDelimiter).to!(string[]);
+            }
+
+            cmdLineOperatorOptions.each!(dg => dg(hasHeader, headerFields));
+
             derivations();
         }
         catch (Exception exc)
@@ -265,12 +274,27 @@ struct TsvSummarizeOptions {
         return tuple(true, 0);
     }
 
+    /* CmdOptionHandler delegate signature - This is the call made to process the command
+     * line option arguments after the header line has been read.
+     */
+    alias CmdOptionHandler = void delegate(bool hasHeader, string[] headerFields);
+
+    CmdOptionHandler[]  cmdLineOperatorOptions;
+
+    void addOperatorOptionHandler(OperatorClass : SingleFieldOperator)(string option, string optionVal)
+    {
+        cmdLineOperatorOptions ~=
+            (bool hasHeader, string[] headerFields)
+            => operatorOptionHandler!OperatorClass(hasHeader, headerFields, option, optionVal);
+    }
+
     /* operationOptionHandler functions are callbacks that process command line options
      * specifying summarization operations. eg. '--max 5', '--last 3:LastEntry'. Handlers
      * check syntactic correctness and instantiate Operator objects that do the work. This
      * is also where 1-upped field numbers are converted to 0-based indices.
      */
-    private void operatorOptionHandler(OperatorClass : SingleFieldOperator)(string option, string optionVal)
+    private void operatorOptionHandler(OperatorClass : SingleFieldOperator)
+    (bool hasHeader, string[] headerFields, string option, string optionVal)
     {
         import std.range : enumerate;
         import std.typecons : Yes, No;
@@ -312,8 +336,15 @@ struct TsvSummarizeOptions {
         }
     }
 
+    void addQuantileOperatorOptionHandler(string option, string optionVal)
+    {
+        cmdLineOperatorOptions ~=
+            (bool hasHeader, string[] headerFields)
+            => quantileOperatorOptionHandler(hasHeader, headerFields, option, optionVal);
+    }
+
     /* QuantileOperator has a different syntax and needs a custom command option handler. */
-    private void quantileOperatorOptionHandler(string option, string optionVal)
+    private void quantileOperatorOptionHandler(bool hasHeader, string[] headerFields, string option, string optionVal)
     {
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist :  parseNumericFieldList;
@@ -389,12 +420,26 @@ struct TsvSummarizeOptions {
         }
     }
 
-    private void countOptionHandler()
+    void addCountOptionHandler()
+    {
+        cmdLineOperatorOptions ~=
+            (bool hasHeader, string[] headerFields)
+            => countOptionHandler(hasHeader, headerFields);
+    }
+
+    private void countOptionHandler(bool hasHeader, string[] headerFields)
     {
         operators.insertBack(new CountOperator());
     }
 
-    private void countHeaderOptionHandler(string option, string optionVal)
+    void addCountHeaderOptionHandler(string option, string optionVal)
+    {
+        cmdLineOperatorOptions ~=
+            (bool hasHeader, string[] headerFields)
+            => countHeaderOptionHandler(hasHeader, headerFields, option, optionVal);
+    }
+
+    private void countHeaderOptionHandler(bool hasHeader, string[] headerFields, string option, string optionVal)
     {
         auto op = new CountOperator();
         op.setCustomHeader(optionVal);
@@ -404,7 +449,7 @@ struct TsvSummarizeOptions {
     /* This routine does validations not handled by processArgs. */
     private void consistencyValidations()
     {
-        enforce(!operators.empty, "At least one summary operator is required.");
+        enforce(!cmdLineOperatorOptions.empty, "At least one summary operator is required.");
 
         enforce(inputFieldDelimiter != valuesDelimiter,
                 "Cannot use the same character for both --d|field-delimiter and --v|values-delimiter.");

--- a/tsv-summarize/tests/gold/basic_tests_1.txt
+++ b/tsv-summarize/tests/gold/basic_tests_1.txt
@@ -5,7 +5,15 @@ Basic tests set 1
 color	color_first	color_last	length_min	length_max	length_range	length_sum	length_median	length_pct50	length_mad	length_var	length_stdev	color_mode	color_mode_count	color_values	color_unique_values
 red	red	green	7.4	16	8.6	78.4	11	11	3	9.61	3.1	blue	3	red|red|blue|green|blue|blue|green	red|blue|green
 
+====[tsv-summarize --header --float-precision 2 --retain color --first color --last color --min length --max length --range length --sum length --median length --quantile length:0.5 --mad length --var length --stdev length --mode color --mode-count color --values color --unique-values color input_5field_a.tsv]====
+color	color_first	color_last	length_min	length_max	length_range	length_sum	length_median	length_pct50	length_mad	length_var	length_stdev	color_mode	color_mode_count	color_values	color_unique_values
+red	red	green	7.4	16	8.6	78.4	11	11	3	9.61	3.1	blue	3	red|red|blue|green|blue|blue|green	red|blue|green
+
 ====[tsv-summarize --header --missing-count 1 --not-missing-count 1 input_1field_a.tsv]====
+size_missing_count	size_not_missing_count
+1	5
+
+====[tsv-summarize --header --missing-count size --not-missing-count size input_1field_a.tsv]====
 size_missing_count	size_not_missing_count
 1	5
 
@@ -39,6 +47,14 @@ blue	solid	2	14	2	3	4	4	16
 green	solid	2	7.4	5.5	3.2	5.4	6.0	11
 blue	striped	1	12	1	2	2	1	12
 
+====[tsv-summarize --header --group-by color,pattern --count --min length-height --max height-length input_5field_a.tsv]====
+color	pattern	count	length_min	width_min	height_min	height_max	width_max	length_max
+red	solid	1	10	4	7	7	4	10
+red	striped	1	8	6	6	6	6	8
+blue	solid	2	14	2	3	4	4	16
+green	solid	2	7.4	5.5	3.2	5.4	6.0	11
+blue	striped	1	12	1	2	2	1	12
+
 ====[tsv-summarize --header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv]====
 count	length_min	width_min	height_min	length_max	width_max	height_max
 12	6	1	2	16	7	8
@@ -63,6 +79,14 @@ blue	striped	1	12	1	2	12	1	2
 red	checked	1	10	4	7	10	4	7
 
 ====[tsv-summarize --header --group-by 1 --count --range 3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv]====
+color	count	length_range	width_range	height_range
+red	4	4	4	2
+blue	3	4	3	2
+green	2	3.6	0.5	2.2
+赤	2	1	1	2
+青	1	0	0	0
+
+====[tsv-summarize --header --group-by 1 --count --range length,width,height input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv]====
 color	count	length_range	width_range	height_range
 red	4	4	4	2
 blue	3	4	3	2

--- a/tsv-summarize/tests/gold/error_tests_1.txt
+++ b/tsv-summarize/tests/gold/error_tests_1.txt
@@ -5,25 +5,26 @@ Error test set 1
 [tsv-summarize] Error processing command line arguments: Cannot open file `no_such_file.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-summarize --unique-count 0 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--unique-count] Field numbers must be greater than zero: '0'.
+[tsv-summarize] Error processing command line arguments: [--unique-count 0] Field numbers must be greater than zero: '0'.
 
 ====[tsv-summarize --unique-count 2, input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--unique-count] Empty field number.
+[tsv-summarize] Error processing command line arguments: [--unique-count 2,] Invalid field list: '2,'.
 
 ====[tsv-summarize --unique-count 2: input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--unique-count 2:'. Expected: '--unique-count <field-list>' or '--unique-count <field>:<header>'.
+[tsv-summarize] Error processing command line arguments: [--unique-count 2:] No value after field list.
+   Expected: '--unique-count <field-list>' or '--unique-count <field>:<header>'.
 
 ====[tsv-summarize --unique-count 2,3:my_header input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2,3:my_header'. Cannot specify a custom header when using multiple fields.
+[tsv-summarize] Error processing command line arguments: [--unique-count 2,3:my_header] Cannot specify a custom header when using multiple fields.
 
 ====[tsv-summarize --unique-count 2-5:my_header input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2-5:my_header'. Cannot specify a custom header when using multiple fields.
+[tsv-summarize] Error processing command line arguments: [--unique-count 2-5:my_header] Cannot specify a custom header when using multiple fields.
 
 ====[tsv-summarize --retain 2:my_header input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--retain] Invalid option: '--retain 2:my_header'. Operator does not support custom headers.
+[tsv-summarize] Error processing command line arguments: [--retain 2:my_header] Operator does not support custom headers.
 
 ====[tsv-summarize --unique-count x input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--unique-count] Unexpected 'x' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--unique-count x] Non-numeric field group: 'x'. Use '--H|header' when using named field groups.
 
 ====[tsv-summarize --unique-count 2 input_5field_a.tsv input_1field_a.tsv]====
 Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line: 1
@@ -32,28 +33,28 @@ Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line
 [tsv-summarize] Error processing command line arguments: At least one summary operator is required.
 
 ====[tsv-summarize --group-by 0 --count input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'.
+[tsv-summarize] Error processing command line arguments: [--g|group-by 0]. Field numbers must be greater than zero: '0'.
 
 ====[tsv-summarize --group-by 0 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'.
+[tsv-summarize] Error processing command line arguments: [--g|group-by 0]. Field numbers must be greater than zero: '0'.
 
 ====[tsv-summarize --group-by 2, input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Empty field number.
+[tsv-summarize] Error processing command line arguments: [--g|group-by 2,]. Invalid field list: '2,'.
 
 ====[tsv-summarize --group-by 2: input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Unexpected ':' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--g|group-by 2:]. Invalid field list: '2:'.
 
 ====[tsv-summarize --group-by x input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Unexpected 'x' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--g|group-by x]. Non-numeric field group: 'x'. Use '--H|header' when using named field groups.
 
 ====[tsv-summarize --group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv]====
 Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line: 1
 
 ====[tsv-summarize --group-by 1- input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Incomplete ranges are not supported: '1-'.
+[tsv-summarize] Error processing command line arguments: [--g|group-by 1-]. Incomplete ranges are not supported: '1-'.
 
 ====[tsv-summarize --group-by 3-0 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'.
+[tsv-summarize] Error processing command line arguments: [--g|group-by 3-0]. Field numbers must be greater than zero: '0'.
 
 ====[tsv-summarize --header --max 1 input_1field_a.tsv]====
 Error [tsv-summarize]: Could not process line or field: no digits seen for input "small".
@@ -78,52 +79,68 @@ Error [tsv-summarize]: Could not process line or field: no digits seen for input
 [tsv-summarize] Error processing command line arguments: Cannot use both '--x|exclude-missing' and '--r|replace-missing'.
 
 ====[tsv-summarize --quantile 3 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile 3]. No probabilities entered.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:2 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3:2'. Probability '2' is not in the interval [0.0,1.0].
+[tsv-summarize] Error processing command line arguments: [--quantile 3:2]. Probability '2' is not in the interval [0.0,1.0].
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:0.5,2 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3:0.5,2'. Probability '2' is not in the interval [0.0,1.0].
+[tsv-summarize] Error processing command line arguments: [--quantile 3:0.5,2]. Probability '2' is not in the interval [0.0,1.0].
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 0:0.5 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'.
+[tsv-summarize] Error processing command line arguments: [--quantile 0:0.5]. Field numbers must be greater than zero: '0'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3,4:0.75:q3 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3,4:0.75:q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
+[tsv-summarize] Error processing command line arguments: [--quantile 3,4:0.75:q3]. Cannot specify a custom header when using multiple fields or multiple probabilities.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:0.25,0.75:q1q3 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3:0.25,0.75:q1q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
+[tsv-summarize] Error processing command line arguments: [--quantile 3:0.25,0.75:q1q3]. Cannot specify a custom header when using multiple fields or multiple probabilities.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3: input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3:'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile 3:]. No probabilities entered.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile :0.25 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile :0.25'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile :0.25]. Empty field list: ':0.25'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile : input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile :'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile :]. Empty field list: ':'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:0.25: input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3:0.25:'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile 3:0.25:]. Empty custom header.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:0.25g input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3:0.25g'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile 3:0.25g]. Unexpected 'g' when converting from type string to type double
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3, input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3,'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile 3,]. Invalid field list: '3,'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3- input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3-'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: [--quantile 3-]. Incomplete ranges are not supported: '3-'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 0:0.25 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'.
+[tsv-summarize] Error processing command line arguments: [--quantile 0:0.25]. Field numbers must be greater than zero: '0'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 1.5:0.25 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--quantile] Unexpected '.' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--quantile 1.5:0.25]. Non-numeric field group: '1.5'. Use '--H|header' when using named field groups.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 1-:0.25 input_5field_a.tsv]====
-[tsv-summarize] Error processing command line arguments: [--quantile] Incomplete ranges are not supported: '1-'.
+[tsv-summarize] Error processing command line arguments: [--quantile 1-:0.25]. Incomplete ranges are not supported: '1-'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile -2:0.25 input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: Missing value for argument --quantile.

--- a/tsv-summarize/tests/gold/error_tests_1.txt
+++ b/tsv-summarize/tests/gold/error_tests_1.txt
@@ -145,6 +145,20 @@ Error [tsv-summarize]: Could not process line or field: no digits seen for input
 ====[tsv-summarize --quantile -2:0.25 input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: Missing value for argument --quantile.
 
+====[tsv-summarize --group-by 2 --sum width,len input_5field_a.tsv]====
+[tsv-summarize] Error processing command line arguments: [--sum width,len] Non-numeric field group: 'width'. Use '--H|header' when using named field groups.
+
+====[tsv-summarize -H --group-by 2 --sum width,len input_5field_a.tsv]====
+[tsv-summarize] Error processing command line arguments: [--sum width,len] Field not found in file header: 'len'.
+
+====[tsv-summarize --quantile len,width:0.25,0.75 input_5field_a.tsv]====
+[tsv-summarize] Error processing command line arguments: [--quantile len,width:0.25,0.75]. Non-numeric field group: 'len'. Use '--H|header' when using named field groups.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+
+====[tsv-summarize -H --quantile len,width:0.25,0.75 input_5field_a.tsv]====
+[tsv-summarize] Error processing command line arguments: [--quantile len,width:0.25,0.75]. Field not found in file header: 'len'.
+   Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+
 ====[tsv-summarize --count input_1field_a_dos.tsv]====
 Error [tsv-summarize]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input_1field_a_dos.tsv, Line: 1

--- a/tsv-summarize/tests/tests.sh
+++ b/tsv-summarize/tests/tests.sh
@@ -33,7 +33,11 @@ echo "-----------------" >> ${basic_tests_1}
 ## One test for each operator. Make sure it is hooked up to the command line args properly
 runtest ${prog} "--header --float-precision 2 --retain 1 --first 1 --last 1 --min 3 --max 3 --range 3 --sum 3 --median 3 --quantile 3:0.5 --mad 3 --var 3 --stdev 3 --mode 1 --mode-count 1 --values 1 --unique-values 1 input_5field_a.tsv" ${basic_tests_1}
 
+runtest ${prog} "--header --float-precision 2 --retain color --first color --last color --min length --max length --range length --sum length --median length --quantile length:0.5 --mad length --var length --stdev length --mode color --mode-count color --values color --unique-values color input_5field_a.tsv" ${basic_tests_1}
+
 runtest ${prog} "--header --missing-count 1 --not-missing-count 1 input_1field_a.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --missing-count size --not-missing-count size input_1field_a.tsv" ${basic_tests_1}
 
 ## Functionality tests
 runtest ${prog} "--header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
@@ -41,6 +45,7 @@ runtest ${prog} "--header --count-header the_count input_5field_a.tsv" ${basic_t
 runtest ${prog} "--header --group-by 1 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1,2 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1-2 --count --min 3-5 --max 5-3 input_5field_a.tsv" ${basic_tests_1}
+runtest ${prog} "--header --group-by color,pattern --count --min length-height --max height-length input_5field_a.tsv" ${basic_tests_1}
 
 runtest ${prog} "--header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv" ${basic_tests_1}
@@ -48,6 +53,8 @@ runtest ${prog} "--header --group-by 1 --count --min 3,4,5 --max 3,4,5 input_5fi
 runtest ${prog} "--header --group-by 1,2 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv" ${basic_tests_1}
 
 runtest ${prog} "--header --group-by 1 --count --range 3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --group-by 1 --count --range length,width,height input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv" ${basic_tests_1}
 
 ## No header tests.
 runtest ${prog} "--count --unique-count 1,2,3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv" ${basic_tests_1}
@@ -163,6 +170,11 @@ runtest ${prog} "--quantile 0:0.25 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--quantile 1.5:0.25 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--quantile 1-:0.25 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--quantile -2:0.25 input_5field_a.tsv" ${error_tests_1}
+
+runtest ${prog} "--group-by 2 --sum width,len input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "-H --group-by 2 --sum width,len input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile len,width:0.25,0.75 input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "-H --quantile len,width:0.25,0.75 input_5field_a.tsv" ${error_tests_1}
 
 # Windows line endings detection
 runtest ${prog} "--count input_1field_a_dos.tsv" ${error_tests_1}


### PR DESCRIPTION
This PR is a follow-on to PRs #284 and #285. It adds named field support to tsv-summarize. It works the same way as the support added to tsv-select, see PR #284 for more info.

Named field support is backward compatible with numeric fields. As with `tsv-select` and `tsv-filter`, this support is not documented yet, even in the help text. Documentation will be added when named field support has been added to all tools and a release performed.

This is a step towards enhancement request #25.