### PR TITLE
Fieldlists: Refactor command line arg processing, part 1

### DIFF
--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -288,9 +288,20 @@ Error [tsv-filter]: Could not process line or field: no digits seen for input "f
   Is this a header line? Use --header to skip.
 
 ====[tsv-filter --header --eq 2:1 input1_dos.tsv]====
-Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+[tsv-filter] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1
 
 ====[tsv-filter --str-eq 4:ABC input1_dos.tsv]====
 Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1
+
+====[tsv-filter --header --eq 2:1 input1.tsv input1_dos.tsv]====
+Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1
+F1	F2	F3	F4
+1	1.0	a	A
+
+====[tsv-filter --str-eq 4:ABC input1.tsv input1_dos.tsv]====
+Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1
+10	10.1	abc	ABC

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -555,4 +555,6 @@ cat input_3x2.tsv | ${prog} --ge 2:23 >> ${error_tests_1} 2>&1
 ## Windows line endings
 runtest ${prog} "--header --eq 2:1 input1_dos.tsv" ${error_tests_1}
 runtest ${prog} "--str-eq 4:ABC input1_dos.tsv" ${error_tests_1}
+runtest ${prog} "--header --eq 2:1 input1.tsv input1_dos.tsv" ${error_tests_1}
+runtest ${prog} "--str-eq 4:ABC input1.tsv input1_dos.tsv" ${error_tests_1}
 exit $?

--- a/tsv-join/src/tsv_utils/tsv-join.d
+++ b/tsv-join/src/tsv_utils/tsv-join.d
@@ -104,6 +104,7 @@ struct TsvJoinOptions
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist;
+        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
         bool helpVerbose = false;        // --help-verbose
         bool versionWanted = false;      // --V|version
@@ -187,73 +188,155 @@ struct TsvJoinOptions
             enforce(!(filterFile == "-" && cmdArgs.length == 1),
                     "A data file is required when standard input is used for the filter file (--f|filter-file -).");
 
-            filterSource = byLineSourceRange([filterFile]);
-
             string[] filepaths = (cmdArgs.length > 1) ? cmdArgs[1 .. $] : ["-"];
             cmdArgs.length = 1;
-            ReadHeader readHeader = hasHeader ? Yes.readHeader : No.readHeader;
-            inputSources = inputSourceRange(filepaths, readHeader);
 
-            /* Field-list args (--k|key-fields, --d|data-fields --a|append-fields are
-             * parsed after header lines from the filter file and first data file have
-             * been read. The files were opened in the previous step, when setting up
-             * the 'filterSource' and 'inputSources' ranges.
+             /* Validation and derivations - Do as much validation prior to header line
+             * processing as possible (avoids waiting on stdin).
              *
-             * The field-list parsing step translates any named fields to one-based
-             * field numbers. Note that a named field may have different field
-             * numbers in the filter file and data files.
-             *
-             * The 'derivations()' method works off the one-based indices, converting
-             * them to zero-based. It also handles the full-line cases.
+             * Note: In tsv-join, when header processing is on, there is very little
+             * validatation that can be done prior to reading the header line. All the
+             * logic is in the fieldListArgProcessing function.
              */
 
             string[] filterFileHeaderFields;
             string[] inputSourceHeaderFields;
 
-            if (hasHeader && !filterSource.front.byLine.empty)
+            /* fieldListArgProcessing encapsulates the field list dependent processing.
+             * It is called prior to reading the header line if headers are not being used,
+             * and after if headers are being used.
+             */
+            void fieldListArgProcessing()
             {
-                filterFileHeaderFields = filterSource.front.byLine.front.split(delim).to!(string[]);
-            }
+                import std.algorithm : all, each;
 
-            if (hasHeader) inputSourceHeaderFields = inputSources.front.header.split(delim).to!(string[]);
+                /* field list parsing. */
+                if (!keyFieldsArg.empty)
+                {
+                    keyFields =
+                        keyFieldsArg
+                        .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
+                        (hasHeader, filterFileHeaderFields, keyFieldsOptionString)
+                        .array;
+                }
 
