### PR TITLE
Updates docs for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,9 +454,9 @@ See the [keep-header reference](docs/tool_reference/keep-header.md) for more inf
 
 ## Obtaining and installation
 
-There are several ways to obtain the tools: [prebuilt binaries](#prebuilt-binaries); [building from source code](#build-from-source-files); and [installing using the DUB package manager](#install-using-dub). The tools are tested on Linux and MacOS.
+There are several ways to obtain the tools: [prebuilt binaries](#prebuilt-binaries); [building from source code](#build-from-source-files); and [installing using the DUB package manager](#install-using-dub).
 
-The tools are not tested on Windows. Windows users are encouraged to use either [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/). Linux builds of the tools can be used on these systems.
+The tools are tested on Linux and MacOS. Windows users are encouraged to use either [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/). Linux builds of the tools can be used on these systems.
 
 ### Prebuilt binaries
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ See the [keep-header reference](docs/tool_reference/keep-header.md) for more inf
 
 There are several ways to obtain the tools: [prebuilt binaries](#prebuilt-binaries); [building from source code](#build-from-source-files); and [installing using the DUB package manager](#install-using-dub).
 
-The tools are tested on Linux and MacOS. Windows users are encouraged to use either [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/). Linux builds of the tools can be used on these systems.
+The tools are tested on Linux and MacOS. Windows users are encouraged to use either [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) and run Linux builds of the tools.
 
 ### Prebuilt binaries
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,9 @@ See the [keep-header reference](docs/tool_reference/keep-header.md) for more inf
 
 ## Obtaining and installation
 
-There are several ways to obtain the tools: [prebuilt binaries](#prebuilt-binaries); [building from source code](#build-from-source-files); and [installing using the DUB package manager](#install-using-dub). The tools have been tested on Linux and Mac OS X. They have not been tested on Windows, but there are no obvious impediments to running on Windows as well.
+There are several ways to obtain the tools: [prebuilt binaries](#prebuilt-binaries); [building from source code](#build-from-source-files); and [installing using the DUB package manager](#install-using-dub). The tools are tested on Linux and MacOS.
+
+The tools are not tested on Windows. Windows users are encouraged to use either [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/). Linux builds of the tools can be used on these systems.
 
 ### Prebuilt binaries
 
@@ -476,7 +478,7 @@ For some distributions a package can directly be installed:
 
 ### Build from source files
 
-[Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.088.1 or later, LDC version 1.18.0 or later.
+[Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers on MacOS and Linux. Use DMD version 2.088.1 or later, LDC version 1.18.0 or later.
 
 Clone this repository, select a compiler, and run `make` from the top level directory:
 ```


### PR DESCRIPTION
This PR does updates the README file recommend Windows users run Linux versions of the tools by using either  [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/).

This PR also changes `tsv-split` to enable building on Windows. Windows remains an untested platform.

These changes are to address build issues identified in #307.  

