### PR TITLE
Fieldlists: Refactor command line arg processing, part 2

### DIFF
--- a/number-lines/src/tsv_utils/number-lines.d
+++ b/number-lines/src/tsv_utils/number-lines.d
@@ -150,6 +150,14 @@ void numberLines(const NumberLinesOptions cmdopt, const string[] inputFiles)
                     bufferedOutput.append(cmdopt.delim);
                     bufferedOutput.appendln(line);
                     headerWritten = true;
+
+                    /* Flush the header immediately. This helps tasks further on in a
+                     * unix pipeline detect errors quickly, without waiting for all
+                     * the data to flow through the pipeline. Note that an upstream
+                     * task may have flushed its header line, so the header may
+                     * arrive long before the main block of data.
+                     */
+                    bufferedOutput.flush;
                 }
             }
             else

--- a/tsv-summarize/tests/gold/basic_tests_1.txt
+++ b/tsv-summarize/tests/gold/basic_tests_1.txt
@@ -149,7 +149,6 @@ count
 6
 
 ====[tsv-summarize --header --count empty_file.tsv]====
-count
 0
 
 ====[tsv-summarize --header --count --unique-count 1 input_1field_a.tsv input_1field_b.tsv]====
@@ -207,6 +206,21 @@ small	2	1
 8	1	1
 9	1	1
 medium	1	1
+
+====[tsv-summarize --header --write-header --count input_1field_a.tsv]====
+count
+6
+
+====[tsv-summarize --header --write-header --count empty_file.tsv]====
+0
+
+====[tsv-summarize --write-header --count input_1field_a.tsv]====
+count
+7
+
+====[tsv-summarize --write-header --count empty_file.tsv]====
+count
+0
 
 ====[tsv-summarize --count input_1field_a.tsv --exclude-missing]====
 7

--- a/tsv-summarize/tests/gold/error_tests_1.txt
+++ b/tsv-summarize/tests/gold/error_tests_1.txt
@@ -35,25 +35,25 @@ Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line
 ====[tsv-summarize --group-by 0 --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by 0]. Field numbers must be greater than zero: '0'.
 
-====[tsv-summarize --group-by 0 input_5field_a.tsv]====
+====[tsv-summarize --group-by 0 --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by 0]. Field numbers must be greater than zero: '0'.
 
-====[tsv-summarize --group-by 2, input_5field_a.tsv]====
+====[tsv-summarize --group-by 2, --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by 2,]. Invalid field list: '2,'.
 
-====[tsv-summarize --group-by 2: input_5field_a.tsv]====
+====[tsv-summarize --group-by 2: --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by 2:]. Invalid field list: '2:'.
 
-====[tsv-summarize --group-by x input_5field_a.tsv]====
+====[tsv-summarize --group-by x --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by x]. Non-numeric field group: 'x'. Use '--H|header' when using named field groups.
 
 ====[tsv-summarize --group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv]====
 Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line: 1
 
-====[tsv-summarize --group-by 1- input_5field_a.tsv]====
+====[tsv-summarize --group-by 1- --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by 1-]. Incomplete ranges are not supported: '1-'.
 
-====[tsv-summarize --group-by 3-0 input_5field_a.tsv]====
+====[tsv-summarize --group-by 3-0 --count input_5field_a.tsv]====
 [tsv-summarize] Error processing command line arguments: [--g|group-by 3-0]. Field numbers must be greater than zero: '0'.
 
 ====[tsv-summarize --header --max 1 input_1field_a.tsv]====
@@ -164,5 +164,5 @@ Error [tsv-summarize]: Windows/DOS line ending found. Convert file to Unix newli
   File: input_1field_a_dos.tsv, Line: 1
 
 ====[tsv-summarize -H --count input_1field_a_dos.tsv]====
-Error [tsv-summarize]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+[tsv-summarize] Error processing command line arguments: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input_1field_a_dos.tsv, Line: 1

