### PR TITLE
An experiment: Use GitHub Actions to run a Windows build.

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -1,0 +1,30 @@
+# Workflow to run a D compile on Windows. No tests, just the build step. 
+name: D
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build tsv-utils on Windows
+    strategy:
+      matrix:
+        os: [windows-latest]
+        dc: [dmd-latest, ldc-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.dc }}
+
+      - name: Build and Run
+        run: |
+          dub run


### PR DESCRIPTION
This PR will add a Windows build (compile and link) CI step using GitHub Actions.

No tests. There would be some failures currently due to newline consistency issues. But maintaining successful compilation is a useful step.