### PR TITLE
GitHub actions linux builds

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -1,5 +1,5 @@
 # Workflow to run a D compile on Windows. No tests, just the build step. 
-name: D
+name: build-test
 
 on:
   push:
@@ -42,7 +42,7 @@ jobs:
           make unittest DCOMPILER=${DC} DFLAGS=-m64
 
   linux-macos-build:
-    name: Basic builds of tsv-utils on Linux and macOS
+    name: Build tsv-utils on Linux, macOS
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -46,8 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
-        dc: [dmd-latest, ldc-latest]
+        os: [macOS-latest, ubuntu-latest]
+        dc: [ldc-latest, dmd-latest]
         include:
           - os: ubuntu-latest
             dc: dmd-2.088.1

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -41,13 +41,15 @@ jobs:
         run: |
           make unittest DCOMPILER=${DC} DFLAGS=-m64
 
-  macos-build:
-    name: Build tsv-utils on macOS
+  linux-macos-build:
+    name: Basic builds of tsv-utils on Linux and macOS
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         dc: [dmd-latest, ldc-latest]
+      include:
+        - { os:ubuntu-latest, dc: dmd-2.088.1 }
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -48,9 +48,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
         dc: [dmd-latest, ldc-latest]
-      include:
-        - os: ubuntu-latest
-          dc: dmd-2.088.1
+        include:
+          - os: ubuntu-latest
+            dc: dmd-2.088.1
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -49,7 +49,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         dc: [dmd-latest, ldc-latest]
       include:
-        - os:ubuntu-latest
+        - os: ubuntu-latest
           dc: dmd-2.088.1
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -49,7 +49,8 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         dc: [dmd-latest, ldc-latest]
       include:
