### PR TITLE
tsv-sample named field support

### DIFF
--- a/tsv-sample/tests/gold/basic_tests_1.txt
+++ b/tsv-sample/tests/gold/basic_tests_1.txt
@@ -133,6 +133,24 @@ random_value	line	title	weight
 0.98790073658052613	16	Leabhráin an Irisleabhair—III	53
 0.98749557482104600	20	羅生門	87
 
+====[tsv-sample -H -s --print-random -w weight --num 15 input3x10.tsv input3x25.tsv]====
+random_value	line	title	weight
+0.99908579189996327	4	Soitannollisia satuja ja jutelmia	44
+0.99901558340711527	8	Door het land der Skipetaren	30
+0.99879172703983321	23	佛說四十二章經	81
+0.99865837418900094	11	Il "Damo viennese"	23
+0.99825480062516203	24	La Navidad en las Montañas	100
+0.99794680410799219	1	Белые ночи	98
+0.99624994223962704	19	Annie Laurie and Azalea	85
+0.99543373928688561	6	Große und kleine Welt	91
+0.99378709513896757	12	הצופה לבית ישראל	91
+0.99263530964898050	14	Pasáček Ali: Pověst z východu	64
+0.99222012414636029	18	Right Half Hollins	67
+0.99064333596333232	22	豆棚閒話	73
+0.98948484575632678	17	Diné yázhí ba'áłchíní	88
+0.98790073658052613	16	Leabhráin an Irisleabhair—III	53
+0.98749557482104600	20	羅生門	87
+
 ====[tsv-sample -H -s --print-random -n 15 input3x10.tsv input3x25.tsv]====
 random_value	line	title	weight
 0.97088520275428891	8	Door het land der Skipetaren	30
@@ -355,6 +373,24 @@ line	title	weight
 23	佛說四十二章經	81
 24	La Navidad en las Montañas	100
 
+====[tsv-sample -H -s --inorder -n 15 --weight-field weight input3x10.tsv input3x25.tsv]====
+line	title	weight
+4	Soitannollisia satuja ja jutelmia	44
+8	Door het land der Skipetaren	30
+1	Белые ночи	98
+6	Große und kleine Welt	91
+11	Il "Damo viennese"	23
+12	הצופה לבית ישראל	91
+14	Pasáček Ali: Pověst z východu	64
+16	Leabhráin an Irisleabhair—III	53
+17	Diné yázhí ba'áłchíní	88
+18	Right Half Hollins	67
+19	Annie Laurie and Azalea	85
+20	羅生門	87
+22	豆棚閒話	73
+23	佛說四十二章經	81
+24	La Navidad en las Montañas	100
+
 ====[tsv-sample -H -s --prob 1.0 --print-random input3x10.tsv input3x25.tsv]====
 random_value	line	title	weight
 0.010968807619065046	1	Álomvilág: Elbeszélések	41
@@ -467,7 +503,47 @@ café	2019	Marreca-cabocla	1
 blutrot	2093	Araqua-pintado	2
 jaune	2104	Tüpfelsumpfhuhn	1
 
+====[tsv-sample -H -s --prob .25 -k c\-3,c\-1 input4x50.tsv input4x15.tsv]====
+c-1	c-2	c-3	c-4
+púrpura	2088	Macuco	1
+schneeweiß	2117	Porrón Islándico	4
+café	2088	Purpurreiher	2
+Orange-red	2089	Purpurreiher	1
+púrpura	2070	Macreuse à bec jaune	2
+púrpura	2092	Macreuse à bec jaune	4
+púrpura	2093	Macreuse à bec jaune	4
+schneeweiß	2121	Porrón Islándico	1
+café	2062	Purpurreiher	4
+café	2100	Purpurreiher	2
+красный	2049	Weißwangengans	3
+púrpura	2119	Macuco	4
+púrpura	2145	Macreuse à bec jaune	2
+café	2041	Purpurreiher	4
+café	2019	Marreca-cabocla	1
+blutrot	2093	Araqua-pintado	2
+jaune	2104	Tüpfelsumpfhuhn	1
+
 ====[tsv-sample -H -s --prob .25 -k 3,1 --inorder input4x50.tsv input4x15.tsv]====
