### PR TITLE
Try re-enabling the formatNumber rounding tests with 64-bit Windows builds

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: make unittest
         # Currently, only run unit tests on DMD. LDC has failures due to numeric formatting.
-        if: ${{ startsWith(matrix.dc, 'dmd') }}
+        # if: ${{ startsWith(matrix.dc, 'dmd') }}
         shell: bash
         run: |
           make unittest DCOMPILER=${DC} DFLAGS=-m64

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -34,8 +34,9 @@ jobs:
           make clean
 
       - name: make unittest
-        # Currently, only run unit tests on DMD. LDC has failures due to numeric formatting.
-        # if: ${{ startsWith(matrix.dc, 'dmd') }}
+        # Currently, only run unit tests on DMD. LDC has failures in tsv-sample due
+        # to minor descrepancies in printed random numbers.
+        if: ${{ startsWith(matrix.dc, 'dmd') }}
         shell: bash
         run: |
           make unittest DCOMPILER=${DC} DFLAGS=-m64

--- a/common/src/tsv_utils/common/numerics.d
+++ b/common/src/tsv_utils/common/numerics.d
@@ -343,7 +343,6 @@ unittest  // formatNumber unit tests
         assert(formatNumber(-0.6, 0) == "-1");
     }
 
-    assert(formatNumber(-0.6, 0) == "-1");
     assert(formatNumber(-0.6, 1) == "-0.6");
     assert(formatNumber(-0.06, 0) == "-0");
     assert(formatNumber(-0.06, 1) == "-0.1");

--- a/common/src/tsv_utils/common/numerics.d
+++ b/common/src/tsv_utils/common/numerics.d
@@ -209,35 +209,28 @@ unittest  // formatNumber unit tests
     assert(formatNumber(1234567891234.0, 0) == "1234567891234");
     assert(formatNumber(1234567891234.0, 1) == "1234567891234");
 