-        - { os:ubuntu-latest, dc: dmd-2.088.1 }
+        - os:ubuntu-latest
+          dc: dmd-2.088.1
 
     runs-on: ${{ matrix.os }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       group: travis_latest
       language: d
       d: dmd
-      env: DUBTEST=1 MAKETEST=1 CODECOV=1
+      env: CODECOV=1
 #    - os: osx
 #      osx_image: xcode11.5
 #      group: travis_latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@
 #       macos build credits for releases until working with the new Travis-CI fee structure
 #       (non-free macos builds) can be addressed.
 #
+# Note: Feb 2021 - Drop all but essential builds in prep for moving to github actions. Keeping
+#       code coverage and release action builds.
+#
 matrix:
   allow_failures:
     - env: DUBTEST=1 MAKETEST=1 ALLOW_FAILURES=true
@@ -41,19 +44,22 @@ matrix:
 #      if: |
 #        fork = false AND \
 #        type IN (push)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc
-      env: LTOPGO_V2=default
+#    - os: linux
+#      dist: xenial
+#      group: travis_latest
+#      language: d
+#      d: ldc
+#      env: LTOPGO_V2=default
     - os: linux
       dist: xenial
       group: travis_latest
       language: d
       d: ldc-1.23.0
       env: LINUX_SPECIAL=1 DEPLOY=1
-      # if: type IN (pull_request, cron)
+      if:  |
+        fork = false AND \
+        type IN (push) AND \
+        tag IS present
     - os: osx
       osx_image: xcode11.5
       group: travis_latest
@@ -72,125 +78,39 @@ matrix:
 #      env: LTOPGO_V2=default
 #      if: |
 #         type IN (pull_request, cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc-1.18.0
-      env: DUBTEST=0 MAKETEST=1
-      if: type IN (pull_request, cron)
-#    - os: linux
-#        W/PR #281 (InputSourceRange), require ldc-1.17.0/dmd-2.087.0
-#        (Phobos PR #7117)
-#        W/ fieldlist, ldc-1.18.0/dmd-2.088.1. @safe format
-#      dist: xenial
-#      group: travis_latest
-#      language: d
-#      d: ldc-1.6.0
-#      env: DUBTEST=0 MAKETEST=1
-#      if: type IN (pull_request, cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc
-      env: DUBTEST=1 MAKETEST=1
-      if: type IN (pull_request)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc
-      env: DUBTEST=1 MAKETEST=1 APPLTO=full
-      if: type IN (cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc
-      env: APPLTO=thin ALLLTO=default
-      if: type IN (cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc
-      env: LTOPGO=default
-      if: type IN (cron)
 #    - os: linux
 #      dist: xenial
-#      sudo: required
 #      group: travis_latest
 #      language: d
-#      d: ldc-1.7.0
-#      services: docker
-#      env: DOCKERSPECIAL=1
-#      if: type IN (cron)
-#    - os: linux
-#      dist: xenial
-#      sudo: required
-#      group: travis_latest
-#      language: d
-#      d: ldc-1.12.0
-#      services: docker
-#      env: DOCKERSPECIAL=2
-#      if: type IN (cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc-beta
-      env: DUBTEST=1 MAKETEST=1 APPLTO=full
-      if: type IN (cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: ldc-beta
-      env: LTOPGO_V2=default
-      if: type IN (cron)
-    - os: linux
-      arch: arm64
-      language: d
-      d: ldc
-      env: MAKE_BUILDONLY=1 MAKETEST=1 ALLOW_FAILURES=true
-      if: type IN (cron)
-#    - os: osx
-#      osx_image: xcode11.5
-#      group: travis_latest
-#      language: d
-#      d: ldc-beta
-#      env: LTOPGO_V2=default
-#      if: type IN (cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: dmd-nightly
-      # Allow dmd-nightly (xenial) to fail until dub issue in 2.089 is fixed.
-      env: DUBTEST=1 MAKETEST=1 ALLOW_FAILURES=true
-      if: type IN (cron)
-#    - os: osx
-#      osx_image: xcode11.5
-#      group: travis_latest
-#      language: d
-#      d: dmd-nightly
+#      d: ldc
 #      env: DUBTEST=1 MAKETEST=1
-#      if: type IN (cron)
-    - os: linux
-      dist: xenial
-      group: travis_latest
-      language: d
-      d: dmd-beta
-      # Allow dmd-beta (xenial) to fail until dub issue in 2.089 is fixed.
-      env: DUBTEST=1 MAKETEST=1 ALLOW_FAILURES=true
-      if: type IN (cron)
-#    - os: osx
-#      osx_image: xcode11.5
+#      if: type IN (pull_request)
+#    - os: linux
+#      dist: xenial
 #      group: travis_latest
 #      language: d
-#      d: dmd-beta
-#      env: DUBTEST=1 MAKETEST=1
+#      d: ldc
+#      env: DUBTEST=1 MAKETEST=1 APPLTO=full
+#      if: type IN (cron)
+#    - os: linux
+#      dist: xenial
+#      group: travis_latest
+#      language: d
+#      d: ldc
+#      env: APPLTO=thin ALLLTO=default
+#      if: type IN (cron)
+#    - os: linux
+#      dist: xenial
+#      group: travis_latest
+#      language: d
+#      d: ldc
+#      env: LTOPGO=default
+#      if: type IN (cron)
+#    - os: linux
+#      arch: arm64
+#      language: d
+#      d: ldc
+#      env: MAKE_BUILDONLY=1 MAKETEST=1 ALLOW_FAILURES=true
 #      if: type IN (cron)
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ File an [issue](https://github.com/eBay/tsv-utils/issues) if you have problems, 
 * [Exploring D via Benchmarking of eBay's TSV Utilities](http://dconf.org/2018/talks/degenhardt.html). May 2, 2018. A presentation at [DConf 2018](http://dconf.org/2018/) describing performance benchmark studies conducted using eBay's TSV Utilities (slides [here](docs/dconf2018.pdf)).
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/eBay/tsv-utils/build-test)
-[![Travis](https://img.shields.io/travis/eBay/tsv-utils.svg)](https://travis-ci.org/eBay/tsv-utils)
 [![Codecov](https://img.shields.io/codecov/c/github/eBay/tsv-utils.svg)](https://codecov.io/gh/eBay/tsv-utils)
 [![GitHub release](https://img.shields.io/github/release/eBay/tsv-utils.svg)](https://github.com/eBay/tsv-utils/releases)
 [![Github commits (since latest release)](https://img.shields.io/github/commits-since/eBay/tsv-utils/latest.svg)](https://github.com/eBay/tsv-utils/commits/master)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ File an [issue](https://github.com/eBay/tsv-utils/issues) if you have problems, 
 * [Tools Reference](docs/ToolReference.md) - Detailed documentation.
 * [Releases](https://github.com/eBay/tsv-utils/releases) - Prebuilt binaries and release notes. Recent updates:
   * Current release: [version 2.1.2](https://github.com/eBay/tsv-utils/releases/tag/v2.1.2).
-  * `csv2tsv` performance and functionality improvements. See [version 2.1 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.1.0).
+  * Improved `csv2tsv` performance and functionality. See [version 2.1 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.1.0).
   * Named fields! See [version 2.0 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.0.0).
 * [Tips and tricks](docs/TipsAndTricks.md) - Simpler and faster command line tool use.
 * [Performance Studies](docs/Performance.md) - Benchmarks against similar tools and other performance studies.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ File an [issue](https://github.com/eBay/tsv-utils/issues) if you have problems, 
 **Additional documents:**
 * [Tools Reference](docs/ToolReference.md) - Detailed documentation.
 * [Releases](https://github.com/eBay/tsv-utils/releases) - Prebuilt binaries and release notes. Recent updates:
-  * Named field support! See [version 2.0 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.0.0).
-  * Improved `csv2tsv` performance and functionality. See [version 2.1 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.1.0).
+  * Current release: [version 2.1.2](https://github.com/eBay/tsv-utils/releases/tag/v2.1.2).
+  * `csv2tsv` performance and functionality improvements. See [version 2.1 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.1.0).
+  * Named fields! See [version 2.0 release notes](https://github.com/eBay/tsv-utils/releases/tag/v2.0.0).
 * [Tips and tricks](docs/TipsAndTricks.md) - Simpler and faster command line tool use.
 * [Performance Studies](docs/Performance.md) - Benchmarks against similar tools and other performance studies.
 * [Comparing TSV and CSV formats](docs/comparing-tsv-and-csv.md)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ File an [issue](https://github.com/eBay/tsv-utils/issues) if you have problems, 
 * [Experimenting with Link Time Optimization](docs/dlang-meetup-14dec2017.pdf). Dec 14, 2017. A presentation at the [Silicon Valley D Meetup](https://www.meetup.com/D-Lang-Silicon-Valley/) describing experiments using LTO based on eBay's TSV Utilities.
 * [Exploring D via Benchmarking of eBay's TSV Utilities](http://dconf.org/2018/talks/degenhardt.html). May 2, 2018. A presentation at [DConf 2018](http://dconf.org/2018/) describing performance benchmark studies conducted using eBay's TSV Utilities (slides [here](docs/dconf2018.pdf)).
 
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/eBay/tsv-utils/build-test)
 [![Travis](https://img.shields.io/travis/eBay/tsv-utils.svg)](https://travis-ci.org/eBay/tsv-utils)
 [![Codecov](https://img.shields.io/codecov/c/github/eBay/tsv-utils.svg)](https://codecov.io/gh/eBay/tsv-utils)
 [![GitHub release](https://img.shields.io/github/release/eBay/tsv-utils.svg)](https://github.com/eBay/tsv-utils/releases)


### PR DESCRIPTION
Add linux builds to github actions, drop most of the travis-ci builds. What's left on travis-ci:
* One dmd linux build with code coverage
* Release builds for macOS and Linux

Made a couple README file changes also.