-            if (!keyFieldsArg.empty)
+                if (!dataFieldsArg.empty)
+                {
+                    dataFields =
+                        dataFieldsArg
+                        .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
+                        (hasHeader, inputSourceHeaderFields, dataFieldsOptionString)
+                        .array;
+                }
+                else if (!keyFieldsArg.empty)
+                {
+                    dataFields =
+                        keyFieldsArg
+                        .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
+                        (hasHeader, inputSourceHeaderFields, dataFieldsOptionString)
+                        .array;
+                }
+
+                if (!appendFieldsArg.empty)
+                {
+                    appendFields =
+                        appendFieldsArg
+                        .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
+                        (hasHeader, filterFileHeaderFields, appendFieldsOptionString)
+                        .array;
+                }
+
+                /* Validations */
+                if (writeAll)
+                {
+                    enforce(appendFields.length != 0,
+                            "Use --a|append-fields when using --w|write-all.");
+
+                    enforce(!(appendFields.length == 1 && appendFields[0] == 0),
+                            "Cannot use '--a|append-fields 0' (whole line) when using --w|write-all.");
+                }
+
+                enforce(!(appendFields.length > 0 && exclude),
+                        "--e|exclude cannot be used with --a|append-fields.");
+
+                enforce(appendHeaderPrefix.length == 0 || hasHeader,
+                        "Use --header when using --p|prefix.");
+
+                enforce(dataFields.length == 0 || keyFields.length == dataFields.length,
+                        "Different number of --k|key-fields and --d|data-fields.");
+
+                enforce(keyFields.length != 1 ||
+                        dataFields.length != 1 ||
+                        (keyFields[0] == 0 && dataFields[0] == 0) ||
+                        (keyFields[0] != 0 && dataFields[0] != 0),
+                        "If either --k|key-field or --d|data-field is zero both must be zero.");
+
+                enforce((keyFields.length <= 1 || all!(a => a != 0)(keyFields)) &&
+                        (dataFields.length <= 1 || all!(a => a != 0)(dataFields)) &&
+                        (appendFields.length <= 1 || all!(a => a != 0)(appendFields)),
+                        "Field 0 (whole line) cannot be combined with individual fields (non-zero).");
+
+                /* Derivations. */
+
+                // Convert 'full-line' field indexes (index zero) to boolean flags.
+                if (keyFields.length == 0)
+                {
+                    assert(dataFields.length == 0);
+                    keyIsFullLine = true;
+                    dataIsFullLine = true;
+                }
+                else if (keyFields.length == 1 && keyFields[0] == 0)
+                {
+                    keyIsFullLine = true;
+                    keyFields.popFront;
+                    dataIsFullLine = true;
+
+                    if (dataFields.length == 1)
+                    {
+                        assert(dataFields[0] == 0);
+                        dataFields.popFront;
+                    }
+                }
+
+                if (appendFields.length == 1 && appendFields[0] == 0)
+                {
+                    appendFullLine = true;
+                    appendFields.popFront;
+                }
+
+                assert(!(keyIsFullLine && keyFields.length > 0));
+                assert(!(dataIsFullLine && dataFields.length > 0));
+                assert(!(appendFullLine && appendFields.length > 0));
+
+                // Switch to zero-based field indexes.
+                keyFields.each!((ref a) => --a);
+                dataFields.each!((ref a) => --a);
+                appendFields.each!((ref a) => --a);
+
+            } // End fieldListArgProcessing()
+
+
+            if (!hasHeader) fieldListArgProcessing();
+
+            /*
+             * Create the input source ranges for the filter file and data stream files
+             * and perform header line processing.
+             */
+
+            filterSource = byLineSourceRange([filterFile]);
+            ReadHeader readHeader = hasHeader ? Yes.readHeader : No.readHeader;
+            inputSources = inputSourceRange(filepaths, readHeader);
+
+            if (hasHeader)
             {
-                keyFields =
-                    keyFieldsArg
-                    .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
-                    (hasHeader, filterFileHeaderFields, keyFieldsOptionString)
-                    .array;
+                if (!filterSource.front.byLine.empty)
+                {
+                    throwIfWindowsNewlineOnUnix(filterSource.front.byLine.front, filterSource.front.name, 1);
+                    filterFileHeaderFields = filterSource.front.byLine.front.split(delim).to!(string[]);
+                }
+                inputSourceHeaderFields = inputSources.front.header.split(delim).to!(string[]);
+                fieldListArgProcessing();
             }
-
-            if (!dataFieldsArg.empty)
-            {
-                dataFields =
-                    dataFieldsArg
-                    .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
-                    (hasHeader, inputSourceHeaderFields, dataFieldsOptionString)
-                    .array;
-            }
-            else if (!keyFieldsArg.empty)
-            {
-                dataFields =
-                    keyFieldsArg
-                    .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
-                    (hasHeader, inputSourceHeaderFields, dataFieldsOptionString)
-                    .array;
-            }
-
-            if (!appendFieldsArg.empty)
-            {
-                appendFields =
-                    appendFieldsArg
-                    .parseFieldList!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)
-                    (hasHeader, filterFileHeaderFields, appendFieldsOptionString)
-                    .array;
-            }
-
-            consistencyValidations(cmdArgs);
-            derivations();
         }
         catch (Exception exc)
         {
@@ -261,85 +344,6 @@ struct TsvJoinOptions
             return tuple(false, 1);
         }
         return tuple(true, 0);
