### PR TITLE
Switch to rawWrite for output.

### DIFF
--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -483,7 +483,7 @@ if (isFileHandle!(Unqual!OutputTarget) || isOutputRange!(Unqual!OutputTarget, ch
 
     void flush()
     {
-        static if (isFileHandle!OutputTarget) _outputTarget.write(_outputBuffer.data);
+        static if (isFileHandle!OutputTarget) _outputTarget.rawWrite(_outputBuffer.data);
         else _outputTarget.put(_outputBuffer.data);
 
         _outputBuffer.clear;


### PR DESCRIPTION
Switch `BufferedOutputRange` to use `File.rawWrite` rather than `File.write` when writing to file. This has two effects:
* Small performance gain on, up to 10% on some tools, but generally quite small.
* On Windows, writes in binary mode rather than text mode. This means Unix newlines are written rather than Windows newlines.

Regarding Windows newlines - Window is not currently supported, but it is worthwhile moving Windows support forward. A newline policy on Windows is TBD, but writing Unix newlines is an improvement, as it would enable the tools to work with each other in pipelines, and it gets closer to having a working Windows test suite. Updates to Windows newline handling can occur after that. See Issue #310.