### PR TITLE
Set -link-defaultlib-shared=false when building with LDC LTO and runtime libs.

### DIFF
--- a/makedefs.mk
+++ b/makedefs.mk
@@ -291,7 +291,7 @@ ifeq ($(compiler_type),ldc)
 	endif
 
 	ifneq ($(LDC_LTO_RUNTIME),)
-		lto_link_flags = -defaultlib=phobos2-ldc-lto,druntime-ldc-lto
+		lto_link_flags = -defaultlib=phobos2-ldc-lto,druntime-ldc-lto -link-defaultlib-shared=false
 	else ifneq ($(LDC_BUILD_RUNTIME),)
 		ifeq ($(OS_NAME),Darwin)
 			lto_link_flags = -L-L$(ldc_build_runtime_dir)/lib


### PR DESCRIPTION
Fix for Issue #325.

This PR adds the `-link-defaultlib-shared=false` when building with LDC LTO using LTO versions of druntime and Phobos (the default libs). This is to override an `ldc2.conf` setting of `-link-defaultlib-shared=true` used in some environments. This issue was identified on the Archlinux LDC installation (Issue #325) but may occur in other environments as well.