+c-1	c-2	c-3	c-4
+púrpura	2088	Macuco	1
+schneeweiß	2117	Porrón Islándico	4
+café	2088	Purpurreiher	2
+Orange-red	2089	Purpurreiher	1
+púrpura	2070	Macreuse à bec jaune	2
+púrpura	2092	Macreuse à bec jaune	4
+púrpura	2093	Macreuse à bec jaune	4
+schneeweiß	2121	Porrón Islándico	1
+café	2062	Purpurreiher	4
+café	2100	Purpurreiher	2
+красный	2049	Weißwangengans	3
+púrpura	2119	Macuco	4
+púrpura	2145	Macreuse à bec jaune	2
+café	2041	Purpurreiher	4
+café	2019	Marreca-cabocla	1
+blutrot	2093	Araqua-pintado	2
+jaune	2104	Tüpfelsumpfhuhn	1
+
+====[tsv-sample -H -s --prob .25 -k c\-3,c\-1 --inorder input4x50.tsv input4x15.tsv]====
 c-1	c-2	c-3	c-4
 púrpura	2088	Macuco	1
 schneeweiß	2117	Porrón Islándico	4
@@ -690,6 +766,19 @@ random_value	c-1	c-2	c-3	c-4
 2	Orange-red	2089	Purpurreiher	1
 0	暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 
+====[tsv-sample -H -s -p .2 -k c\-3 --gen-random-inorder -n 10 input4x50.tsv input4x15.tsv]====
+random_value	c-1	c-2	c-3	c-4
+3	púrpura	2088	Macuco	1
+3	blutrot	2142	Tüpfelsumpfhuhn	1
+2	Indigo	2056	Голубь	1
+2	Indigo	2141	Голубь	1
+3	blutrot	2118	Tüpfelsumpfhuhn	4
+0	Cerise	2076	Malvasía Cabeciblanca	4
+3	schneeweiß	2117	Porrón Islándico	4
+2	café	2088	Purpurreiher	2
+2	Orange-red	2089	Purpurreiher	1
+0	暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
+
 ====[tsv-sample --static-seed --compatibility-mode input2x10_noheader.tsv input2x5_noheader.tsv]====
 0.20987466	殘唐五代史演義傳
 0.67881307	Burning Daylight
@@ -844,6 +933,12 @@ random_value@title@weight
 0.99924716274568337@友情@5992
 
 ====[tsv-sample -d @ -H -s --print-random -w 2 -n 3 input2x7_atsign.tsv]====
+random_value@title@weight
+0.99999318254827740@幽霊書店@5903
+0.99994907561939606@Aristophanis Lysistrata@5464
+0.99988270641217591@マルチン・ルターの小信仰問答書@5489
+
+====[tsv-sample -d @ -H -s --print-random -w weight -n 3 input2x7_atsign.tsv]====
 random_value@title@weight
 0.99999318254827740@幽霊書店@5903
 0.99994907561939606@Aristophanis Lysistrata@5464
@@ -1126,6 +1221,26 @@ line	title	weight
 line	title	weight
 
 ====[cat input3x10.tsv tsv-sample -H -s -w 3 --compatibility-mode -- input3x3.tsv - input3x4.tsv]====
+line	title	weight
+1	Álomvilág: Elbeszélések	41
+5	Pinocchion seikkailut	19
+8	Door het land der Skipetaren	30
+3	Le Silence de la mer	72
+3	Mesék és regék	20
+4	Soitannollisia satuja ja jutelmia	44
+3	The Catcher in the Rye	19
+7	Oude Egyptische Legenden	28
+9	Las Fábulas de Esopo	45
+2	A Room of One's Own	62
+1	Aurélien	36
+2	Grimm testvérek összegyüjtött meséi	9
+6	Piepkuikentje	17
+4	Ficciones	23
+1	Thérèse Desqueyroux	43
+2	Bonjour Tristesse	3
+10	Platero y yo	2
+
+====[cat input3x10.tsv tsv-sample -H -s -w weight --compatibility-mode -- input3x3.tsv - input3x4.tsv]====
 line	title	weight
 1	Álomvilág: Elbeszélések	41
 5	Pinocchion seikkailut	19