-    // Test round off cases
-    version(Windows)
-    {
-        /* Round-off cases don't work properly on Windows. They truncate rather than
-         * round. May be a DMD specific Windows bug, not clear.
-         */
-    }
-    else
-    {
-        assert(formatNumber(0.6, 0) == "1");
-        assert(formatNumber(0.6, 1) == "0.6");
-        assert(formatNumber(0.06, 0) == "0");
-        assert(formatNumber(0.06, 1) == "0.1");
-        assert(formatNumber(0.06, 2) == "0.06");
-        assert(formatNumber(0.06, 3) == "0.06");
-        assert(formatNumber(9.49999, 0) == "9");
-        assert(formatNumber(9.49999, 1) == "9.5");
-        assert(formatNumber(9.6, 0) == "10");
-        assert(formatNumber(9.6, 1) == "9.6");
-        assert(formatNumber(99.99, 0) == "100");
-        assert(formatNumber(99.99, 1) == "100");
-        assert(formatNumber(99.99, 2) == "99.99");
-        assert(formatNumber(9999.9996, 3) == "10000");
-        assert(formatNumber(9999.9996, 4) == "9999.9996");
-        assert(formatNumber(99999.99996, 4) == "100000");
-        assert(formatNumber(99999.99996, 5) == "99999.99996");
-        assert(formatNumber(999999.999996, 5) == "1000000");
-        assert(formatNumber(999999.999996, 6) == "999999.999996");
-    }
+    /* Test round off cases. Note: These tests will not pass on Windows 32-bit builds.
+     * Use the -m64 flag on Windows to get a 64-bit build.
+     */
+    assert(formatNumber(0.6, 0) == "1");
+    assert(formatNumber(0.6, 1) == "0.6");
+    assert(formatNumber(0.06, 0) == "0");
+    assert(formatNumber(0.06, 1) == "0.1");
+    assert(formatNumber(0.06, 2) == "0.06");
+    assert(formatNumber(0.06, 3) == "0.06");
+    assert(formatNumber(9.49999, 0) == "9");
+    assert(formatNumber(9.49999, 1) == "9.5");
+    assert(formatNumber(9.6, 0) == "10");
+    assert(formatNumber(9.6, 1) == "9.6");
+    assert(formatNumber(99.99, 0) == "100");
+    assert(formatNumber(99.99, 1) == "100");
+    assert(formatNumber(99.99, 2) == "99.99");
+    assert(formatNumber(9999.9996, 3) == "10000");
+    assert(formatNumber(9999.9996, 4) == "9999.9996");
+    assert(formatNumber(99999.99996, 4) == "100000");
+    assert(formatNumber(99999.99996, 5) == "99999.99996");
+    assert(formatNumber(999999.999996, 5) == "1000000");
+    assert(formatNumber(999999.999996, 6) == "999999.999996");
 
     /* Turn off precision, the 'human readable' style.
      * Note: Remains o if both are zero (first test). If it becomes desirable to support
@@ -314,41 +307,34 @@ unittest  // formatNumber unit tests
     assert(formatNumber(-1234567891234.0, 0) == "-1234567891234");
     assert(formatNumber(-1234567891234.0, 1) == "-1234567891234");
 
-    // Test round off cases
-    version(Windows)
-    {
-        /* Round-off cases don't work properly on Windows. They truncate rather than
-         * round. May be a DMD specific Windows bug, not clear.
-         */
-    }
-    else
-    {
-        assert(formatNumber(-0.6, 0) == "-1");
-        assert(formatNumber(-0.6, 1) == "-0.6");
-        assert(formatNumber(-0.06, 0) == "-0");
-        assert(formatNumber(-0.06, 1) == "-0.1");
-        assert(formatNumber(-0.06, 2) == "-0.06");
-        assert(formatNumber(-0.06, 3) == "-0.06");
-        assert(formatNumber(-9.49999, 0) == "-9");
-        assert(formatNumber(-9.49999, 1) == "-9.5");
-        assert(formatNumber(-9.6, 0) == "-10");
-        assert(formatNumber(-9.6, 1) == "-9.6");
-        assert(formatNumber(-99.99, 0) == "-100");
-        assert(formatNumber(-99.99, 1) == "-100");
-        assert(formatNumber(-99.99, 2) == "-99.99");
-        assert(formatNumber(-9999.9996, 3) == "-10000");
-        assert(formatNumber(-9999.9996, 4) == "-9999.9996");
-        assert(formatNumber(-99999.99996, 4) == "-100000");
-        assert(formatNumber(-99999.99996, 5) == "-99999.99996");
-        assert(formatNumber(-999999.999996, 5) == "-1000000");
-        assert(formatNumber(-999999.999996, 6) == "-999999.999996");
+    /* Test round off cases. Note: These tests will not pass on Windows 32-bit builds.
+     * Use the -m64 flag on Windows to get a 64-bit build.
+     */
+    assert(formatNumber(-0.6, 0) == "-1");
+    assert(formatNumber(-0.6, 1) == "-0.6");
+    assert(formatNumber(-0.06, 0) == "-0");
+    assert(formatNumber(-0.06, 1) == "-0.1");
+    assert(formatNumber(-0.06, 2) == "-0.06");
+    assert(formatNumber(-0.06, 3) == "-0.06");
+    assert(formatNumber(-9.49999, 0) == "-9");
+    assert(formatNumber(-9.49999, 1) == "-9.5");
+    assert(formatNumber(-9.6, 0) == "-10");
+    assert(formatNumber(-9.6, 1) == "-9.6");
+    assert(formatNumber(-99.99, 0) == "-100");
+    assert(formatNumber(-99.99, 1) == "-100");
+    assert(formatNumber(-99.99, 2) == "-99.99");
+    assert(formatNumber(-9999.9996, 3) == "-10000");
+    assert(formatNumber(-9999.9996, 4) == "-9999.9996");
+    assert(formatNumber(-99999.99996, 4) == "-100000");
+    assert(formatNumber(-99999.99996, 5) == "-99999.99996");
+    assert(formatNumber(-999999.999996, 5) == "-1000000");
+    assert(formatNumber(-999999.999996, 6) == "-999999.999996");
 
-        assert(formatNumber!(double, 0)(-999.123412, 0) == "-999");
-        assert(formatNumber!(double, 0)(-999.123412, 1) == "-1e+03");
-        assert(formatNumber!(double, 0)(-999.123412, 2) == "-1e+03");
-        assert(formatNumber!(double, 0)(-999.123412, 3) == "-999");
-        assert(formatNumber!(double, 0)(-999.123412, 4) == "-999.1");
-    }
+    assert(formatNumber!(double, 0)(-999.123412, 0) == "-999");
+    assert(formatNumber!(double, 0)(-999.123412, 1) == "-1e+03");
+    assert(formatNumber!(double, 0)(-999.123412, 2) == "-1e+03");
+    assert(formatNumber!(double, 0)(-999.123412, 3) == "-999");
+    assert(formatNumber!(double, 0)(-999.123412, 4) == "-999.1");
 
     // Default number printing
     assert(formatNumber(-1.2) == "-1.2");

