### PR TITLE
tsv-filter fieldlist bug fix 

### DIFF
--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -627,7 +627,8 @@ void fieldVsFieldOptionHandler(
 
         auto fieldIndices2 =
             optionVal[optionValParse.consumed + 1 .. $]
-            .parseFieldList!(size_t, Yes.convertToZeroBasedIndex)
+            .parseFieldList!(size_t, Yes.convertToZeroBasedIndex, No.allowFieldNumZero, Yes.consumeEntireFieldListString)
+            (hasHeader, headerFields)
             .array;
 
         enforce(fieldIndices2.length != 0, "Second field argument is empty.");

--- a/tsv-filter/tests/gold/basic_tests_1.txt
+++ b/tsv-filter/tests/gold/basic_tests_1.txt
@@ -1993,6 +1993,16 @@ F1	F2	F3	F4
 100	102	abc	AbC
 100	103	abc	AbC
 
+====[tsv-filter --header --ff-lt F1:F2 input1.tsv]====
+F1	F2	F3	F4
+10	10.1	abc	ABC
+-1	-0.1	abc def	abc def
+0.	100.	àbc	ÀBC
+0.0	100.0	àßc	ÀssC
+100	101		
+100	102	abc	AbC
+100	103	abc	AbC
+
 ====[tsv-filter --header --ff-ge F1:2 input1.tsv]====
 F1	F2	F3	F4
 1	1.0	a	A
@@ -2005,6 +2015,10 @@ F1	F2	F3	F4
 100	100	abc	
 
 ====[tsv-filter --header --ff-gt F1:2 input1.tsv]====
+F1	F2	F3	F4
+-0.0	-100.0	àßc	ÀSSC
+
+====[tsv-filter --header --ff-gt F1:F2 input1.tsv]====
 F1	F2	F3	F4
 -0.0	-100.0	àßc	ÀSSC
 

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -174,7 +174,7 @@ F1	F2	F3	F4
    Expected: '--ff-eq <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le 2:3.1 input1.tsv]====
-[tsv-filter] Error processing command line arguments: [--ff-le 2:3.1]. Non-numeric field group: '3.1'. Use '--H|header' when using named field groups.
+[tsv-filter] Error processing command line arguments: [--ff-le 2:3.1]. Field not found in file header: '3.1'.
    Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[tsv-filter --header --ff-le 2: input1.tsv]====
@@ -277,6 +277,10 @@ Error [tsv-filter]: Could not process line or field: no digits seen for input "F
 ====[tsv-filter --regex :^A[b|B]C$ input1_noheader.tsv]====
 [tsv-filter] Error processing command line arguments: [--regex :^A[b|B]C$]. Empty field list: ':^A[b|B]C$'.
    Expected: '--regex <field>:<val>' or '--regex <field-list>:<val>' where <val> is a regular expression.
+
+====[tsv-filter --ff-le 2:3.1 input1.tsv]====
+[tsv-filter] Error processing command line arguments: [--ff-le 2:3.1]. Non-numeric field group: '3.1'. Use '--H|header' when using named field groups.
+   Expected: '--ff-le <field1>:<field2>' where <field1> and <field2> are individual fields.
 
 ====[cat input_3x2.tsv | tsv-filter --ge 2:23]====
 Error [tsv-filter]: Could not process line or field: no digits seen for input "f2".

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -316,8 +316,10 @@ runtest ${prog} "--header --ff-eq F1:2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-ne F1:2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-le F1:2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-lt F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-lt F1:F2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-ge F1:2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-gt F1:2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header --ff-gt F1:F2 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-str-eq F3:4 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-str-ne F3:4 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ff-istr-eq F3:4 input1.tsv" ${basic_tests_1}
@@ -544,6 +546,7 @@ runtest ${prog} "--empty 0 input1_noheader.tsv" ${error_tests_1}
 runtest ${prog} "--str-gt 0:abc input1_noheader.tsv" ${error_tests_1}
 runtest ${prog} "--str-eq :def input1_noheader.tsv" ${error_tests_1}
 runtest ${prog} "--regex :^A[b|B]C$ input1_noheader.tsv" ${error_tests_1}
+runtest ${prog} "--ff-le 2:3.1 input1.tsv" ${error_tests_1}
 
 # Standard input tests
 echo "" >> ${error_tests_1}; echo "====[cat input_3x2.tsv | tsv-filter --ge 2:23]====" >> ${error_tests_1}


### PR DESCRIPTION
Second field in `--ff-<xyz>` operators was not being parsed as a named field.