--- a/tsv-summarize/tests/tests.sh
+++ b/tsv-summarize/tests/tests.sh
@@ -25,6 +25,15 @@ runtest () {
     return 0
 }
 
+## A special version used by some of the error handling tests. It is used to
+## filter out lines other than error lines. See the calls for examples.
+runtest_filter () {
+    echo "" >> $3
+    echo "====[tsv-summarize $2]====" >> $3
+    $1 $2 2>&1 | grep -v $4 >> $3 2>&1
+    return 0
+}
+
 basic_tests_1=${odir}/basic_tests_1.txt
 
 echo "Basic tests set 1" > ${basic_tests_1}
@@ -89,6 +98,11 @@ runtest ${prog} "--count --unique-count 1 input_1field_a.tsv input_1field_b.tsv 
 runtest ${prog} "--group-by 1 --count --unique-count 1 input_1field_a.tsv input_1field_b.tsv " ${basic_tests_1}
 runtest ${prog} "--group-by 1 --count --unique-count 1 input_1field_a.tsv input_1field_b.tsv empty_file.tsv" ${basic_tests_1}
 
+runtest ${prog} "--header --write-header --count input_1field_a.tsv" ${basic_tests_1}
+runtest ${prog} "--header --write-header --count empty_file.tsv" ${basic_tests_1}
+runtest ${prog} "--write-header --count input_1field_a.tsv" ${basic_tests_1}
+runtest ${prog} "--write-header --count empty_file.tsv" ${basic_tests_1}
+
 runtest ${prog} "--count input_1field_a.tsv --exclude-missing" ${basic_tests_1}
 runtest ${prog} "--values 1 input_1field_a.tsv --exclude-missing" ${basic_tests_1}
 runtest ${prog} "--count input_1field_a.tsv --replace-missing XYZ" ${basic_tests_1}
@@ -139,14 +153,14 @@ runtest ${prog} "--unique-count x input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--unique-count 2 input_5field_a.tsv input_1field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 1 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 0 --count input_5field_a.tsv" ${error_tests_1}
-runtest ${prog} "--group-by 0 input_5field_a.tsv" ${error_tests_1}
-runtest ${prog} "--group-by 2, input_5field_a.tsv" ${error_tests_1}
-runtest ${prog} "--group-by 2: input_5field_a.tsv" ${error_tests_1}
-runtest ${prog} "--group-by x input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 0 --count input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 2, --count input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 2: --count input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by x --count input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv" ${error_tests_1}
-runtest ${prog} "--group-by 1- input_5field_a.tsv" ${error_tests_1}
-runtest ${prog} "--group-by 3-0 input_5field_a.tsv" ${error_tests_1}
-runtest ${prog} "--header --max 1 input_1field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 1- --count input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 3-0 --count input_5field_a.tsv" ${error_tests_1}
+runtest_filter ${prog} "--header --max 1 input_1field_a.tsv" ${error_tests_1} 'size_max'
 runtest ${prog} "-d abc --count input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "-d ß --count input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "-v abc --count input_5field_a.tsv" ${error_tests_1}


### PR DESCRIPTION
This PR is a follow-on to the named field PR series start with PR #284. In particular, it completes the work in PR #293.

These two PRs address one of the main issues with using named fields - The header line must be read before command line arguments using field names can processed. If the tool is in the later stage of a unix command pipeline, it might be a while before the tool receives data and reads the header line. An error in the command line arguments will terminate the operation. If the data is large, this could occur a decent period after starting the operation.

These PR addresses this in a couple of ways. First, command line arguments not needing access to the header line are processed first, prior to reading the header. Errors for invalid command line arguments are output immediately. If header lines are not being processed (no --H|headers), then this includes field lists, as they must be numeric. Second, header lines are output immediately, prior to processing other input. This has the effect of passing header lines down the Unix command pipeline. Command line argument handling can occur much earlier, without a lengthy time delay.

This PR implements this logic in the tools remaining after PR #293: `tsv-summarize`, `tsv-uniq`, `tsv-append`, and `number lines`

This is a step towards enhancement request #25.