### PR TITLE
Change Windows newline detection to occur on all platforms

### DIFF
--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -753,7 +753,7 @@ struct TsvFilterOptions
         import std.getopt;
         import std.path : baseName, stripExtension;
         import tsv_utils.common.getopt_inorder;
-        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+        import tsv_utils.common.utils : throwIfWindowsNewline;
 
         bool helpVerbose = false;        // --help-verbose
         bool helpOptions = false;        // --help-options
@@ -974,7 +974,7 @@ struct TsvFilterOptions
 
             if (hasHeader)
             {
-                throwIfWindowsNewlineOnUnix(inputSources.front.header, inputSources.front.name, 1);
+                throwIfWindowsNewline(inputSources.front.header, inputSources.front.name, 1);
                 headerFields = inputSources.front.header.split(delim).to!(string[]);
                 fieldListArgProcessing();
             }
@@ -995,7 +995,7 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
     import std.algorithm : all, any, splitter;
     import std.range;
     import tsv_utils.common.utils : BufferedOutputRange, bufferedByLine, InputSourceRange,
-        throwIfWindowsNewlineOnUnix;
+        throwIfWindowsNewline;
 
     /* inputSources must be an InputSourceRange and include at least stdin. */
     assert(!cmdopt.inputSources.empty);
@@ -1028,11 +1028,11 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (lineNum, line; inputStream.file.bufferedByLine.enumerate(fileBodyStartLine))
         {
-            if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, lineNum);
+            if (lineNum == 1) throwIfWindowsNewline(line, inputStream.name, lineNum);
 
             /* Copy the needed number of fields to the fields array. */
             int fieldIndex = -1;

--- a/tsv-join/src/tsv_utils/tsv-join.d
+++ b/tsv-join/src/tsv_utils/tsv-join.d
@@ -121,7 +121,7 @@ struct TsvJoinOptions
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist;
-        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+        import tsv_utils.common.utils : throwIfWindowsNewline;
 
         bool helpVerbose = false;        // --help-verbose
         bool helpFields = false;         // --help-fields
@@ -356,10 +356,10 @@ struct TsvJoinOptions
             {
                 if (!filterSource.front.byLine.empty)
                 {
-                    throwIfWindowsNewlineOnUnix(filterSource.front.byLine.front, filterSource.front.name, 1);
+                    throwIfWindowsNewline(filterSource.front.byLine.front, filterSource.front.name, 1);
                     filterFileHeaderFields = filterSource.front.byLine.front.split(delim).to!(string[]);
                 }
-                throwIfWindowsNewlineOnUnix(inputSources.front.header, inputSources.front.name, 1);
+                throwIfWindowsNewline(inputSources.front.header, inputSources.front.name, 1);
                 inputSourceHeaderFields = inputSources.front.header.split(delim).to!(string[]);
                 fieldListArgProcessing();
             }
