### PR TITLE
csv2tsv refactor

### DIFF
--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -366,7 +366,7 @@ input streams chunk-by-chunk.
  *
  * Params:
  *   inputSource           =  A "bufferable" input source, either a file open for
- *                            read, or a dynamic, mutable ubyte array.
+ *                            read or an input range with ubyte elements.
  *   outputStream          =  An output range to write TSV bytes to.
  *   readBuffer            =  A buffer to use for reading.
  *   filename              =  Name of file to use when reporting errors. A descriptive
@@ -418,7 +418,6 @@ if (isBufferableInputSource!InputSource &&
      *   * fieldNum - Field number in the current line/record. Field numbers are
      *     one-upped. The field number set to zero at the start of a new record,
      *     prior to processing the first character of the first field on the record.
-     *   * byteIndex - Read buffer index of the current byte being processed.
      *   * csvState - The current state of CSV processing. In particular, the state
      *     of the finite state machine.
      *   * writeRegionStart - Read buffer index where the next write starts from.

--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -492,14 +492,15 @@ if (isBufferableInputSource!InputSource &&
         foreach (size_t nextIndex, char nextChar; inputChunk)
         {
             /* nextRecord is used when an end of record (end of line) is found. It
-             * does two things: bump the record number, and flush the current write
-             * region if it represents the last line being skipped at the start of
-             * input. Normally the header line.
+             * bump the record number moves resets the field number. It also flushes
+             * the current write region if the line we were on was the last line
+             * being skipped at the start of input. Normally the header line.
              */
             void nextRecord()
             {
                 if (recordNum == skipLines) flushCurrentRegion(nextIndex);
-                 ++recordNum;
+                ++recordNum;
+                fieldNum = 0;
             }
 
         OuterSwitch: final switch (csvState)
@@ -533,13 +534,11 @@ if (isBufferableInputSource!InputSource &&
                     break OuterSwitch;
                 case LF:
                     nextRecord();
-                    fieldNum = 0;
                     csvState = CSVState.FieldEnd;
                     break OuterSwitch;
                 case CR:
                     inputChunk[nextIndex] = LF;
                     nextRecord();
-                    fieldNum = 0;
                     csvState = CSVState.CRAtFieldEnd;
                     break OuterSwitch;
                 case tsvDelim:
@@ -619,13 +618,11 @@ if (isBufferableInputSource!InputSource &&
                     break OuterSwitch;
                 case LF:
                     nextRecord();
-                    fieldNum = 0;
                     csvState = CSVState.FieldEnd;
                     break OuterSwitch;
                 case CR:
                     inputChunk[nextIndex] = LF;
                     nextRecord();
-                    fieldNum = 0;
                     csvState = CSVState.CRAtFieldEnd;
                     break OuterSwitch;
                 default:


### PR DESCRIPTION
Some code refactoring:
* Moved `isBufferableInputSource` and `inputSourceByChunk` to `common/utils.d`. They were also modified to take arbitrary ubyte input ranges, not just arrays.
* Refactoring of end-of-record / end-of-line code in `csv2tsv` state machine.