### PR TITLE
csv2tsv newline replacement

### DIFF
--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -23,11 +23,11 @@ _csv2tsv()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --version --header --quote --csv-delim --tsv-delim --replacement"
+    opts="--help --help-verbose --version --header --quote --csv-delim --tsv-delim --tab-replacement --newline-replacement"
 
     # Options requiring an argument or precluding other options
     case $prev in
-         -h|--help|--help-verbose|-V|--version|-q|--quote|-c|--csv-delim|-t|--tsv-delim|-r|--replacement)
+         -h|--help|--help-verbose|-V|--version|-q|--quote|-c|--csv-delim|-t|--tsv-delim|-r|--tab-replacement|-n|--newline-replacement)
           return
           ;;
     esac

--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -79,7 +79,8 @@ struct Csv2tsvOptions
     char csvQuoteChar = '"';           // --q|quote
     char csvDelimChar = ',';           // --c|csv-delim
     char tsvDelimChar = '\t';          // --t|tsv-delim
-    string tsvDelimReplacement = " ";  // --r|replacement
+    string tsvDelimReplacement = " ";  // --r|tab-replacement
+    string newlineReplacement = " ";   // --n|newline-replacement
     bool versionWanted = false;        // --V|version
 
     auto processArgs (ref string[] cmdArgs)
@@ -94,16 +95,17 @@ struct Csv2tsvOptions
         {
             auto r = getopt(
                 cmdArgs,
-                "help-verbose",  "     Print full help.", &helpVerbose,
+                "help-verbose",          "     Print full help.", &helpVerbose,
                 std.getopt.config.caseSensitive,
-                "H|header",      "     Treat the first line of each file as a header. Only the header of the first file is output.", &hasHeader,
+                "H|header",              "     Treat the first line of each file as a header. Only the header of the first file is output.", &hasHeader,
                 std.getopt.config.caseSensitive,
-                "q|quote",       "CHR  Quoting character in CSV data. Default: double-quote (\")", &csvQuoteChar,
-                "c|csv-delim",   "CHR  Field delimiter in CSV data. Default: comma (,).", &csvDelimChar,
-                "t|tsv-delim",   "CHR  Field delimiter in TSV data. Default: TAB", &tsvDelimChar,
-                "r|replacement", "STR  Replacement for newline and TSV field delimiters found in CSV input. Default: Space.", &tsvDelimReplacement,
+                "q|quote",               "CHR  Quoting character in CSV data. Default: double-quote (\")", &csvQuoteChar,
+                "c|csv-delim",           "CHR  Field delimiter in CSV data. Default: comma (,).", &csvDelimChar,
+                "t|tsv-delim",           "CHR  Field delimiter in TSV data. Default: TAB", &tsvDelimChar,
+                "r|tab-replacement",     "STR  Replacement for TSV field delimiters (typically TABs) found in CSV input. Default: Space.", &tsvDelimReplacement,
+                "n|newline-replacement", "STR  Replacement for newlines found in CSV input. Default: Space.", &newlineReplacement,
                 std.getopt.config.caseSensitive,
-                "V|version",     "     Print version information and exit.", &versionWanted,
+                "V|version",             "     Print version information and exit.", &versionWanted,
                 std.getopt.config.caseInsensitive,
                 );
 
@@ -141,7 +143,10 @@ struct Csv2tsvOptions
                     "TSV field delimiter cannot be newline (--t|tsv-delim).");
 
             enforce(!canFind!(c => (c == '\n' || c == '\r' || c == tsvDelimChar))(tsvDelimReplacement),
-                    "Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).");
+                    "Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).");
+
+            enforce(!canFind!(c => (c == '\n' || c == '\r' || c == tsvDelimChar))(newlineReplacement),
+                    "Replacement character cannot contain newlines or TSV field delimiters (--n|newline-replacement).");
         }
         catch (Exception exc)
         {
@@ -208,7 +213,7 @@ void csv2tsvFiles(const ref Csv2tsvOptions cmdopt, const string[] inputFiles)
         csv2tsv(inputStream, stdoutWriter, fileRawBuf, printFileName, skipLines,
                 cmdopt.csvQuoteChar, cmdopt.csvDelimChar,
                 cmdopt.tsvDelimChar, cmdopt.tsvDelimReplacement,
-                cmdopt.tsvDelimReplacement);
+                cmdopt.newlineReplacement);
 
         firstFile = false;
     }

--- a/csv2tsv/tests/gold/basic_tests_1.txt
+++ b/csv2tsv/tests/gold/basic_tests_1.txt
@@ -82,19 +82,64 @@ QCQ	QNQ	CNQACAQ	_Q_NCCQCQ
 A	AA	AAA	AAAA
 a	ab	abc	abcd
 
