### PR TITLE
csv2tsv output buffer size tuning

### DIFF
--- a/csv2tsv/README.md
+++ b/csv2tsv/README.md
@@ -13,7 +13,7 @@ The main issue when working with CSV data is the potential for CSV escapes in th
 
 Many csv-to-tsv conversion tools don't remove escapes. Instead they generate CSV-style escapes, producing data in CSV format except using TAB as the record delimiter rather than comma. Such data is not correctly interpreted by traditional Unix tools. 
 
-`csv2tsv` avoids escapes by replacing TAB and newline characters in the data with a single space. These characters are rare in data mining scenarios, and space is usually a good substitute in cases where they do occur. The replacement string is customizable to enable alternate handling when needed.
+`csv2tsv` avoids escapes by replacing TAB and newline characters in the data with a single space. These characters are rare in data mining scenarios, and space is usually a good substitute in cases where they do occur. The replacement strings are customizable to enable alternate handling when needed.
 
 Another useful benefit of the `csv2tsv` converter is that it normalizes newlines. Many programs generate Windows newlines when exporting in CSV format, even on Unix systems.
 

--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -200,7 +200,7 @@ void csv2tsvFiles(const ref Csv2tsvOptions cmdopt, const string[] inputFiles)
     import tsv_utils.common.utils : BufferedOutputRange;
 
     ubyte[1024 * 128] fileRawBuf;
-    auto stdoutWriter = BufferedOutputRange!(typeof(stdout))(stdout);
+    auto stdoutWriter = BufferedOutputRange!(typeof(stdout))(stdout, 1024 * 10, 1024 * 129, 1024 * 128);
     bool firstFile = true;
 
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])


### PR DESCRIPTION
This PR changes the `BufferedOutputRange` buffer and flush sizes used by `csv2tsv`. The result is to flush data to standard output a bit quicker (smaller block writes) when `csv2tsv` is processing CSV files containing limited amounts of CSV escape syntax. This makes better use of memory and is slightly faster. Main benefit occurs in Unix pipelines. The next process in the pipeline receives data in smaller chunks increasing parallelism between pipeline stages.