-    }
-
-    /* This routine does validations not handled by getopt, usually because they
-     * involve interactions between multiple parameters.
-     */
-    private void consistencyValidations(ref string[] processedCmdArgs)
-    {
-        import std.algorithm : all;
-
-        if (writeAll)
-        {
-            enforce(appendFields.length != 0,
-                    "Use --a|append-fields when using --w|write-all.");
-
-            enforce(!(appendFields.length == 1 && appendFields[0] == 0),
-                    "Cannot use '--a|append-fields 0' (whole line) when using --w|write-all.");
-        }
-
-        enforce(!(appendFields.length > 0 && exclude),
-                "--e|exclude cannot be used with --a|append-fields.");
-
-        enforce(appendHeaderPrefix.length == 0 || hasHeader,
-                "Use --header when using --p|prefix.");
-
-        enforce(dataFields.length == 0 || keyFields.length == dataFields.length,
-                "Different number of --k|key-fields and --d|data-fields.");
-
-        enforce(keyFields.length != 1 ||
-                dataFields.length != 1 ||
-                (keyFields[0] == 0 && dataFields[0] == 0) ||
-                (keyFields[0] != 0 && dataFields[0] != 0),
-                "If either --k|key-field or --d|data-field is zero both must be zero.");
-
-        enforce((keyFields.length <= 1 || all!(a => a != 0)(keyFields)) &&
-                (dataFields.length <= 1 || all!(a => a != 0)(dataFields)) &&
-                (appendFields.length <= 1 || all!(a => a != 0)(appendFields)),
-                "Field 0 (whole line) cannot be combined with individual fields (non-zero).");
-    }
-
-    /* Post-processing derivations. */
-    void derivations()
-    {
-        import std.algorithm : each;
-        import std.range;
-
-        // Convert 'full-line' field indexes (index zero) to boolean flags.
-        if (keyFields.length == 0)
-        {
-            assert(dataFields.length == 0);
-            keyIsFullLine = true;
-            dataIsFullLine = true;
-        }
-        else if (keyFields.length == 1 && keyFields[0] == 0)
-        {
-            keyIsFullLine = true;
-            keyFields.popFront;
-            dataIsFullLine = true;
-
-            if (dataFields.length == 1)
-            {
-                assert(dataFields[0] == 0);
-                dataFields.popFront;
-            }
-        }
-
-        if (appendFields.length == 1 && appendFields[0] == 0)
-        {
-            appendFullLine = true;
-            appendFields.popFront;
-        }
-
-        assert(!(keyIsFullLine && keyFields.length > 0));
-        assert(!(dataIsFullLine && dataFields.length > 0));
-        assert(!(appendFullLine && appendFields.length > 0));
-
-        // Switch to zero-based field indexes.
-        keyFields.each!((ref a) => --a);
-        dataFields.each!((ref a) => --a);
-        appendFields.each!((ref a) => --a);
     }
 }
 

--- a/tsv-join/tests/gold/basic_tests_1.txt
+++ b/tsv-join/tests/gold/basic_tests_1.txt
@@ -3186,7 +3186,6 @@ col a:col b:Field B
 ====[tsv-join -f input_emptyfile.tsv input2.tsv]====
 
 ====[tsv-join -H -f input_emptyfile.tsv input2.tsv]====
-f1	f2	f3	f4	f5
 
 ====[tsv-join -f input1.tsv input_emptyfile.tsv]====
 

--- a/tsv-join/tests/gold/error_tests_1.txt
+++ b/tsv-join/tests/gold/error_tests_1.txt
@@ -278,7 +278,7 @@ Error [tsv-join]: Not enough fields in line. File: input2_noheader.tsv, Line: 1
 ===Windows Newline detection===
 
 ====[tsv-join --header -f input1_dos.tsv -k 2,3 input2.tsv]====
-Error [tsv-join]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+[tsv-join] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1
 
 ====[tsv-join --header -f input1.tsv -k 2,3 input2_dos.tsv]====
@@ -302,7 +302,19 @@ Error [tsv-join]: Windows/DOS line ending found. Convert file to Unix newlines b
 [tsv-join] Error processing command line arguments: Cannot open file `no_such_file' in mode `rb' (No such file or directory)
 
 ====[tsv-join -f input1_noheader.tsv -k 2 -d 2,3 no_such-file.tsv]====
-[tsv-join] Error processing command line arguments: Cannot open file `no_such-file.tsv' in mode `rb' (No such file or directory)
+[tsv-join] Error processing command line arguments: Different number of --k|key-fields and --d|data-fields.
 
 ====[tsv-join -f no_such_file -k 2,3 -d 2 input2_noheader.tsv]====
+[tsv-join] Error processing command line arguments: Different number of --k|key-fields and --d|data-fields.
+
+====[tsv-join --header -f input1.tsv -k 2 -d 2 no_such-file.tsv]====
+[tsv-join] Error processing command line arguments: Cannot open file `no_such-file.tsv' in mode `rb' (No such file or directory)
+
+====[tsv-join --header -f no_such_file -k 2 -d 2 input2.tsv]====
+[tsv-join] Error processing command line arguments: Cannot open file `no_such_file' in mode `rb' (No such file or directory)
+
+====[tsv-join -f input1_noheader.tsv -k 2 -d 2 no_such-file.tsv]====
+[tsv-join] Error processing command line arguments: Cannot open file `no_such-file.tsv' in mode `rb' (No such file or directory)
+
+====[tsv-join -f no_such_file -k 2 -d 2 input2_noheader.tsv]====
 [tsv-join] Error processing command line arguments: Cannot open file `no_such_file' in mode `rb' (No such file or directory)

--- a/tsv-join/tests/gold/error_tests_1.txt
+++ b/tsv-join/tests/gold/error_tests_1.txt
@@ -282,7 +282,7 @@ Error [tsv-join]: Not enough fields in line. File: input2_noheader.tsv, Line: 1
   File: input1_dos.tsv, Line: 1
 
 ====[tsv-join --header -f input1.tsv -k 2,3 input2_dos.tsv]====