-====[csv2tsv --quote # --csv-delim | --tsv-delim $ --replacement <==> input2.csv]====
+====[csv2tsv --quote # --csv-delim | --tsv-delim $ --delim-replacement <==> --newline-replacement <==> input2.csv]====
 field1$field2$field3
 123$456$789
 234$567$890
 |abc$#def#$gh><==>ijk><==>lmn<
 ABC$DEF$GHI
 
-====[csv2tsv -q # -c | -t @ -r <--> input2.csv]====
+====[csv2tsv -q # -c | -t @ -r <--> -n <--> input2.csv]====
 field1@field2@field3
 123@456@789
 234@567@890
 |abc@#def#@gh><-->ijk><-->lmn<
 ABC@DEF@GHI
+
+====[csv2tsv input3.csv]====
+Type	Value1	Value2
+Vanilla	ABC	123
+Quoted	ABC	123
+With Comma	abc,def	123,4
+With Quotes	Say "Hello World!"	10" high
+With Newline	Value 1 Line 1 Value 1 Line 2	Value 2 Line 1 Value 2 Line 2
+With TAB	ABC DEF	123 456
+
+====[csv2tsv --delim-replacement <TAB> input3.csv]====
+Type	Value1	Value2
+Vanilla	ABC	123
+Quoted	ABC	123
+With Comma	abc,def	123,4
+With Quotes	Say "Hello World!"	10" high
+With Newline	Value 1 Line 1 Value 1 Line 2	Value 2 Line 1 Value 2 Line 2
+With TAB	ABC<TAB>DEF	123<TAB>456
+
+====[csv2tsv --newline-replacement <NL> input3.csv]====
+Type	Value1	Value2
+Vanilla	ABC	123
+Quoted	ABC	123
+With Comma	abc,def	123,4
+With Quotes	Say "Hello World!"	10" high
+With Newline	Value 1 Line 1<NL>Value 1 Line 2	Value 2 Line 1<NL>Value 2 Line 2
+With TAB	ABC DEF	123 456
+
+====[csv2tsv -r <TAB> -n <NL> input3.csv]====
+Type	Value1	Value2
+Vanilla	ABC	123
+Quoted	ABC	123
+With Comma	abc,def	123,4
+With Quotes	Say "Hello World!"	10" high
+With Newline	Value 1 Line 1<NL>Value 1 Line 2	Value 2 Line 1<NL>Value 2 Line 2
+With TAB	ABC<TAB>DEF	123<TAB>456
+
+====[csv2tsv -r ␉ -n ␤ input3.csv]====
+Type	Value1	Value2
+Vanilla	ABC	123
+Quoted	ABC	123
+With Comma	abc,def	123,4
+With Quotes	Say "Hello World!"	10" high
+With Newline	Value 1 Line 1␤Value 1 Line 2	Value 2 Line 1␤Value 2 Line 2
+With TAB	ABC␉DEF	123␉456
 
 ====[csv2tsv header1.csv header2.csv header3.csv header4.csv header5.csv]====
 field1	field2	field3

--- a/csv2tsv/tests/gold/basic_tests_1.txt
+++ b/csv2tsv/tests/gold/basic_tests_1.txt
@@ -82,7 +82,7 @@ QCQ	QNQ	CNQACAQ	_Q_NCCQCQ
 A	AA	AAA	AAAA
 a	ab	abc	abcd
 
-====[csv2tsv --quote # --csv-delim | --tsv-delim $ --delim-replacement <==> --newline-replacement <==> input2.csv]====
+====[csv2tsv --quote # --csv-delim | --tsv-delim $ --tab-replacement <==> --newline-replacement <==> input2.csv]====
 field1$field2$field3
 123$456$789
 234$567$890
@@ -105,7 +105,7 @@ With Quotes	Say "Hello World!"	10" high
 With Newline	Value 1 Line 1 Value 1 Line 2	Value 2 Line 1 Value 2 Line 2
 With TAB	ABC DEF	123 456
 
-====[csv2tsv --delim-replacement <TAB> input3.csv]====
+====[csv2tsv --tab-replacement <TAB> input3.csv]====
 Type	Value1	Value2
 Vanilla	ABC	123
 Quoted	ABC	123

--- a/csv2tsv/tests/gold/error_tests_1.txt
+++ b/csv2tsv/tests/gold/error_tests_1.txt
@@ -26,17 +26,17 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 ====[csv2tsv --tsv-delim $'\r' input2.csv]====
 [csv2tsv] Error processing command line arguments: TSV field delimiter cannot be newline (--t|tsv-delim).
 
-====[csv2tsv --delim-replacement $'\n' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
+====[csv2tsv --tab-replacement $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).
 
-====[csv2tsv --delim-replacement $'\r' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
+====[csv2tsv --tab-replacement $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).
 
 ====[csv2tsv -r $'__\n__' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).
 
 ====[csv2tsv -r $'__\r__' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).
 
 ====[csv2tsv --newline-replacement $'\n' input2.csv]====
 [csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--n|newline-replacement).
@@ -57,7 +57,7 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 [csv2tsv] Error processing command line arguments: CSV quote and TSV field delimiter characters must be different (--q|quote, --t|tsv-delim).
 
 ====[csv2tsv -t x -r wxyz input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).
 
 ====[csv2tsv invalid1.csv]====
 Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid1.csv, Line: 3

--- a/csv2tsv/tests/gold/error_tests_1.txt
+++ b/csv2tsv/tests/gold/error_tests_1.txt
@@ -26,17 +26,29 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 ====[csv2tsv --tsv-delim $'\r' input2.csv]====
 [csv2tsv] Error processing command line arguments: TSV field delimiter cannot be newline (--t|tsv-delim).
 
-====[csv2tsv --replacement $'\n' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+====[csv2tsv --delim-replacement $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
 
-====[csv2tsv --replacement $'\r' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+====[csv2tsv --delim-replacement $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
 
 ====[csv2tsv -r $'__\n__' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
 
 ====[csv2tsv -r $'__\r__' input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
+
+====[csv2tsv --newline-replacement $'\n' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--n|newline-replacement).
+
+====[csv2tsv --newline-replacement $'\r' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--n|newline-replacement).
+
+====[csv2tsv -n $'__\n__' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--n|newline-replacement).
+
+====[csv2tsv -n $'__\r__' input2.csv]====
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--n|newline-replacement).
 
 ====[csv2tsv -q x -c x input2.csv]====
 [csv2tsv] Error processing command line arguments: CSV quote and CSV field delimiter characters must be different (--q|quote, --c|csv-delim).
@@ -45,7 +57,7 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 [csv2tsv] Error processing command line arguments: CSV quote and TSV field delimiter characters must be different (--q|quote, --t|tsv-delim).
 
 ====[csv2tsv -t x -r wxyz input2.csv]====
-[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|delim-replacement).
 
 ====[csv2tsv invalid1.csv]====
 Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid1.csv, Line: 3

--- a/csv2tsv/tests/input3.csv
+++ b/csv2tsv/tests/input3.csv
@@ -1,0 +1,9 @@
+Type,Value1,Value2
+Vanilla,ABC,123
+Quoted,"ABC","123"
+With Comma,"abc,def","123,4"
+With Quotes,"Say ""Hello World!""","10"" high"
+With Newline,"Value 1 Line 1
+Value 1 Line 2","Value 2 Line 1
+Value 2 Line 2"
+With TAB,"ABC	DEF","123	456"

--- a/csv2tsv/tests/tests.sh
+++ b/csv2tsv/tests/tests.sh
@@ -4,7 +4,7 @@
 # These tests do some basic, plus file handling and error cases.
 
 if [ $# -le 1 ]; then
-    echo "Insufficient arguments. A program name and output directory are required."
+    echo "Insufficient arguments. A program name and ouatput directory are required."
     exit 1
 fi
 
@@ -29,8 +29,13 @@ echo "-----------------" >> ${basic_tests_1}
 runtest ${prog} "input1_format1.csv" ${basic_tests_1}
 runtest ${prog} "input1_format2.csv" ${basic_tests_1}
 runtest ${prog} "input1_format3.csv" ${basic_tests_1}
-runtest ${prog} "--quote # --csv-delim | --tsv-delim $ --replacement <==> input2.csv" ${basic_tests_1}
-runtest ${prog} "-q # -c | -t @ -r <--> input2.csv" ${basic_tests_1}
+runtest ${prog} "--quote # --csv-delim | --tsv-delim $ --tab-replacement <==> --newline-replacement <==> input2.csv" ${basic_tests_1}
+runtest ${prog} "-q # -c | -t @ -r <--> -n <--> input2.csv" ${basic_tests_1}
+runtest ${prog} "input3.csv" ${basic_tests_1}
+runtest ${prog} "--tab-replacement <TAB> input3.csv" ${basic_tests_1}
+runtest ${prog} "--newline-replacement <NL> input3.csv" ${basic_tests_1}
+runtest ${prog} "-r <TAB> -n <NL> input3.csv" ${basic_tests_1}
+runtest ${prog} "-r ␉ -n ␤ input3.csv" ${basic_tests_1}
 runtest ${prog} "header1.csv header2.csv header3.csv header4.csv header5.csv" ${basic_tests_1}
 runtest ${prog} "--header header1.csv header2.csv header3.csv header4.csv header5.csv" ${basic_tests_1}
 runtest ${prog} "-H header1.csv header2.csv header3.csv header4.csv header5.csv" ${basic_tests_1}
@@ -92,11 +97,11 @@ ${prog} --tsv-delim $'\n' input2.csv >> ${error_tests_1} 2>&1
 echo ""  >> ${error_tests_1}; echo "====[csv2tsv --tsv-delim $'\r' input2.csv]====" >> ${error_tests_1}
 ${prog} --tsv-delim $'\r' input2.csv >> ${error_tests_1} 2>&1
 
-echo ""  >> ${error_tests_1}; echo "====[csv2tsv --replacement $'\n' input2.csv]====" >> ${error_tests_1}
-${prog} --replacement $'\n' input2.csv >> ${error_tests_1} 2>&1
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --tab-replacement $'\n' input2.csv]====" >> ${error_tests_1}
+${prog} --tab-replacement $'\n' input2.csv >> ${error_tests_1} 2>&1
 
-echo ""  >> ${error_tests_1}; echo "====[csv2tsv --replacement $'\r' input2.csv]====" >> ${error_tests_1}
-${prog} --replacement $'\r' input2.csv >> ${error_tests_1} 2>&1
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --tab-replacement $'\r' input2.csv]====" >> ${error_tests_1}
+${prog} --tab-replacement $'\r' input2.csv >> ${error_tests_1} 2>&1
 
 echo ""  >> ${error_tests_1}; echo "====[csv2tsv -r $'__\n__' input2.csv]====" >> ${error_tests_1}
 ${prog} -r $'__\n__' input2.csv >> ${error_tests_1} 2>&1
@@ -104,6 +109,17 @@ ${prog} -r $'__\n__' input2.csv >> ${error_tests_1} 2>&1
 echo ""  >> ${error_tests_1}; echo "====[csv2tsv -r $'__\r__' input2.csv]====" >> ${error_tests_1}
 ${prog} -r $'__\r__' input2.csv >> ${error_tests_1} 2>&1
 
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --newline-replacement $'\n' input2.csv]====" >> ${error_tests_1}
+${prog} --newline-replacement $'\n' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv --newline-replacement $'\r' input2.csv]====" >> ${error_tests_1}
+${prog} --newline-replacement $'\r' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv -n $'__\n__' input2.csv]====" >> ${error_tests_1}
+${prog} -n $'__\n__' input2.csv >> ${error_tests_1} 2>&1
+
+echo ""  >> ${error_tests_1}; echo "====[csv2tsv -n $'__\r__' input2.csv]====" >> ${error_tests_1}
+${prog} -n $'__\r__' input2.csv >> ${error_tests_1} 2>&1
 
 runtest ${prog} "-q x -c x input2.csv" ${error_tests_1}
 runtest ${prog} "-q x -t x input2.csv" ${error_tests_1}

--- a/csv2tsv/tests/tests.sh
+++ b/csv2tsv/tests/tests.sh
@@ -4,7 +4,7 @@
 # These tests do some basic, plus file handling and error cases.
 
 if [ $# -le 1 ]; then
-    echo "Insufficient arguments. A program name and ouatput directory are required."
+    echo "Insufficient arguments. A program name and output directory are required."
     exit 1
 fi
 


### PR DESCRIPTION
This PR changes `csv2tsv` to have separate command line arguments for the TAB and Newline replacement strings. Prior to this, `csv2tsv` used the same replacement string for both. The replacement strings default to a single space as before.

The previous command line argument, `--r|replacement` has bee replaced by a pair of arguments:
* `--r|tab-replacement` - Replacement string for TSV field delimiters, normally TABs, found in the CSV data.
* `--n|newline-replacement` - Replacement string for newlines (record delimiters) found in the CSV data.

This change provides better ability to preserve the original CSV data when the need occurs. For example, there are several Unicode representations for TAB and Newline that can be used. It may also be desirable to replace TABs with spaces, but use a Unicode Newline representation for newlines in the data. Some relevant Unicode characters:
* U+2028 - Line Separator
* U+2029 - Paragraph Separator
* U+2424 (`␤`) - Visual symbol for Newline
* U+2409 (`␉`) - Visual symbol for Horizontal TAB.

None of these characters are used as field or record terminators in TSV and can be used safely. The choice to use a these characters or any others as replacements can only be made in the context of the task being performed. This PR better enables these choices.