### PR TITLE
fieldlists: Detect mixed numeric and named field ranges (not supported).

### DIFF
--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -114,6 +114,18 @@ Not specifying a range? Backslash escape any hyphens in the field name.
 [tsv-select] Error processing command line arguments: [--e|exclude] First field in range matches multiple header fields. Range: 'field*-field1'.
 Not specifying a range? Backslash escape any hyphens in the field name.
 
+====[tsv-select -H -f 1- input_header1.tsv]====
+[tsv-select] Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '1-'.
+
+====[tsv-select -H -f 1-g input_header1.tsv]====
+[tsv-select] Error processing command line arguments: [--f|fields] Ranges with both numeric and named components are not supported: '1-g'.
+
+====[tsv-select -H -f field1-2 input_header1.tsv]====
+[tsv-select] Error processing command line arguments: [--f|fields] Ranges with both numeric and named components are not supported: 'field1-2'.
+
+====[tsv-select -H -f field1-field2,field2-1 input_header1.tsv]====
+[tsv-select] Error processing command line arguments: [--f|fields] Ranges with both numeric and named components are not supported: 'field2-1'.
+
 ====[tsv-select -f 1 input1_dos.tsv]====
 Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -278,6 +278,10 @@ runtest ${prog} "-H -e no_such_field input1.tsv" ${error_tests_1}
 runtest ${prog} "-H -e field1,no*such_field input_header1.tsv" ${error_tests_1}
 runtest ${prog} "-H -e NoSuchField-field1 input_header1.tsv" ${error_tests_1}
 runtest ${prog} "-H -e field*-field1 input_header1.tsv" ${error_tests_1}
+runtest ${prog} "-H -f 1- input_header1.tsv" ${error_tests_1}
+runtest ${prog} "-H -f 1-g input_header1.tsv" ${error_tests_1}
+runtest ${prog} "-H -f field1-2 input_header1.tsv" ${error_tests_1}
+runtest ${prog} "-H -f field1-field2,field2-1 input_header1.tsv" ${error_tests_1}
 
 # Windows line ending detection
 runtest ${prog} "-f 1 input1_dos.tsv" ${error_tests_1}

--- a/tsv-uniq/tests/gold/error_tests_1.txt
+++ b/tsv-uniq/tests/gold/error_tests_1.txt
@@ -50,8 +50,7 @@ Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 1
 [tsv-uniq] Error processing command line arguments: [--f|fields] Field not found in file header: 'g'.
 
 ====[tsv-uniq -H -f 1-g input1.tsv]====
-[tsv-uniq] Error processing command line arguments: [--f|fields] First field in range not found in file header. Range: '1-g'.
-Not specifying a range? Backslash escape any hyphens in the field name.
+[tsv-uniq] Error processing command line arguments: [--f|fields] Ranges with both numeric and named components are not supported: '1-g'.
 
 ====[tsv-uniq -H -f 0-2 input1.tsv]====
 [tsv-uniq] Error processing command line arguments: [--f|fields] Zero cannot be used as part of a range: '0-2'.


### PR DESCRIPTION
This PR adds a missed error detection case in the new fieldlist support (named fields). The case occurs when a field range is entered that contains both numeric and non-numeric elements. e.g.
```
$ tsv-select --header -f field3-7
```
Prior to this change the second component, the `7` is marked as and searched for in the file header. Typically it won't be found and an error message generated, but a misleading error message. If found, it generally won't be what was intended.

This PR detects this case and generates the correct error message. Note that in the above example, if there really is a field named `7`, the way to designate it is:
```
$ tsv-select --header -f `field3-\7`
```

This is part of the named field PR series starting with #284. Enhancement request #25.