### PR TITLE
tsv-split named field support

### DIFF
--- a/tsv-split/tests/gold/error_tests_1.txt
+++ b/tsv-split/tests/gold/error_tests_1.txt
@@ -55,7 +55,7 @@ input1x3.txt: line 3
 [tsv-split] Error processing command line arguments: '--n|num-files must be two or more.
 
 ====[tsv-split -n 2 -k 1.5 input4x58.tsv]====
-[tsv-split] Error processing command line arguments: [--k|key-fields] Unexpected '.' when converting from type string to type ulong
+[tsv-split] Error processing command line arguments: [--k|key-fields] Non-numeric field group: '1.5'. Use '--H|header' when using named field groups.
 
 ====[tsv-split -n 2 -k 0,1 input4x58.tsv]====
 [tsv-split] Error processing command line arguments: Whole line as key (--k|key-fields 0) cannot be combined with multiple fields.
@@ -95,6 +95,15 @@ Error [tsv-split]: Not enough fields in line. File: input4x58.tsv, Line: 1
 
 ====[tsv-split -n 2 --suffix ab/cd input4x58.tsv]====
 [tsv-split] Error processing command line arguments: '--suffix' cannot contain forward slash characters. Use '--dir' to specify an output directory.
+
+====[tsv-split -n 2 --key-fields c\-1 input4x58.tsv]====
+[tsv-split] Error processing command line arguments: [--k|key-fields] Non-numeric field group: 'c\-1'. Use '--H|header' when using named field groups.
+
+====[tsv-split -n 2 -H --key-fields c-1 input4x58.tsv]====
+[tsv-split] Error processing command line arguments: [--k|key-fields] Ranges with both numeric and named components are not supported: 'c-1'.
+
+====[tsv-split -n 2 -I --key-fields c-1 input4x58.tsv]====
+[tsv-split] Error processing command line arguments: [--k|key-fields] Ranges with both numeric and named components are not supported: 'c-1'.
 
 ====[ulimit -Sn 5 && tsv-split -s -n 101 -k 3 --max-open-files 6 ../input4x58.tsv]====
 [tsv-split] Error processing command line arguments: '--max-open-files' value (6) greater current system limit (5).

--- a/tsv-split/tests/gold/key_assignment_tests.txt
+++ b/tsv-split/tests/gold/key_assignment_tests.txt
@@ -698,6 +698,134 @@ rouge	2037	Marreca-cabocla	0
 fumée	2113	Araqua-pintado	0
 fumée	2124	Araqua-pintado	0
 