-Error [tsv-join]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+[tsv-join] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input2_dos.tsv, Line: 1
 
 ====[tsv-join -f input1_dos.tsv -k 2,3 input2.tsv]====

--- a/tsv-join/tests/tests.sh
+++ b/tsv-join/tests/tests.sh
@@ -18,6 +18,15 @@ runtest () {
     return 0
 }
 
+## A special version used by some of the error handling tests. It is used to
+## filter out lines other than error lines. See the calls for examples.
+runtest_filter () {
+    echo "" >> $3
+    echo "====[tsv-join $2]====" >> $3
+    $1 $2 2>&1 | grep -v $4 >> $3 2>&1
+    return 0
+}
+
 ## Note: input1.tsv has duplicate values in fields 2 & 3. Tests with those fields
 ## as keys that have append values need to use --allow-duplicate-keys (unless
 ## testing error handling).
@@ -301,17 +310,22 @@ echo "Error test set 1" > ${error_tests_1}
 echo "----------------" >> ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Duplicate keys===" >> ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k 2 -a 0 input2.tsv" ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k 2 -a 4 input2.tsv" ${error_tests_1}
+
+# Note: If headers are being processed, the header will be output before the duplicates
+# are detected. Filter out the header line to avoids issues with stdout/stderr output order.
+input2_header='f1[[:blank:]]f2[[:blank:]]f3[[:blank:]]f4[[:blank:]]f5'
+
+runtest_filter ${prog} "--header -f input1.tsv -k 2 -a 0 input2.tsv" ${error_tests_1} ${input2_header}
+runtest_filter ${prog} "--header -f input1.tsv -k 2 -a 4 input2.tsv" ${error_tests_1} ${input2_header}
 
 runtest ${prog} "-f input1_noheader.tsv -k 2 -a 0 input2_noheader.tsv" ${error_tests_1}
 runtest ${prog} "-f input1_noheader.tsv -k 2 -a 4 input2_noheader.tsv" ${error_tests_1}
 
-runtest ${prog} "--header -f input1.tsv -k f2 -a 0 input2.tsv" ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k f2 -a f4 input2.tsv" ${error_tests_1}
+runtest_filter ${prog} "--header -f input1.tsv -k f2 -a 0 input2.tsv" ${error_tests_1} ${input2_header}
+runtest_filter ${prog} "--header -f input1.tsv -k f2 -a f4 input2.tsv" ${error_tests_1} ${input2_header}
 