--- a/tsv-sample/tests/gold/error_tests_1.txt
+++ b/tsv-sample/tests/gold/error_tests_1.txt
@@ -15,8 +15,21 @@ Error [tsv-sample]: Could not process line: Not enough fields on line. Number re
   File: input3x25.tsv Line: 2
 line	title	weight
 
+====[tsv-sample -H -w 0 input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: [--w|weight-field] Field numbers must be greater than zero: '0'.
+
+====[tsv-sample -H -w no_such_field input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: [--w|weight-field] Field not found in file header: 'no_such_field'.
+
+====[tsv-sample -w weight input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: [--w|weight-field] Non-numeric field group: 'weight'. Use '--H|header' when using named field groups.
+
 ====[tsv-sample -H -w 3 input3x25_dos.tsv]====
-Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -w weight input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input3x25_dos.tsv, Line: 1
 
 ====[tsv-sample -w 1 input2x5_noheader_dos.tsv]====
@@ -24,6 +37,9 @@ Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines
   File: input2x5_noheader_dos.tsv, Line: 1
 
 ====[tsv-sample --prob 0.5 --weight-field 3 input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: --w|weight-field and --p|prob cannot be used together.
+
+====[tsv-sample --prob 0.5 --weight-field 0 input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: --w|weight-field and --p|prob cannot be used together.
 
 ====[tsv-sample --prob 0 input3x25.tsv]====
@@ -59,6 +75,9 @@ Error [tsv-sample]: Not enough fields in line. File: input4x50.tsv, Line: 1
 ====[tsv-sample -H -p 0.5 -k 5 input4x50.tsv input4x15.tsv]====
 Error [tsv-sample]: Not enough fields in line. File: input4x50.tsv, Line: 2
 c-1	c-2	c-3	c-4
+
+====[tsv-sample -H -p 0.5 -k no_such_field input4x50.tsv input4x15.tsv]====
+[tsv-sample] Error processing command line arguments: [--k|key-fields] Field not found in file header: 'no_such_field'.
 
 ====[tsv-sample -p 0.05 -k 1 --compatibility-mode input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: Distinct sampling (--k|key-fields --p|prob) does not support --compatibility-mode.

--- a/tsv-sample/tests/gold/error_tests_1.txt
+++ b/tsv-sample/tests/gold/error_tests_1.txt
@@ -24,6 +24,15 @@ line	title	weight
 ====[tsv-sample -w weight input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: [--w|weight-field] Non-numeric field group: 'weight'. Use '--H|header' when using named field groups.
 
+====[tsv-sample -H -w weight,line input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: '--w|weight-field' must be a single field.
+
+====[tsv-sample -H -w line,weight input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: '--w|weight-field' must be a single field.
+
+====[tsv-sample -w 1,3 input3x25.tsv]====
+[tsv-sample] Error processing command line arguments: '--w|weight-field' must be a single field.
+
 ====[tsv-sample -H -w 3 input3x25_dos.tsv]====
 [tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input3x25_dos.tsv, Line: 1

--- a/tsv-sample/tests/tests.sh
+++ b/tsv-sample/tests/tests.sh
@@ -205,6 +205,9 @@ runtest ${prog} "-H -w 11 input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w 0 input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w no_such_field input3x25.tsv" ${error_tests}
 runtest ${prog} "-w weight input3x25.tsv" ${error_tests}
+runtest ${prog} "-H -w weight,line input3x25.tsv" ${error_tests}
+runtest ${prog} "-H -w line,weight input3x25.tsv" ${error_tests}
+runtest ${prog} "-w 1,3 input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w 3 input3x25_dos.tsv" ${error_tests}
 runtest ${prog} "-H -w weight input3x25_dos.tsv" ${error_tests}
 runtest ${prog} "-w 1 input2x5_noheader_dos.tsv" ${error_tests}

--- a/tsv-sample/tests/tests.sh
+++ b/tsv-sample/tests/tests.sh
@@ -43,6 +43,7 @@ runtest ${prog} "--header --static-seed --compatibility-mode input3x10.tsv input
 runtest ${prog} "-H -s --print-random input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --print-random --weight-field 3 input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --print-random -w 3 --num 15 input3x10.tsv input3x25.tsv" ${basic_tests_1}
+runtest ${prog} "-H -s --print-random -w weight --num 15 input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --print-random -n 15 input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -n 100  --compatibility-mode input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --gen-random-inorder --weight-field 3 input3x10.tsv input3x25.tsv" ${basic_tests_1}
@@ -52,6 +53,7 @@ runtest ${prog} "-H -s --gen-random-inorder -n 15 input3x10.tsv input3x25.tsv" $
 runtest ${prog} "-H -s --inorder -n 15 --compatibility-mode input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --inorder -n 15 --prefer-algorithm-r input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --inorder -n 15 --weight-field 3 input3x10.tsv input3x25.tsv" ${basic_tests_1}
+runtest ${prog} "-H -s --inorder -n 15 --weight-field weight input3x10.tsv input3x25.tsv" ${basic_tests_1}
 
 # Bernoulli sampling
 runtest ${prog} "-H -s --prob 1.0 --print-random input3x10.tsv input3x25.tsv" ${basic_tests_1}
@@ -67,7 +69,9 @@ runtest ${prog} "-s --r input2x5_noheader.tsv --num 7 --compatibility-mode" ${ba
 
 # Distinct Sampling
 runtest ${prog} "-H -s --prob .25 -k 3,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "-H -s --prob .25 -k c\-3,c\-1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --prob .25 -k 3,1 --inorder input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "-H -s --prob .25 -k c\-3,c\-1 --inorder input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .25 -k 1,3 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .25 -k 1,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .25 --key-fields 1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
@@ -78,6 +82,7 @@ runtest ${prog} "-s -p 1 -k 3,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .2 -k 3 --print-random input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .2 -k 3 --print-random -n 5 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .2 -k 3 --gen-random-inorder -n 10 input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "-H -s -p .2 -k c\-3 --gen-random-inorder -n 10 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 
 runtest ${prog} "--static-seed --compatibility-mode input2x10_noheader.tsv input2x5_noheader.tsv" ${basic_tests_1}
 runtest ${prog} "-s --print-random input2x10_noheader.tsv input2x5_noheader.tsv" ${basic_tests_1}
@@ -94,6 +99,7 @@ runtest ${prog} "--delimiter @ -H --static-seed --compatibility-mode input2x7_at
 runtest ${prog} "-d @ -H -s --print-random input2x7_atsign.tsv" ${basic_tests_1}
 runtest ${prog} "-d @ -H -s --print-random -w 2 input2x7_atsign.tsv" ${basic_tests_1}
 runtest ${prog} "-d @ -H -s --print-random -w 2 -n 3 input2x7_atsign.tsv" ${basic_tests_1}
+runtest ${prog} "-d @ -H -s --print-random -w weight -n 3 input2x7_atsign.tsv" ${basic_tests_1}
 runtest ${prog} "-d @ -H -s --print-random -n 20 input2x7_atsign.tsv" ${basic_tests_1}
 runtest ${prog} "-d @ -H -s --print-random --prob 1.0 input2x7_atsign.tsv" ${basic_tests_1}
 
@@ -128,6 +134,8 @@ cat input3x3.tsv | ${prog} -s --compatibility-mode -- input3x4.tsv - >> ${basic_
 echo "" >> ${basic_tests_1}; echo "====[cat input3x10.tsv tsv-sample -H -s -w 3 --compatibility-mode -- input3x3.tsv - input3x4.tsv]====" >> ${basic_tests_1}
 cat input3x10.tsv | ${prog} -H -s -w 3 --compatibility-mode -- input3x3.tsv - input3x4.tsv >> ${basic_tests_1} 2>&1
 
+echo "" >> ${basic_tests_1}; echo "====[cat input3x10.tsv tsv-sample -H -s -w weight --compatibility-mode -- input3x3.tsv - input3x4.tsv]====" >> ${basic_tests_1}
+cat input3x10.tsv | ${prog} -H -s -w weight --compatibility-mode -- input3x3.tsv - input3x4.tsv >> ${basic_tests_1} 2>&1
 
 echo "" >> ${basic_tests_1}; echo "====[cat input3x10.tsv tsv-sample -H -s --replace --num 10 --compatibility-mode]====" >> ${basic_tests_1}
 cat input3x10.tsv | ${prog} -H -s --replace --num 10 --compatibility-mode >> ${basic_tests_1} 2>&1
@@ -194,9 +202,14 @@ runtest ${prog} "no_such_file.tsv" ${error_tests}
 runtest ${prog} "--no-such-param input3x25.tsv" ${error_tests}
 runtest ${prog} "-d ß input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w 11 input3x25.tsv" ${error_tests}
+runtest ${prog} "-H -w 0 input3x25.tsv" ${error_tests}
+runtest ${prog} "-H -w no_such_field input3x25.tsv" ${error_tests}
+runtest ${prog} "-w weight input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w 3 input3x25_dos.tsv" ${error_tests}
+runtest ${prog} "-H -w weight input3x25_dos.tsv" ${error_tests}
 runtest ${prog} "-w 1 input2x5_noheader_dos.tsv" ${error_tests}
 runtest ${prog} "--prob 0.5 --weight-field 3 input3x25.tsv" ${error_tests}
+runtest ${prog} "--prob 0.5 --weight-field 0 input3x25.tsv" ${error_tests}
 runtest ${prog} "--prob 0 input3x25.tsv" ${error_tests}
 runtest ${prog} "--prob 1.00001 input3x25.tsv" ${error_tests}
 runtest ${prog} "-p .1 -k 0,1 input4x50.tsv input4x15.tsv" ${error_tests}
@@ -208,6 +221,7 @@ runtest ${prog} "-p 0.5 -v -10 -k 1 input4x50.tsv input4x15.tsv" ${error_tests}
 runtest ${prog} "-k 1 input4x50.tsv input4x15.tsv" ${error_tests}
 runtest ${prog} "-p 0.5 -k 5 input4x50.tsv input4x15.tsv" ${error_tests}
 runtest ${prog} "-H -p 0.5 -k 5 input4x50.tsv input4x15.tsv" ${error_tests}
+runtest ${prog} "-H -p 0.5 -k no_such_field input4x50.tsv input4x15.tsv" ${error_tests}
 runtest ${prog} "-p 0.05 -k 1 --compatibility-mode input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -p 0.5 --gen-random-inorder input4x50.tsv input4x15.tsv" ${error_tests}
 runtest ${prog} "-H --gen-random-inorder -d , --random-value-header abc,def input3x25.tsv" ${error_tests}

--- a/tsv-select/tests/gold/basic_tests_1.txt
+++ b/tsv-select/tests/gold/basic_tests_1.txt
@@ -1312,6 +1312,22 @@ field3
 13888
 23888
 
+====[tsv-select -H input_header_variants.tsv -f '濡れ羽色,ab\*56,ab.56,ab\,56,ab/56,ab\56,ab\-56,ab\ 56,ab\:56,56\*7,56.7,56\,7,56/7,56\7,56\-7,56\ 7,56\:7,\01,\1,ab\*c,ab\.c,ab\,c,ab/c,ab\c,ab\-c,ab\ c,ab\:c']===
+濡れ羽色	ab*56	ab.56	ab,56	ab/56	ab\56	ab-56	ab 56	ab:56	56*7	56.7	56,7	56/7	56\7	56-7	56 7	56:7	01	1	ab*c	ab.c	ab,c	ab/c	ab\c	ab-c	ab c	ab:c
+r1c26	r1c25	r1c24	r1c23	r1c22	r1c21	r1c20	r1c19	r1c18	r1c17	r1c16	r1c15	r1c14	r1c13	r1c12	r1c11	r1c10	r1c9	r1c8	r1c7	r1c6	r1c5	r1c4	r1c3	r1c2	r1c1	r1c0
+
+====[tsv-select -H input_header_variants.tsv -f '濡れ羽色-ab\:c']===
+濡れ羽色	ab*56	ab.56	ab,56	ab/56	ab\56	ab-56	ab 56	ab:56	56*7	56.7	56,7	56/7	56\7	56-7	56 7	56:7	01	1	ab*c	ab.c	ab,c	ab/c	ab\c	ab-c	ab c	ab:c
+r1c26	r1c25	r1c24	r1c23	r1c22	r1c21	r1c20	r1c19	r1c18	r1c17	r1c16	r1c15	r1c14	r1c13	r1c12	r1c11	r1c10	r1c9	r1c8	r1c7	r1c6	r1c5	r1c4	r1c3	r1c2	r1c1	r1c0
+
+====[tsv-select -H input_header_variants.tsv -f 'ab\-56-56\-7,ab\,c,ab\-c]===
+ab-56	ab 56	ab:56	56*7	56.7	56,7	56/7	56\7	56-7	ab,c	ab-c
+r1c20	r1c19	r1c18	r1c17	r1c16	r1c15	r1c14	r1c13	r1c12	r1c5	r1c2
+
+====[tsv-select -H input_header_variants.tsv -f '濡れ羽色-ab\*56,ab.56-ab\,56,ab/56-ab\56,ab\-56-ab\ 56,ab\:56-56\*7,56.7-56\,7,56/7-56\7,56\-7-56\ 7,56\:7-\01,\1-ab\*c,ab\.c-ab\,c,ab/c-ab\c,ab\-c-ab\ c,ab\:c']===
+濡れ羽色	ab*56	ab.56	ab,56	ab/56	ab\56	ab-56	ab 56	ab:56	56*7	56.7	56,7	56/7	56\7	56-7	56 7	56:7	01	1	ab*c	ab.c	ab,c	ab/c	ab\c	ab-c	ab c	ab:c
+r1c26	r1c25	r1c24	r1c23	r1c22	r1c21	r1c20	r1c19	r1c18	r1c17	r1c16	r1c15	r1c14	r1c13	r1c12	r1c11	r1c10	r1c9	r1c8	r1c7	r1c6	r1c5	r1c4	r1c3	r1c2	r1c1	r1c0
+
 Help and Version printing 1
 -----------------
 

--- a/tsv-select/tests/input_header_variants.tsv
+++ b/tsv-select/tests/input_header_variants.tsv
@@ -1,0 +1,2 @@
+ab:c	ab c	ab-c	ab\c	ab/c	ab,c	ab.c	ab*c	1	01	56:7	56 7	56-7	56\7	56/7	56,7	56.7	56*7	ab:56	ab 56	ab-56	ab\56	ab/56	ab,56	ab.56	ab*56	濡れ羽色
+r1c0	r1c1	r1c2	r1c3	r1c4	r1c5	r1c6	r1c7	r1c8	r1c9	r1c10	r1c11	r1c12	r1c13	r1c14	r1c15	r1c16	r1c17	r1c18	r1c19	r1c20	r1c21	r1c22	r1c23	r1c24	r1c25	r1c26

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -190,6 +190,19 @@ runtest ${prog} "-H -e field1,field2,field3 input_header3.tsv input_header3.tsv 
 runtest ${prog} "-H -e *2 input_header3.tsv input_header3.tsv input_header1.tsv" ${basic_tests_1}
 runtest ${prog} "-H -e field1-field2 input_header1.tsv input_header2.tsv input_header3.tsv input_header4.tsv" ${basic_tests_1}
 
+## Named field tests: Header field escaping cases
+echo "" >> ${basic_tests_1}; echo "====[tsv-select -H input_header_variants.tsv -f '濡れ羽色,ab\*56,ab.56,ab\,56,ab/56,ab\\56,ab\-56,ab\ 56,ab\:56,56\*7,56.7,56\,7,56/7,56\\7,56\-7,56\ 7,56\:7,\01,\1,ab\*c,ab\.c,ab\,c,ab/c,ab\\c,ab\-c,ab\ c,ab\:c']===" >> ${basic_tests_1}
+${prog} -H input_header_variants.tsv -f '濡れ羽色,ab\*56,ab.56,ab\,56,ab/56,ab\\56,ab\-56,ab\ 56,ab\:56,56\*7,56.7,56\,7,56/7,56\\7,56\-7,56\ 7,56\:7,\01,\1,ab\*c,ab\.c,ab\,c,ab/c,ab\\c,ab\-c,ab\ c,ab\:c' >> ${basic_tests_1} 2>&1
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-select -H input_header_variants.tsv -f '濡れ羽色-ab\:c']===" >> ${basic_tests_1}
+${prog} -H input_header_variants.tsv -f '濡れ羽色-ab\:c' >> ${basic_tests_1} 2>&1
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-select -H input_header_variants.tsv -f 'ab\-56-56\-7,ab\,c,ab\-c]===" >> ${basic_tests_1}
+${prog} -H input_header_variants.tsv -f 'ab\-56-56\-7,ab\,c,ab\-c' >> ${basic_tests_1} 2>&1
+
+echo "" >> ${basic_tests_1}; echo "====[tsv-select -H input_header_variants.tsv -f '濡れ羽色-ab\*56,ab.56-ab\,56,ab/56-ab\\56,ab\-56-ab\ 56,ab\:56-56\*7,56.7-56\,7,56/7-56\\7,56\-7-56\ 7,56\:7-\01,\1-ab\*c,ab\.c-ab\,c,ab/c-ab\\c,ab\-c-ab\ c,ab\:c']===" >> ${basic_tests_1}
+${prog} -H input_header_variants.tsv -f '濡れ羽色-ab\*56,ab.56-ab\,56,ab/56-ab\\56,ab\-56-ab\ 56,ab\:56-56\*7,56.7-56\,7,56/7-56\\7,56\-7-56\ 7,56\:7-\01,\1-ab\*c,ab\.c-ab\,c,ab/c-ab\\c,ab\-c-ab\ c,ab\:c' >> ${basic_tests_1} 2>&1
+
 ## Help and Version printing
 
 echo "" >> ${basic_tests_1}

--- a/tsv-split/src/tsv_utils/tsv-split.d
+++ b/tsv-split/src/tsv_utils/tsv-split.d
@@ -294,9 +294,6 @@ struct TsvSplitOptions
                 "l|lines-per-file", "NUM  Number of lines to write to each output file (excluding the header line).", &linesPerFile,
                 "n|num-files",      "NUM  Number of output files to generate.", &numFiles,
 
-                //"k|key-fields",     "<field-list>  Fields to use as key. Lines with the same key are written to the same output file. Use '--k|key-fields 0' to use the entire line as the key.",
-                //keyFields.makeFieldListOptionHandler!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero),
-
                 keyFieldsOptionString,
                 "<field-list>  Fields to use as key. Lines with the same key are written to the same output file. Use '--k|key-fields 0' to use the entire line as the key.",
                 &keyFieldsArg,


### PR DESCRIPTION
This PR is a follow-on to the named field PR series start with PR #284. It adds named field support to tsv-uniq. It works the same way as the support added to `tsv-select`, see PR #284 for more info.

Named field support is backward compatible with numeric fields. As with the other tools, this support is not documented yet, even in the help text. Documentation will be added prior to performing release.

This PR also adds some additional header field variation matches to the `tsv-select` tests. Mainly tests for field names requiring escapes. This is well tested at the unit test level, but its also useful to have some tests at the executable level.

With completion of this PR, all the tools taking fields as command line arguments have basic support for named fields. Documentation needs to be done (include help text), and there's a certain amount of cleanup to do in command line argument processing code for several tools.

This is a step towards enhancement request #25.