+====[tsv-split --header -s -n 2 -k c\-3 ../input4x58.tsv]====
+==> ./tsvsplit_workdir/part_0.tsv <==
+c-1	c-2	c-3	c-4
+blutrot	2142	Tüpfelsumpfhuhn	1
+Blutrot	2142	tüpfelsumpfhuhn	1
+BLUTROT	2142	TÜPFELSUMPFHUHN	1
+Indigo	2056	Голубь	1
+Indigo	2141	Голубь	1
+blutrot	2118	Tüpfelsumpfhuhn	4
+Cerise	2076	Malvasía Cabeciblanca	4
+暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
+zitronengelb	2136	Macreuse à bec jaune	3
+Grünspan	2145	Pipit de Godlewski	4
+grünspan	2145	PIPIT DE GODLEWSKI	4
+Blutrot	2142	tüpfelsumpfhuhn	1
+zitronengelb	2083	Macreuse à bec jaune	4
+púrpura	2070	Macreuse à bec jaune	2
+blutrot	2121	Воробей	4
+púrpura	2092	Macreuse à bec jaune	4
+blutrot	2117	Tüpfelsumpfhuhn	0
+púrpura	2093	Macreuse à bec jaune	4
+dorado	2045	Лебедь	2
+Cerise	2119	Malvasía Cabeciblanca	4
+blanc	2137	Голубь	2
+BLUTROT	2142	TÜPFELSUMPFHUHN	1
+rouge	2135	Marreca-cabocla	1
+grünspan	2145	PIPIT DE GODLEWSKI	4
+blanc	2109	Голубь	3
+blutrot	2143	Tüpfelsumpfhuhn	4
+púrpura	2145	Macreuse à bec jaune	2
+Grünspan	2082	Pipit de Godlewski	2
+blutrot	2149	Tüpfelsumpfhuhn	1
+blutrot	2120	Tüpfelsumpfhuhn	1
+Indigo	2138	Голубь	4
+café	2019	Marreca-cabocla	1
+Grünspan	2053	Pipit de Godlewski	4
+blanc	2038	Голубь	0
+Grünspan	2071	Pipit de Godlewski	3
+rouge	2037	Marreca-cabocla	0
+fumée	2113	Araqua-pintado	0
+fumée	2124	Araqua-pintado	0
+
+==> ./tsvsplit_workdir/part_1.tsv <==
+c-1	c-2	c-3	c-4
+púrpura	2088	Macuco	1
+schneeweiß	2117	Porrón Islándico	4
+café	2088	Purpurreiher	2
+Orange-red	2089	Purpurreiher	1
+rouge	2132	Löffelente	4
+GRÜNSPAN	2145	pipit de godlewski	4
+marrón	2102	Weißwangengans	1
+rouge	2146	Löffelente	1
+schneeweiß	2121	Porrón Islándico	1
+café	2062	Purpurreiher	4
+noir	2082	Weißwangengans	1
+noir	2094	Weißwangengans	4
+café	2100	Purpurreiher	2
+красный	2049	Weißwangengans	3
+noir	2115	Weißwangengans	2
+púrpura	2119	Macuco	4
+café	2041	Purpurreiher	4
+GRÜNSPAN	2145	pipit de godlewski	4
+marrón	2034	Weißwangengans	1
+
+====[tsv-split -H -s -n 2 -k c\-1,c\-3,c\-4 ../input4x58.tsv]====
+==> ./tsvsplit_workdir/part_0.tsv <==
+c-1	c-2	c-3	c-4
+Indigo	2056	Голубь	1
+Indigo	2141	Голубь	1
+Cerise	2076	Malvasía Cabeciblanca	4
+café	2088	Purpurreiher	2
+Orange-red	2089	Purpurreiher	1
+rouge	2132	Löffelente	4
+grünspan	2145	PIPIT DE GODLEWSKI	4
+púrpura	2070	Macreuse à bec jaune	2
+marrón	2102	Weißwangengans	1
+púrpura	2092	Macreuse à bec jaune	4
+rouge	2146	Löffelente	1
+púrpura	2093	Macreuse à bec jaune	4
+dorado	2045	Лебедь	2
+Cerise	2119	Malvasía Cabeciblanca	4
+noir	2094	Weißwangengans	4
+blanc	2137	Голубь	2
+café	2100	Purpurreiher	2
+grünspan	2145	PIPIT DE GODLEWSKI	4
+blanc	2109	Голубь	3
+púrpura	2119	Macuco	4
+púrpura	2145	Macreuse à bec jaune	2
+Grünspan	2082	Pipit de Godlewski	2
+Indigo	2138	Голубь	4
+café	2019	Marreca-cabocla	1
+blanc	2038	Голубь	0
+Grünspan	2071	Pipit de Godlewski	3
+marrón	2034	Weißwangengans	1
+
+==> ./tsvsplit_workdir/part_1.tsv <==
+c-1	c-2	c-3	c-4
+púrpura	2088	Macuco	1
+blutrot	2142	Tüpfelsumpfhuhn	1
+Blutrot	2142	tüpfelsumpfhuhn	1
+BLUTROT	2142	TÜPFELSUMPFHUHN	1
+blutrot	2118	Tüpfelsumpfhuhn	4
+schneeweiß	2117	Porrón Islándico	4
+暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
+zitronengelb	2136	Macreuse à bec jaune	3
+Grünspan	2145	Pipit de Godlewski	4
+GRÜNSPAN	2145	pipit de godlewski	4
+Blutrot	2142	tüpfelsumpfhuhn	1
+zitronengelb	2083	Macreuse à bec jaune	4
+blutrot	2121	Воробей	4
+blutrot	2117	Tüpfelsumpfhuhn	0
+schneeweiß	2121	Porrón Islándico	1
+café	2062	Purpurreiher	4
+noir	2082	Weißwangengans	1
+BLUTROT	2142	TÜPFELSUMPFHUHN	1
+rouge	2135	Marreca-cabocla	1
+красный	2049	Weißwangengans	3
+noir	2115	Weißwangengans	2
+blutrot	2143	Tüpfelsumpfhuhn	4
+blutrot	2149	Tüpfelsumpfhuhn	1
+blutrot	2120	Tüpfelsumpfhuhn	1
+café	2041	Purpurreiher	4
+GRÜNSPAN	2145	pipit de godlewski	4
+Grünspan	2053	Pipit de Godlewski	4
+rouge	2037	Marreca-cabocla	0
+fumée	2113	Araqua-pintado	0
+fumée	2124	Araqua-pintado	0
+
 ====[tsv-split --seed-value 15017 --num-files 2 --key-fields 1 ../input4x58.tsv]====
 ==> ./tsvsplit_workdir/part_0.tsv <==
 c-1	c-2	c-3	c-4
