### PR TITLE
tsv-filter: --count operation.

### DIFF
--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -98,7 +98,7 @@ _tsv_filter()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-fields --help-options --version --header --or --invert --delimiter --empty --not-empty --blank --not-blank --is-numeric --is-finite --is-nan --is-infinity --le --lt --ge --gt --eq --ne --str-le --str-lt --str-ge --str-gt --str-eq --istr-eq --str-ne --istr-ne --str-in-fld --istr-in-fld --str-not-in-fld --istr-not-in-fld --regex --iregex --not-regex --not-iregex --char-len-le --char-len-lt --char-len-ge --char-len-gt --char-len-eq --char-len-ne --byte-len-le --byte-len-lt --byte-len-ge --byte-len-gt --byte-len-eq --byte-len-ne --ff-le --ff-lt --ff-ge --ff-gt --ff-eq --ff-ne --ff-str-eq --ff-istr-eq --ff-str-ne --ff-istr-ne --ff-absdiff-le --ff-absdiff-gt ff-reldiff-le --ff-reldiff-gt"
+    opts="--help --help-verbose --help-fields --help-options --version --header --or --invert --count --delimiter --empty --not-empty --blank --not-blank --is-numeric --is-finite --is-nan --is-infinity --le --lt --ge --gt --eq --ne --str-le --str-lt --str-ge --str-gt --str-eq --istr-eq --str-ne --istr-ne --str-in-fld --istr-in-fld --str-not-in-fld --istr-not-in-fld --regex --iregex --not-regex --not-iregex --char-len-le --char-len-lt --char-len-ge --char-len-gt --char-len-eq --char-len-ne --byte-len-le --byte-len-lt --byte-len-ge --byte-len-gt --byte-len-eq --byte-len-ne --ff-le --ff-lt --ff-ge --ff-gt --ff-eq --ff-ne --ff-str-eq --ff-istr-eq --ff-str-ne --ff-istr-ne --ff-absdiff-le --ff-absdiff-gt ff-reldiff-le --ff-reldiff-gt"
 
     # Options requiring an argument or precluding other options
     case $prev in

--- a/tsv-filter/profile_data/collect_profile_data.sh
+++ b/tsv-filter/profile_data/collect_profile_data.sh
@@ -79,6 +79,7 @@ $prog profile_data_1.tsv -H --ff-absdiff-gt 9:10:2.5 > /dev/null
 $prog profile_data_1.tsv -H --ff-reldiff-le 1:17:2.0 > /dev/null
 $prog profile_data_1.tsv -H --ff-reldiff-gt 1:17:2.0 > /dev/null
 $prog profile_data_5.tsv -H --str-eq 1:weiß --str-ne 3:2 > /dev/null
+$prog profile.data_5.tsv --count --or --str-eq 1:red --eq 3:2 > /dev/null
 $prog profile_data_5.tsv -H --or --istr-eq 1:Grün --str-eq 1:日本語 --istr-ne 1:YELLOW > /dev/null
 $prog profile_data_4.tsv -H --str-le 4:cab --str-gt 5:RR > /dev/null
 $prog profile_data_4.tsv -H --invert --str-lt 4:cab --str-ge 5:RR > /dev/null

--- a/tsv-filter/tests/gold/basic_tests_1.txt
+++ b/tsv-filter/tests/gold/basic_tests_1.txt
@@ -181,6 +181,32 @@ F1	F2	F3	F4
 100	102	abc	AbC
 100	103	abc	AbC
 
+====Count tests===
+
+====[tsv-filter --header --eq 2:1 input1.tsv --count]====
+1
+
+====[tsv-filter --header --le 2:101 input1.tsv -c]====
+13
+
+====[tsv-filter -H --count --empty F1 input1.tsv]====
+0
+
+====[tsv-filter -H -c --not-empty F1 input1.tsv ]====
+15
+
+====[tsv-filter --eq 2:1 input1_noheader.tsv --count]====
+1
+
+====[tsv-filter --le 2:101 input1_noheader.tsv -c]====
+13
+
+====[tsv-filter --count --empty 1 input1_noheader.tsv]====
+0
+
+====[tsv-filter -c --not-empty 1 input1_noheader.tsv ]====
+15
+
 ====Empty and blank field tests===
 
 ====[tsv-filter --header --empty 3 input1.tsv]====

--- a/tsv-filter/tests/tests.sh
+++ b/tsv-filter/tests/tests.sh
@@ -53,6 +53,18 @@ runtest ${prog} "-H --ge F2:101 input1.tsv" ${basic_tests_1}
 runtest ${prog} "-H --gt F2:101 input1.tsv" ${basic_tests_1}
 runtest ${prog} "-H --ne F2:101 input1.tsv" ${basic_tests_1}
 
+# Count tests
+echo "" >> ${basic_tests_1}; echo "====Count tests===" >> ${basic_tests_1}
+runtest ${prog} "--header --eq 2:1 input1.tsv --count" ${basic_tests_1}
+runtest ${prog} "--header --le 2:101 input1.tsv -c" ${basic_tests_1}
+runtest ${prog} "-H --count --empty F1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-H -c --not-empty F1 input1.tsv " ${basic_tests_1}
+
+runtest ${prog} "--eq 2:1 input1_noheader.tsv --count" ${basic_tests_1}
+runtest ${prog} "--le 2:101 input1_noheader.tsv -c" ${basic_tests_1}
+runtest ${prog} "--count --empty 1 input1_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "-c --not-empty 1 input1_noheader.tsv " ${basic_tests_1}
+
 # Empty and blank field tests
 echo "" >> ${basic_tests_1}; echo "====Empty and blank field tests===" >> ${basic_tests_1}
 


### PR DESCRIPTION
This PR add a `--count` operation to `tsv-filter`. Only a count of the matching lines is output when this option is used.