--- a/common/src/tsv_utils/common/numerics.d
+++ b/common/src/tsv_utils/common/numerics.d
@@ -211,8 +211,24 @@ unittest  // formatNumber unit tests
 
     /* Test round off cases. Note: These tests will not pass on Windows 32-bit builds.
      * Use the -m64 flag on Windows to get a 64-bit build.
+     *
+     * Note: The first test case does not generate the correct result on Windows
+     * 64-bit builds. The current Windows result is included both for documentation
+     * and to provide an alert if the correct result starts getting populated. Both
+     * formatNumber and the underlying format call are included.
      */
-    assert(formatNumber(0.6, 0) == "1");
+    version(Windows)
+    {
+        // Incorrect
+        assert(format("%.*f", 0, 0.6) == "0");
+        assert(formatNumber(0.6, 0) == "0");
+    }
+    else
+    {
+        assert(format("%.*f", 0, 0.6) == "1");
+        assert(formatNumber(0.6, 0) == "1");
+    }
+
     assert(formatNumber(0.6, 1) == "0.6");
     assert(formatNumber(0.06, 0) == "0");
     assert(formatNumber(0.06, 1) == "0.1");
@@ -307,9 +323,26 @@ unittest  // formatNumber unit tests
     assert(formatNumber(-1234567891234.0, 0) == "-1234567891234");
     assert(formatNumber(-1234567891234.0, 1) == "-1234567891234");
 
-    /* Test round off cases. Note: These tests will not pass on Windows 32-bit builds.
-     * Use the -m64 flag on Windows to get a 64-bit build.
+    /* Test round off cases with negative numbers. Note: These tests will not pass
+     * on Windows 32-bit builds. Use the -m64 flag on Windows to get a 64-bit build.
+     *
+     * Note: The first test case does not generate the correct result on Windows
+     * 64-bit builds. The current Windows result is included both for documentation
+     * and to provide an alert if the correct result starts getting populated. Both
+     * formatNumber and the underlying format call are included.
      */
+    version(Windows)
+    {
+        // Incorrect
+        assert(format("%.*f", 0, -0.6) == "-0");
+        assert(formatNumber(-0.6, 0) == "0");
+    }
+    else
+    {
+        assert(format("%.*f", 0, -0.6) == "-1");
+        assert(formatNumber(-0.6, 0) == "-1");
+    }
+
     assert(formatNumber(-0.6, 0) == "-1");
     assert(formatNumber(-0.6, 1) == "-0.6");
     assert(formatNumber(-0.06, 0) == "-0");

--- a/common/src/tsv_utils/common/numerics.d
+++ b/common/src/tsv_utils/common/numerics.d
@@ -335,7 +335,7 @@ unittest  // formatNumber unit tests
     {
         // Incorrect
         assert(format("%.*f", 0, -0.6) == "-0");
-        assert(formatNumber(-0.6, 0) == "0");
+        assert(formatNumber(-0.6, 0) == "-0");
     }
     else
     {


### PR DESCRIPTION
On at least some subsets the problems were a result of using 32 bit builds on Windows.

At present it comes down to two test cases that fail on Windows 64-bit builds. It's due to deltas in the underlying call to the `std.format.format` function between Windows and Unix/MacOs platforms. The calls `(format("%.*f", 0, 0.6)` and `format("%.*f", 0, -0.6)` should return `"1"` and `"-1"` respectively, but instead return `"0"` and `"-0"`. The Unix and MacOS platforms return the correct results.

Despite the discrepancy, this is a smaller set than was excluded under 32-bit builds. On 32-bit, it was appearing as if truncation rather than rounding was more widespread.

The formatNumber tests succeed for both DMD and LDC. However, LDC unit test builds are not enabled due to small differences in printed random values in `tsv-sample` tests.