@@ -1471,6 +1599,86 @@ marrón	2034	Weißwangengans	1
 fumée	2124	Araqua-pintado	0
 
 ====[tsv-split -I -s -n 11 -k 3 ../input4x58.tsv]====
+==> ./tsvsplit_workdir/part_00.tsv <==
+BLUTROT	2142	TÜPFELSUMPFHUHN	1
+BLUTROT	2142	TÜPFELSUMPFHUHN	1
+
+==> ./tsvsplit_workdir/part_01.tsv <==
+blutrot	2121	Воробей	4
+marrón	2102	Weißwangengans	1
+noir	2082	Weißwangengans	1
+noir	2094	Weißwangengans	4
+красный	2049	Weißwangengans	3
+noir	2115	Weißwangengans	2
+marrón	2034	Weißwangengans	1
+
+==> ./tsvsplit_workdir/part_02.tsv <==
+schneeweiß	2117	Porrón Islándico	4
+schneeweiß	2121	Porrón Islándico	1
+
+==> ./tsvsplit_workdir/part_03.tsv <==
+Cerise	2076	Malvasía Cabeciblanca	4
+暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
+zitronengelb	2136	Macreuse à bec jaune	3
+zitronengelb	2083	Macreuse à bec jaune	4
+púrpura	2070	Macreuse à bec jaune	2
+púrpura	2092	Macreuse à bec jaune	4
+púrpura	2093	Macreuse à bec jaune	4
+dorado	2045	Лебедь	2
+Cerise	2119	Malvasía Cabeciblanca	4
+púrpura	2145	Macreuse à bec jaune	2
+
+==> ./tsvsplit_workdir/part_04.tsv <==
+grünspan	2145	PIPIT DE GODLEWSKI	4
+grünspan	2145	PIPIT DE GODLEWSKI	4
+
+==> ./tsvsplit_workdir/part_05.tsv <==
+GRÜNSPAN	2145	pipit de godlewski	4
+GRÜNSPAN	2145	pipit de godlewski	4
+fumée	2113	Araqua-pintado	0
+fumée	2124	Araqua-pintado	0
+
+==> ./tsvsplit_workdir/part_06.tsv <==
+púrpura	2088	Macuco	1
+púrpura	2119	Macuco	4
+
+==> ./tsvsplit_workdir/part_07.tsv <==
+Blutrot	2142	tüpfelsumpfhuhn	1
+Blutrot	2142	tüpfelsumpfhuhn	1
+
+==> ./tsvsplit_workdir/part_08.tsv <==
+rouge	2135	Marreca-cabocla	1
+café	2019	Marreca-cabocla	1
+rouge	2037	Marreca-cabocla	0
+
+==> ./tsvsplit_workdir/part_09.tsv <==
+blutrot	2142	Tüpfelsumpfhuhn	1
+blutrot	2118	Tüpfelsumpfhuhn	4
+blutrot	2117	Tüpfelsumpfhuhn	0
+blutrot	2143	Tüpfelsumpfhuhn	4
+blutrot	2149	Tüpfelsumpfhuhn	1
+blutrot	2120	Tüpfelsumpfhuhn	1
+
+==> ./tsvsplit_workdir/part_10.tsv <==
+Indigo	2056	Голубь	1
+Indigo	2141	Голубь	1
+café	2088	Purpurreiher	2
+Orange-red	2089	Purpurreiher	1
+rouge	2132	Löffelente	4
+Grünspan	2145	Pipit de Godlewski	4
+rouge	2146	Löffelente	1
+café	2062	Purpurreiher	4
+blanc	2137	Голубь	2
+café	2100	Purpurreiher	2
+blanc	2109	Голубь	3
+Grünspan	2082	Pipit de Godlewski	2
+café	2041	Purpurreiher	4
+Indigo	2138	Голубь	4
+Grünspan	2053	Pipit de Godlewski	4
+blanc	2038	Голубь	0
+Grünspan	2071	Pipit de Godlewski	3
+
+====[tsv-split -I -s -n 11 -k c\-3 ../input4x58.tsv]====
 ==> ./tsvsplit_workdir/part_00.tsv <==
 BLUTROT	2142	TÜPFELSUMPFHUHN	1
 BLUTROT	2142	TÜPFELSUMPFHUHN	1