@@ -403,7 +403,7 @@ int main(string[] cmdArgs)
 void tsvJoin(ref TsvJoinOptions cmdopt)
 {
     import tsv_utils.common.utils : ByLineSourceRange, bufferedByLine, BufferedOutputRange,
-        isFlushableOutputRange, InputFieldReordering, InputSourceRange, throwIfWindowsNewlineOnUnix;
+        isFlushableOutputRange, InputFieldReordering, InputSourceRange, throwIfWindowsNewline;
     import std.algorithm : splitter;
     import std.array : join;
     import std.range;
@@ -511,7 +511,7 @@ void tsvJoin(ref TsvJoinOptions cmdopt)
 
             debug writeln("  --> [key]:[append] => [", key, "]:[", appendValues, "]");
 
-            if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, filterStream.name, lineNum);
+            if (lineNum == 1) throwIfWindowsNewline(line, filterStream.name, lineNum);
 
             if (lineNum == 1 && cmdopt.hasHeader)
             {
@@ -576,13 +576,13 @@ void tsvJoin(ref TsvJoinOptions cmdopt)
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (lineNum, line; inputStream.file.bufferedByLine.enumerate(fileBodyStartLine))
         {
             debug writeln("[input line] |", line, "|");
 
-            if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, lineNum);
+            if (lineNum == 1) throwIfWindowsNewline(line, inputStream.name, lineNum);
 
             /*
              * Next block checks if the input line matches a hash entry. Two cases:

--- a/tsv-sample/src/tsv_utils/tsv-sample.d
+++ b/tsv-sample/src/tsv_utils/tsv-sample.d
@@ -261,7 +261,7 @@ struct TsvSampleOptions
         import std.math : isNaN;
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
-        import tsv_utils.common.utils : inputSourceRange, ReadHeader, throwIfWindowsNewlineOnUnix;
+        import tsv_utils.common.utils : inputSourceRange, ReadHeader, throwIfWindowsNewline;
         import tsv_utils.common.fieldlist;
 
         bool helpVerbose = false;                  // --help-verbose
@@ -511,7 +511,7 @@ struct TsvSampleOptions
 
             if (hasHeader)
             {
-                throwIfWindowsNewlineOnUnix(inputSources.front.header, inputSources.front.name, 1);
+                throwIfWindowsNewline(inputSources.front.header, inputSources.front.name, 1);
                 headerFields = inputSources.front.header.split(delim).to!(string[]);
                 fieldListArgProcessing();
             }
@@ -613,7 +613,7 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, uniform01;
     import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputSourceRange, throwIfWindowsNewline;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -654,12 +654,12 @@ if (isOutputRange!(OutputRange, char))
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (ulong fileLineNum, line;
                  inputStream.file.bufferedByLine!(KeepTerminator.no).enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             immutable double lineScore = uniform01(randomGenerator);
 
@@ -738,7 +738,7 @@ void bernoulliSkipSampling(OutputRange)(ref TsvSampleOptions cmdopt, OutputRange
     import std.math : log, trunc;
     import std.random : Random = Mt19937, uniform01;
     import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputSourceRange, throwIfWindowsNewline;
 
     assert(cmdopt.inclusionProbability > 0.0 && cmdopt.inclusionProbability < 1.0);
     assert(!cmdopt.printRandom);
@@ -776,12 +776,12 @@ void bernoulliSkipSampling(OutputRange)(ref TsvSampleOptions cmdopt, OutputRange
     ulong numLinesWritten = 0;
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (ulong fileLineNum, line;
                  inputStream.file.bufferedByLine!(KeepTerminator.no).enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             if (remainingSkips > 0)
             {
@@ -832,7 +832,7 @@ if (isOutputRange!(OutputRange, char))
     import std.digest.murmurhash;
     import std.math : lrint;
     import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
-        InputFieldReordering, InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputFieldReordering, InputSourceRange, throwIfWindowsNewline;
 
     static if (generateRandomAll) assert(cmdopt.genRandomInorder);
     else assert(!cmdopt.genRandomInorder);
@@ -887,12 +887,12 @@ if (isOutputRange!(OutputRange, char))
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (ulong fileLineNum, line;
                  inputStream.file.bufferedByLine!(KeepTerminator.no).enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             /* Murmurhash works by successively adding individual keys, then finalizing.
              * Adding individual keys is simpler if the full-line-as-key and individual
@@ -1081,7 +1081,7 @@ if (isOutputRange!(OutputRange, char))
     import std.meta : AliasSeq;
     import std.random : Random = Mt19937, uniform01;
     import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputSourceRange, throwIfWindowsNewline;
 
     static if (isWeighted) assert(cmdopt.hasWeightField);
     else assert(!cmdopt.hasWeightField);
@@ -1139,12 +1139,12 @@ if (isOutputRange!(OutputRange, char))
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (ulong fileLineNum, line;
                  inputStream.file.bufferedByLine!(KeepTerminator.no).enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             static if (!isWeighted)
             {
@@ -1225,7 +1225,7 @@ if (isOutputRange!(OutputRange, char))
 {
     import std.random : Random = Mt19937, uniform01;
     import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputSourceRange, throwIfWindowsNewline;
 
     assert(cmdopt.hasWeightField);
 
@@ -1256,12 +1256,12 @@ if (isOutputRange!(OutputRange, char))
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (ulong fileLineNum, line;
                  inputStream.file.bufferedByLine!(KeepTerminator.no).enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             immutable double lineWeight =
                 getFieldValue!double(line, cmdopt.weightField, cmdopt.delim, inputStream.name, fileLineNum);
@@ -1322,7 +1322,7 @@ if (isOutputRange!(OutputRange, char))
     import std.random : Random = Mt19937, randomShuffle, uniform;
     import std.algorithm : sort;
     import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputSourceRange, throwIfWindowsNewline;
 
     assert(cmdopt.sampleSize > 0);
     assert(!cmdopt.hasWeightField);
@@ -1365,12 +1365,12 @@ if (isOutputRange!(OutputRange, char))
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (ulong fileLineNum, line;
                  inputStream.file.bufferedByLine!(KeepTerminator.no).enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             /* Add lines to the reservoir until the reservoir is filled.
              * After that lines are added with decreasing likelihood, based on
@@ -1625,7 +1625,7 @@ if (isOutputRange!(OutputRange, char))
     import std.algorithm : find, min;
     import std.range : retro;
     import tsv_utils.common.utils : InputSourceRange, isFlushableOutputRange,
-        throwIfWindowsNewlineOnUnix;
+        throwIfWindowsNewline;
 
     static if(!hasRandomValue) assert(!cmdopt.printRandom);
 
@@ -1663,7 +1663,7 @@ if (isOutputRange!(OutputRange, char))
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         /* If the file size can be determined then read it as a single block.
          * Otherwise read as multiple blocks. File.size() returns ulong.max
@@ -1862,7 +1862,7 @@ InputLine!hasRandomValue[] identifyInputLines(HasRandomValue hasRandomValue, Fla
     import std.algorithm : splitter;
     import std.array : appender;
     import std.random : Random = Mt19937, uniform01;
-    import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+    import tsv_utils.common.utils : throwIfWindowsNewline;
 
     static assert(hasRandomValue || !isWeighted);
     static if(!hasRandomValue) assert(!cmdopt.printRandom);
@@ -1888,7 +1888,7 @@ InputLine!hasRandomValue[] identifyInputLines(HasRandomValue hasRandomValue, Fla
         {
             fileLineNum++;
 
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, block.filename, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, block.filename, fileLineNum);
 
             static if (!hasRandomValue)
             {

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -183,7 +183,7 @@ struct TsvSelectOptions
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist;
-        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+        import tsv_utils.common.utils : throwIfWindowsNewline;
 
         bool helpVerbose = false;           // --help-verbose
         bool helpFields = false;            // --help-fields
@@ -348,7 +348,7 @@ struct TsvSelectOptions
             {
                 if (!inputSources.front.byLine.empty)
                 {
-                    throwIfWindowsNewlineOnUnix(inputSources.front.byLine.front, inputSources.front.name, 1);
+                    throwIfWindowsNewline(inputSources.front.byLine.front, inputSources.front.name, 1);
                     headerFields = inputSources.front.byLine.front.split(delim).to!(string[]);
                 }
 
@@ -440,7 +440,7 @@ enum RestLocation { none, first, last };
 void tsvSelect(RestLocation rest)(ref TsvSelectOptions cmdopt)
 {
     import tsv_utils.common.utils: BufferedOutputRange, ByLineSourceRange,
-        InputFieldReordering, throwIfWindowsNewlineOnUnix;
+        InputFieldReordering, throwIfWindowsNewline;
     import std.algorithm: splitter;
     import std.array : appender, Appender;
     import std.format: format;
@@ -492,7 +492,7 @@ void tsvSelect(RestLocation rest)(ref TsvSelectOptions cmdopt)
     {
         foreach (lineNum, line; inputStream.byLine.enumerate(1))
         {
-            if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, lineNum);
+            if (lineNum == 1) throwIfWindowsNewline(line, inputStream.name, lineNum);
 
             if (lineNum == 1 && fileNum > 0 && cmdopt.hasHeader)
             {

--- a/tsv-split/src/tsv_utils/tsv-split.d
+++ b/tsv-split/src/tsv_utils/tsv-split.d
@@ -978,7 +978,7 @@ void splitLinesByKey(ref TsvSplitOptions cmdopt, ref SplitOutputFiles outputFile
     import std.conv : to;
     import std.digest.murmurhash;
     import tsv_utils.common.utils : bufferedByLine, InputFieldReordering,
-        InputSourceRange, throwIfWindowsNewlineOnUnix;
+        InputSourceRange, throwIfWindowsNewline;
 
     assert(cmdopt.keyFields.length > 0);
 
@@ -995,11 +995,11 @@ void splitLinesByKey(ref TsvSplitOptions cmdopt, ref SplitOutputFiles outputFile
     immutable size_t fileBodyStartLine = cmdopt.hasHeader ? 2 : 1;
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (fileLineNum, line; inputStream.file.bufferedByLine.enumerate(fileBodyStartLine))
         {
-            if (fileLineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, fileLineNum);
+            if (fileLineNum == 1) throwIfWindowsNewline(line, inputStream.name, fileLineNum);
 
             /* Murmurhash works by successively adding individual keys, then finalizing.
              * Adding individual keys is simpler if the full-line-as-key and individual

--- a/tsv-summarize/src/tsv_utils/tsv-summarize.d
+++ b/tsv-summarize/src/tsv_utils/tsv-summarize.d
@@ -202,7 +202,7 @@ struct TsvSummarizeOptions {
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist : fieldListHelpText;
         import tsv_utils.common.getopt_inorder;
-        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+        import tsv_utils.common.utils : throwIfWindowsNewline;
 
         bool helpVerbose = false;          // --help-verbose
         bool helpFields = false;           // --help-fields
@@ -336,7 +336,7 @@ struct TsvSummarizeOptions {
             {
                 if (!inputSources.front.byLine.empty)
                 {
-                    throwIfWindowsNewlineOnUnix(inputSources.front.byLine.front, inputSources.front.name, 1);
+                    throwIfWindowsNewline(inputSources.front.byLine.front, inputSources.front.name, 1);
                     headerFields = inputSources.front.byLine.front.split(inputFieldDelimiter).to!(string[]);
                 }
 
@@ -540,7 +540,7 @@ struct TsvSummarizeOptions {
 void tsvSummarize(ref TsvSummarizeOptions cmdopt)
 {
     import tsv_utils.common.utils : BufferedOutputRange, ByLineSourceRange,
-        bufferedByLine, throwIfWindowsNewlineOnUnix;
+        bufferedByLine, throwIfWindowsNewline;
 
     /* Check that the input files were setup as expected. Should at least have one
      * input, stdin if nothing else, and newlines removed from the byLine range.
@@ -589,7 +589,7 @@ void tsvSummarize(ref TsvSummarizeOptions cmdopt)
     {
         foreach (lineNum, line; inputStream.byLine.enumerate(1))
         {
-            if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, lineNum);
+            if (lineNum == 1) throwIfWindowsNewline(line, inputStream.name, lineNum);
 
             /* Copy the needed number of fields to the fields array.
              * Note: The number is zero if no operator needs fields. Notably, the count

--- a/tsv-uniq/src/tsv_utils/tsv-uniq.d
+++ b/tsv-uniq/src/tsv_utils/tsv-uniq.d
@@ -146,7 +146,7 @@ struct TsvUniqOptions
         import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsv_utils.common.fieldlist;
-        import tsv_utils.common.utils : throwIfWindowsNewlineOnUnix;
+        import tsv_utils.common.utils : throwIfWindowsNewline;
 
         bool helpVerbose = false;         // --h|help-verbose
         bool helpFields = false;          // --help-fields
@@ -271,7 +271,7 @@ struct TsvUniqOptions
 
             if (hasHeader)
             {
-                throwIfWindowsNewlineOnUnix(inputSources.front.header, inputSources.front.name, 1);
+                throwIfWindowsNewline(inputSources.front.header, inputSources.front.name, 1);
                 headerFields = inputSources.front.header.split(delim).to!(string[]);
                 fieldListArgProcessing();
             }
@@ -327,7 +327,7 @@ int main(string[] cmdArgs)
 void tsvUniq(ref TsvUniqOptions cmdopt)
 {
     import tsv_utils.common.utils : bufferedByLine, BufferedOutputRange,
-        InputFieldReordering, InputSourceRange, joinAppend, throwIfWindowsNewlineOnUnix;
+        InputFieldReordering, InputSourceRange, joinAppend, throwIfWindowsNewline;
     import std.algorithm : splitter;
     import std.array : appender;
     import std.conv : to;
@@ -387,11 +387,11 @@ void tsvUniq(ref TsvUniqOptions cmdopt)
 
     foreach (inputStream; cmdopt.inputSources)
     {
-        if (cmdopt.hasHeader) throwIfWindowsNewlineOnUnix(inputStream.header, inputStream.name, 1);
+        if (cmdopt.hasHeader) throwIfWindowsNewline(inputStream.header, inputStream.name, 1);
 
         foreach (lineNum, line; inputStream.file.bufferedByLine.enumerate(fileBodyStartLine))
         {
-            if (lineNum == 1) throwIfWindowsNewlineOnUnix(line, inputStream.name, lineNum);
+            if (lineNum == 1) throwIfWindowsNewline(line, inputStream.name, lineNum);
 
             /* Start by finding the key. */
             typeof(line) key;


### PR DESCRIPTION
Most of the tsv-utils tools require Unix newlines. These tools check for Windows newlines on Posix platforms using `throwIfWindowsNewlineOnUnix`. However, these tools generally have trouble with Windows newlines on Windows platforms as well. And, there is no warning to users. This adds detection and user messaging on Windows.

The PR changes Windows newline detection to occur on all platforms. The `throwIfWindowsNewlineOnUnix` was renamed to `throwIfWindowsNewline` and the code changed to throw on all all platforms. Callers were changed to call the new function.

This is a step towards getting a Window build that has a fully functioning test suite. See issue #317. Support for Windows newlines can be evaluated after having a fully functioning test suite on Windows. 