-runtest ${prog} "--header -f input1_rotated.tsv -k f2 -a 0 input2.tsv" ${error_tests_1}
-runtest ${prog} "--header -f input1_rotated.tsv -k f2 -a f4 input2.tsv" ${error_tests_1}
+runtest_filter ${prog} "--header -f input1_rotated.tsv -k f2 -a 0 input2.tsv" ${error_tests_1} ${input2_header}
+runtest_filter ${prog} "--header -f input1_rotated.tsv -k f2 -a f4 input2.tsv" ${error_tests_1} ${input2_header}
 
 echo "" >> ${error_tests_1}; echo "===Invalid field indicies===" >> ${error_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 6 input2.tsv" ${error_tests_1}

--- a/tsv-join/tests/tests.sh
+++ b/tsv-join/tests/tests.sh
@@ -425,4 +425,10 @@ runtest ${prog} "--header -f no_such_file -k 2,3 -d 2 input2.tsv" ${error_tests_
 runtest ${prog} "-f input1_noheader.tsv -k 2 -d 2,3 no_such-file.tsv" ${error_tests_1}
 runtest ${prog} "-f no_such_file -k 2,3 -d 2 input2_noheader.tsv" ${error_tests_1}
 
+runtest ${prog} "--header -f input1.tsv -k 2 -d 2 no_such-file.tsv" ${error_tests_1}
+runtest ${prog} "--header -f no_such_file -k 2 -d 2 input2.tsv" ${error_tests_1}
+
+runtest ${prog} "-f input1_noheader.tsv -k 2 -d 2 no_such-file.tsv" ${error_tests_1}
+runtest ${prog} "-f no_such_file -k 2 -d 2 input2_noheader.tsv" ${error_tests_1}
+
 exit $?

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -441,7 +441,7 @@ struct TsvSampleOptions
 
             string[] headerFields;
 
-            /* FieldListArgProcessing encapsulates the field list processing. It is
+            /* fieldListArgProcessing encapsulates the field list processing. It is
              * called prior to reading the header line if headers are not being used,
              * and after if headers are being used.
              */

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -599,7 +599,8 @@ void bernoulliSampling(Flag!"generateRandomAll" generateRandomAll, OutputRange)
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : bufferedByLine, InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
+        InputSourceRange, throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -613,7 +614,6 @@ if (isOutputRange!(OutputRange, char))
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         static if (generateRandomAll)
         {
@@ -628,6 +628,11 @@ if (isOutputRange!(OutputRange, char))
 
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     /* Process each line. */
@@ -719,7 +724,8 @@ void bernoulliSkipSampling(OutputRange)(ref TsvSampleOptions cmdopt, OutputRange
     import std.conv : to;
     import std.math : log, trunc;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : bufferedByLine, InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
+        InputSourceRange, throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.inclusionProbability > 0.0 && cmdopt.inclusionProbability < 1.0);
     assert(!cmdopt.printRandom);
@@ -742,10 +748,14 @@ void bernoulliSkipSampling(OutputRange)(ref TsvSampleOptions cmdopt, OutputRange
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     /* Process each line. */
@@ -808,8 +818,8 @@ if (isOutputRange!(OutputRange, char))
     import std.conv : to;
     import std.digest.murmurhash;
     import std.math : lrint;
-    import tsv_utils.common.utils : bufferedByLine, InputFieldReordering,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
+        InputFieldReordering, InputSourceRange, throwIfWindowsNewlineOnUnix;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -837,7 +847,6 @@ if (isOutputRange!(OutputRange, char))
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         static if (generateRandomAll)
         {
@@ -852,6 +861,11 @@ if (isOutputRange!(OutputRange, char))
 
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     /* Process each line. */
@@ -1053,7 +1067,8 @@ if (isOutputRange!(OutputRange, char))
     import std.container.binaryheap;
     import std.meta : AliasSeq;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : bufferedByLine, InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
+        InputSourceRange, throwIfWindowsNewlineOnUnix;
 
     static if (isWeighted) assert(cmdopt.hasWeightField);
     else assert(!cmdopt.hasWeightField);
@@ -1090,7 +1105,6 @@ if (isOutputRange!(OutputRange, char))
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         if (cmdopt.printRandom)
         {
@@ -1099,6 +1113,11 @@ if (isOutputRange!(OutputRange, char))
         }
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     /* Process each line. */
@@ -1192,7 +1211,8 @@ void generateWeightedRandomValuesInorder(OutputRange)
 if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : bufferedByLine, InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
+        InputSourceRange, throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.hasWeightField);
 
@@ -1205,12 +1225,16 @@ if (isOutputRange!(OutputRange, char))
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         outputStream.put(cmdopt.randomValueHeader);
         outputStream.put(cmdopt.delim);
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     /* Process each line. */
@@ -1284,7 +1308,8 @@ if (isOutputRange!(OutputRange, char))
     import std.meta : AliasSeq;
     import std.random : Random = Mt19937, randomShuffle, uniform;
     import std.algorithm : sort;
-    import tsv_utils.common.utils : bufferedByLine, InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
+        InputSourceRange, throwIfWindowsNewlineOnUnix;
 
     assert(cmdopt.sampleSize > 0);
     assert(!cmdopt.hasWeightField);
@@ -1311,10 +1336,14 @@ if (isOutputRange!(OutputRange, char))
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     /* Process each line. */
@@ -1582,7 +1611,8 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.algorithm : find, min;
     import std.range : retro;
-    import tsv_utils.common.utils : InputSourceRange, throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : InputSourceRange, isFlushableOutputRange,
+        throwIfWindowsNewlineOnUnix;
 
     static if(!hasRandomValue) assert(!cmdopt.printRandom);
 
@@ -1593,7 +1623,6 @@ if (isOutputRange!(OutputRange, char))
     if (cmdopt.hasHeader && !cmdopt.inputSources.front.isHeaderEmpty)
     {
         auto inputStream = cmdopt.inputSources.front;
-        throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
 
         if (cmdopt.printRandom)
         {
@@ -1602,6 +1631,11 @@ if (isOutputRange!(OutputRange, char))
         }
         outputStream.put(inputStream.header);
         outputStream.put("\n");
+
+        /* Immediately flush the header so subsequent processes in a unix command
+         * pipeline see it early. This helps provide timely error messages.
+         */
+        static if (isFlushableOutputRange!OutputRange) outputStream.flush;
     }
 
     enum BlockSize = 1024L * 1024L * 1024L;  // 1 GB. ('L' notation avoids overflow w/ 2GB+ sizes.)

--- a/tsv-sample/tests/gold/error_tests_1.txt
+++ b/tsv-sample/tests/gold/error_tests_1.txt
@@ -33,18 +33,6 @@ line	title	weight
 ====[tsv-sample -w 1,3 input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: '--w|weight-field' must be a single field.
 
-====[tsv-sample -H -w 3 input3x25_dos.tsv]====
-[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
-  File: input3x25_dos.tsv, Line: 1
-
-====[tsv-sample -H -w weight input3x25_dos.tsv]====
-[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
-  File: input3x25_dos.tsv, Line: 1
-
-====[tsv-sample -w 1 input2x5_noheader_dos.tsv]====
-Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
-  File: input2x5_noheader_dos.tsv, Line: 1
-
 ====[tsv-sample --prob 0.5 --weight-field 3 input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: --w|weight-field and --p|prob cannot be used together.
 
@@ -122,3 +110,139 @@ Use --p|prob and --print-random to print probabilities for lines satisfying the 
 
 ====[tsv-sample --inorder -n 0 input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: Preserving input order (--i|inorder) is not compatible with full data set shuffling. Switch to random sampling with a sample size (--n|num) to use --i|inorder.
+
+====[tsv-sample -H input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -H input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -H input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -w 3 input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -w 3 input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -w weight input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -w weight input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -w 1 input2x5_noheader_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input2x5_noheader_dos.tsv, Line: 1
+
+====[tsv-sample -w 1 input2x1_noheader.tsv input2x5_noheader_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input2x5_noheader_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -H -w 3 input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -H -w 3 input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -H -w weight input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -H -w weight input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -w 1 input2x5_noheader_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input2x5_noheader_dos.tsv, Line: 1
+
+====[tsv-sample -n 2 -w 1 input2x1_noheader.tsv input2x5_noheader_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input2x5_noheader_dos.tsv, Line: 1
+
+====[tsv-sample -r -n 2 -H input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -r -n 2 -H input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -r -n 2 input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -r -n 2 input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -p .2 -H input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -p .2 -H input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -p .2 input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -p .2 input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -p .2 -k 2 input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -p .2 -k 2 input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -p .2 -k title input3x25_dos.tsv]====
+[tsv-sample] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -H -p .2 -k title input3x0.tsv input3x25_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input3x25_dos.tsv, Line: 1
+
+====[tsv-sample -p .2 -k 2 input2x5_noheader_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input2x5_noheader_dos.tsv, Line: 1
+
+====[tsv-sample -p .2 -k 2 input2x1_noheader.tsv input2x5_noheader_dos.tsv]====
+Error [tsv-sample]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input2x5_noheader_dos.tsv, Line: 1

--- a/tsv-sample/tests/input2x1_noheader.tsv
+++ b/tsv-sample/tests/input2x1_noheader.tsv
@@ -1,0 +1,1 @@
+0.157876295	Jacques le fataliste et son maître

--- a/tsv-sample/tests/input3x0.tsv
+++ b/tsv-sample/tests/input3x0.tsv
@@ -1,0 +1,1 @@
+line	title	weight

--- a/tsv-sample/tests/tests.sh
+++ b/tsv-sample/tests/tests.sh
@@ -34,6 +34,15 @@ runtest () {
     return 0
 }
 
+## A special version used by some of the error handling tests. It is used to
+## filter out lines other than error lines. See the calls for examples.
+runtest_filter () {
+    echo "" >> $3
+    echo "====[tsv-sample $2]====" >> $3
+    $1 $2 2>&1 | grep -v $4 >> $3 2>&1
+    return 0
+}
+
 basic_tests_1=${odir}/basic_tests_1.txt
 
 echo "Basic tests set 1" > ${basic_tests_1}
@@ -208,9 +217,6 @@ runtest ${prog} "-w weight input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w weight,line input3x25.tsv" ${error_tests}
 runtest ${prog} "-H -w line,weight input3x25.tsv" ${error_tests}
 runtest ${prog} "-w 1,3 input3x25.tsv" ${error_tests}
-runtest ${prog} "-H -w 3 input3x25_dos.tsv" ${error_tests}
-runtest ${prog} "-H -w weight input3x25_dos.tsv" ${error_tests}
-runtest ${prog} "-w 1 input2x5_noheader_dos.tsv" ${error_tests}
 runtest ${prog} "--prob 0.5 --weight-field 3 input3x25.tsv" ${error_tests}
 runtest ${prog} "--prob 0.5 --weight-field 0 input3x25.tsv" ${error_tests}
 runtest ${prog} "--prob 0 input3x25.tsv" ${error_tests}
@@ -236,6 +242,53 @@ runtest ${prog} "--replace -n 5 --gen-random-inorder input3x25.tsv" ${error_test
 runtest ${prog} "--inorder --replace -n 5 input3x25.tsv" ${error_tests}
 runtest ${prog} "--inorder input3x25.tsv" ${error_tests}
 runtest ${prog} "--inorder -n 0 input3x25.tsv" ${error_tests}
+
+# Windows line endings. The tests where the windows line ending is in the second
+# file use a single line first file that is filtered out of the output.
+
+header_line_3x0='line[[:blank:]]title[[:blank:]]weight'
+line1_2x1='0.157876295	Jacques le fataliste et son maître'
+
+runtest ${prog} "-H input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-H input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+
+runtest ${prog} "-n 2 -H input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-n 2 -H input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-n 2 input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-n 2 input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+
+runtest ${prog} "-H -w 3 input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-H -w 3 input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-H -w weight input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-H -w weight input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-w 1 input2x5_noheader_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-w 1 input2x1_noheader.tsv input2x5_noheader_dos.tsv" ${error_tests} ${line1_2x1}
+
+runtest ${prog} "-n 2 -H -w 3 input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-n 2 -H -w 3 input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-n 2 -H -w weight input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-n 2 -H -w weight input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-n 2 -w 1 input2x5_noheader_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-n 2 -w 1 input2x1_noheader.tsv input2x5_noheader_dos.tsv" ${error_tests} ${line1_2x1}
+
+runtest ${prog} "-r -n 2 -H input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-r -n 2 -H input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-r -n 2 input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-r -n 2 input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+
+runtest ${prog} "-p .2 -H input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-p .2 -H input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-p .2 input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-p .2 input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+
+runtest ${prog} "-H -p .2 -k 2 input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-H -p .2 -k 2 input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-H -p .2 -k title input3x25_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-H -p .2 -k title input3x0.tsv input3x25_dos.tsv" ${error_tests} ${header_line_3x0}
+runtest ${prog} "-p .2 -k 2 input2x5_noheader_dos.tsv" ${error_tests}
+runtest_filter ${prog} "-p .2 -k 2 input2x1_noheader.tsv input2x5_noheader_dos.tsv" ${error_tests} ${line1_2x1}
 
 # Error tests 2 are tests that are compiler version dependent. There are multiple
 # version files in test-config.json.

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -240,7 +240,7 @@ struct TsvSelectOptions
 
             string[] headerFields;
 
-            /* FieldListArgProcessing encapsulates the field list processing. It is
+            /* fieldListArgProcessing encapsulates the field list processing. It is
              * called prior to reading the header line if headers are not being used,
              * and after if headers are being used.
              */

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -156,6 +156,7 @@ struct TsvSelectOptions
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist;
+        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
 
         bool helpVerbose = false;           // --help-verbose
         string fieldsArg;                   // --f|fields
@@ -222,75 +223,97 @@ struct TsvSelectOptions
 
             /* Remaining command line args are files. Use standard input if files
              * were not provided. Truncate cmdArgs to consume the arguments.
-             *
-             * Note: If reading from stdin, this will wait until a line is available.
              */
             string[] filepaths = (cmdArgs.length > 1) ? cmdArgs[1 .. $] : ["-"];
             cmdArgs.length = 1;
-            inputSources = byLineSourceRange(filepaths);
 
-            /*
-             * Consistency checks and derivations.
+            /* Validation and derivations - Do as much validation prior to header line
+             * processing as possible (avoids waiting on stdin).
+             *
+             * Note: fields and excludedFields depend on header line processing, but
+             * fieldsArg and excludedFieldsArg can be used to detect whether the
+             * command line argument was specified.
              */
+
+            enforce(!fieldsArg.empty || !excludedFieldsArg.empty,
+                    "One of '--f|fields' or '--e|exclude' is required.");
 
             string[] headerFields;
 
-            if (hasHeader && !inputSources.front.byLine.empty)
+            /* FieldListArgProcessing encapsulates the field list processing. It is
+             * called prior to reading the header line if headers are not being used,
+             * and after if headers are being used.
+             */
+            void fieldListArgProcessing()
             {
-                headerFields = inputSources.front.byLine.front.split(delim).to!(string[]);
-            }
-
-            if (!fieldsArg.empty)
-            {
-                fields = fieldsArg
-                    .parseFieldList!(size_t, Yes.convertToZeroBasedIndex)(hasHeader, headerFields, fieldsOptionString)
-                    .array;
-            }
-
-            size_t[] excludedFields;
-
-            if (!excludedFieldsArg.empty)
-            {
-                excludedFields = excludedFieldsArg
-                    .parseFieldList!(size_t, Yes.convertToZeroBasedIndex)(hasHeader, headerFields, excludedFieldsOptionString)
-                    .array;
-            }
-
-            enforce(fields.length != 0 || excludedFields.length != 0,
-                    "One of '--f|fields' or '--e|exclude' is required.");
-
-            if (excludedFields.length > 0)
-            {
-                /* Make sure selected and excluded fields do not overlap. */
-                foreach (e; excludedFields)
+                if (!fieldsArg.empty)
                 {
-                    foreach (f; fields)
-                    {
-                        enforce(e != f, "'--f|fields' and '--e|exclude' have overlapping fields.");
-                    }
+                    fields = fieldsArg
+                        .parseFieldList!(size_t, Yes.convertToZeroBasedIndex)(hasHeader, headerFields, fieldsOptionString)
+                        .array;
                 }
 
-                /* '--exclude' changes '--rest' default to 'last'. */
-                if (restArg == RestOption.none) restArg = RestOption.last;
+                size_t[] excludedFields;
 
-                /* Build the excluded field lookup table.
-                 *
-                 * Note: Users won't have any reason to expect memory is allocated based
-                 * on the max field number. However, users might pick arbitrarily large
-                 * numbers when trimming fields. So, limit the max field number to something
-                 * big but reasonable (more than 1 million). The limit can be raised if use
-                 * cases arise.
-                 */
-                size_t maxExcludedField = excludedFields.maxElement;
-                size_t maxAllowedExcludedField = 1024 * 1024;
+                if (!excludedFieldsArg.empty)
+                {
+                    excludedFields = excludedFieldsArg
+                        .parseFieldList!(size_t, Yes.convertToZeroBasedIndex)(hasHeader, headerFields, excludedFieldsOptionString)
+                        .array;
+                }
 
-                enforce(maxExcludedField < maxAllowedExcludedField,
-                        format("Maximum allowed '--e|exclude' field number is %d.",
-                               maxAllowedExcludedField));
+                if (excludedFields.length > 0)
+                {
+                    /* Make sure selected and excluded fields do not overlap. */
+                    foreach (e; excludedFields)
+                    {
+                        foreach (f; fields)
+                        {
+                            enforce(e != f, "'--f|fields' and '--e|exclude' have overlapping fields.");
+                        }
+                    }
 
-                excludedFieldsTable.length = maxExcludedField + 1;          // Initialized to false
-                foreach (e; excludedFields) excludedFieldsTable[e] = true;
+                    /* '--exclude' changes '--rest' default to 'last'. */
+                    if (restArg == RestOption.none) restArg = RestOption.last;
+
+                    /* Build the excluded field lookup table.
+                     *
+                     * Note: Users won't have any reason to expect memory is allocated based
+                     * on the max field number. However, users might pick arbitrarily large
+                     * numbers when trimming fields. So, limit the max field number to something
+                     * big but reasonable (more than 1 million). The limit can be raised if use
+                     * cases arise.
+                     */
+                    size_t maxExcludedField = excludedFields.maxElement;
+                    size_t maxAllowedExcludedField = 1024 * 1024;
+
+                    enforce(maxExcludedField < maxAllowedExcludedField,
+                            format("Maximum allowed '--e|exclude' field number is %d.",
+                                   maxAllowedExcludedField));
+
+                    excludedFieldsTable.length = maxExcludedField + 1;          // Initialized to false
+                    foreach (e; excludedFields) excludedFieldsTable[e] = true;
+                }
             }
+
+            if (!hasHeader) fieldListArgProcessing();
+
+            /*
+             * Create the byLineSourceRange and perform header line processing.
+             */
+            inputSources = byLineSourceRange(filepaths);
+
+            if (hasHeader)
+            {
+                if (!inputSources.front.byLine.empty)
+                {
+                    throwIfWindowsNewlineOnUnix(inputSources.front.byLine.front, inputSources.front.name, 1);
+                    headerFields = inputSources.front.byLine.front.split(delim).to!(string[]);
+                }
+
+                fieldListArgProcessing();
+            }
+
         }
         catch (Exception exc)
         {
@@ -417,8 +440,8 @@ void tsvSelect(RestLocation rest)(ref TsvSelectOptions cmdopt)
         auto leftOverFieldsAppender = appender!(char[][]);
     }
 
-    /* BufferedOutputRange (from tsvutils.d) is a performance improvement over writing
-     * directly to stdout.
+    /* BufferedOutputRange (from common/utils.d) is a performance improvement over
+     * writing directly to stdout.
      */
     auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 
@@ -521,6 +544,12 @@ void tsvSelect(RestLocation rest)(ref TsvSelectOptions cmdopt)
             }
 
             bufferedOutput.appendln;
+
+            /* Send the first line of the first file immediately. This helps detect
+             * errors quickly in multi-stage unix pipelines. Note that tsv-select may
+             * have been sent one line from an upstream process, usually a header line.
+             */
+            if (lineNum == 1 && fileNum == 0) bufferedOutput.flush;
         }
     }
 }

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -131,5 +131,31 @@ Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines
   File: input1_dos.tsv, Line: 1
 
 ====[tsv-select -H -f 1 input1_dos.tsv]====
+[tsv-select] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1
+
+====[tsv-select -f 1 input1.tsv input1_dos.tsv]====
 Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1
+f1
+1
+
+3
+4
+5
+6
+7
+8
+
+====[tsv-select -H -f 1 input1.tsv input1_dos.tsv]====
+Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1
+f1
+1
+
+3
+4
+5
+6
+7
+8

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -299,5 +299,7 @@ runtest ${prog} "-H -f field1-field2,field2-1 input_header1.tsv" ${error_tests_1
 # Windows line ending detection
 runtest ${prog} "-f 1 input1_dos.tsv" ${error_tests_1}
 runtest ${prog} "-H -f 1 input1_dos.tsv" ${error_tests_1}
+runtest ${prog} "-f 1 input1.tsv input1_dos.tsv" ${error_tests_1}
+runtest ${prog} "-H -f 1 input1.tsv input1_dos.tsv" ${error_tests_1}
 
 exit $?


### PR DESCRIPTION
This PR is a follow-on to the named field PR series start with PR #284.

This PR addresses one of the main issues with using named fields - The header line must be read before command line arguments using field names can processed. If the tool is in the later stage of a unix command pipeline, it might be a while before the tool receives data and reads the header line. An error in the command line arguments will terminate the operation. If the data is large, this could occur a decent period after starting the operation.

This PR addresses this in a couple of ways. First, command line arguments not needing access to the header line are processed first, prior to reading the header. Errors for invalid command line arguments are output immediately. If header lines are not being processed (no `--H|headers`), then this includes field lists, as they must be numeric. Second, header lines are output immediately, prior to processing other input. This has the effect of passing header lines down the Unix command pipeline. Command line argument handling can occur much earlier, without a lengthy time delay.

This PR implements this for: `tsv-select`, `tsv-filter`, `tsv-sample`, and `tsv-join`. Other tools will be updated in a subsequent PR.

This is a step towards enhancement request #25.