--- a/tsv-split/tests/tests.sh
+++ b/tsv-split/tests/tests.sh
@@ -353,6 +353,9 @@ runtest_wdir ${prog} "-s -n 17 -k 1,3 ${testdir_relpath}/input4x58.tsv" ${key_as
 runtest_wdir ${prog} "-s -n 101 -k 1,3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 runtest_wdir ${prog} "-s -n 2 -k 1,3,4 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 
+runtest_wdir ${prog} "--header -s -n 2 -k c\-3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
+runtest_wdir ${prog} "-H -s -n 2 -k c\-1,c\-3,c\-4 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
+
 runtest_wdir ${prog} "--seed-value 15017 --num-files 2 --key-fields 1 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 runtest_wdir ${prog} "-v 15017 -n 101 -k 3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 
@@ -364,6 +367,7 @@ runtest_wdir ${prog} "-H -v 15017 -n 101 -k 1,3 ${testdir_relpath}/input4x58.tsv
 
 runtest_wdir ${prog} "--header-in-only --static-seed --num-files 2 --key-fields 1 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 runtest_wdir ${prog} "-I -s -n 11 -k 3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
+runtest_wdir ${prog} "-I -s -n 11 -k c\-3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 runtest_wdir ${prog} "-I -s -n 101 -k 1,3 ${testdir_relpath}/input4x58.tsv" ${key_assignment_tests}
 runtest_wdir ${prog} "-I -v 15017 -n 101 -k 1,3 ${testdir_relpath}/input4x58.tsv ${testdir_relpath}/input4x18.tsv" ${key_assignment_tests}
 
@@ -459,6 +463,9 @@ runtest ${prog} "-l 10 -n 3 -k 1 input4x58.tsv" ${error_tests_1}
 runtest ${prog} "-l 10 --header --header-in-only input4x58.tsv" ${error_tests_1}
 runtest ${prog} "-n 2 --prefix dir/file input4x58.tsv" ${error_tests_1}
 runtest ${prog} "-n 2 --suffix ab/cd input4x58.tsv" ${error_tests_1}
+runtest ${prog} "-n 2 --key-fields c\-1 input4x58.tsv" ${error_tests_1}
+runtest ${prog} "-n 2 -H --key-fields c-1 input4x58.tsv" ${error_tests_1}
+runtest ${prog} "-n 2 -I --key-fields c-1 input4x58.tsv" ${error_tests_1}
 runtest_wdir_ulimit ${prog} "-s -n 101 -k 3 --max-open-files 6 ${testdir_relpath}/input4x58.tsv" ${error_tests_1} 5
 runtest_wdir_ulimit ${prog} "-s -n 101 -k 3 ${testdir_relpath}/input4x58.tsv" ${error_tests_1} 4
 runtest_wdir_append ${prog} "-l 3" ${error_tests_1} ${testdir_relpath}/input1x5.txt ${testdir_relpath}/input1x5.txt


### PR DESCRIPTION
This PR is a follow-on to PRs #284, #285, #286, #288, and #289. It adds named field support to tsv-uniq. It works the same way as the support added to tsv-select, see PR #284 for more info.

Named field support is backward compatible with numeric fields. As with the other tools, this support is not documented yet, even in the help text. Documentation will be added when named field support has been added to all tools and a release performed.

This PR also fixes a regression introduced in PR #290. That PR incorrectly identified field groups containing a backslash escaped hyphen as a mixed named-numeric ranges. These were flagged as invalid, incorrectly terminating command line argument processing.

This is a step towards enhancement request #25.