### PR TITLE
Line buffering updates and tsv-select support

### DIFF
--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -98,7 +98,7 @@ _tsv_filter()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-fields --help-options --version --header --or --invert --count --delimiter --empty --not-empty --blank --not-blank --is-numeric --is-finite --is-nan --is-infinity --le --lt --ge --gt --eq --ne --str-le --str-lt --str-ge --str-gt --str-eq --istr-eq --str-ne --istr-ne --str-in-fld --istr-in-fld --str-not-in-fld --istr-not-in-fld --regex --iregex --not-regex --not-iregex --char-len-le --char-len-lt --char-len-ge --char-len-gt --char-len-eq --char-len-ne --byte-len-le --byte-len-lt --byte-len-ge --byte-len-gt --byte-len-eq --byte-len-ne --ff-le --ff-lt --ff-ge --ff-gt --ff-eq --ff-ne --ff-str-eq --ff-istr-eq --ff-str-ne --ff-istr-ne --ff-absdiff-le --ff-absdiff-gt ff-reldiff-le --ff-reldiff-gt"
+    opts="--help --help-verbose --help-fields --help-options --version --header --or --invert --count --delimiter --line-buffered --empty --not-empty --blank --not-blank --is-numeric --is-finite --is-nan --is-infinity --le --lt --ge --gt --eq --ne --str-le --str-lt --str-ge --str-gt --str-eq --istr-eq --str-ne --istr-ne --str-in-fld --istr-in-fld --str-not-in-fld --istr-not-in-fld --regex --iregex --not-regex --not-iregex --char-len-le --char-len-lt --char-len-ge --char-len-gt --char-len-eq --char-len-ne --byte-len-le --byte-len-lt --byte-len-ge --byte-len-gt --byte-len-eq --byte-len-ne --ff-le --ff-lt --ff-ge --ff-gt --ff-eq --ff-ne --ff-str-eq --ff-istr-eq --ff-str-ne --ff-istr-ne --ff-absdiff-le --ff-absdiff-gt ff-reldiff-le --ff-reldiff-gt"
 
     # Options requiring an argument or precluding other options
     case $prev in
@@ -206,7 +206,7 @@ _tsv_select()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-fields --version --header --fields --exclude --rest --delimiter"
+    opts="--help --help-verbose --help-fields --version --header --fields --exclude --rest --delimiter --line-buffered"
 
     # Options requiring an argument or precluding other options
     # Options with a restricted set of arguments (ie. -r|--rest) have their own case clause.

--- a/csv2tsv/src/tsv_utils/csv2tsv.d
+++ b/csv2tsv/src/tsv_utils/csv2tsv.d
@@ -187,7 +187,7 @@ else
         catch (Exception exc)
         {
             writeln();
-            stdin.flush();
+            stdout.flush();
             stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
             return 1;
         }

--- a/csv2tsv/tests/gold/error_tests_1.txt
+++ b/csv2tsv/tests/gold/error_tests_1.txt
@@ -2,8 +2,8 @@ Error test set 1
 ----------------
 
 ====[csv2tsv nosuchfile.txt]====
-Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or directory)
 
+Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or directory)
 
 ====[csv2tsv --nosuchparam input1.txt]====
 [csv2tsv] Error processing command line arguments: Unrecognized option --nosuchparam
@@ -60,14 +60,14 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 [csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|tab-replacement).
 
 ====[csv2tsv invalid1.csv]====
-Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid1.csv, Line: 3
 field1	field2	field3
 100	ab c	de f
 200	gh i,
+Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid1.csv, Line: 3
 
 ====[csv2tsv invalid2.csv]====
-Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid2.csv, Line: 4
 field1	field2	field3
 100	ab c	de f
 200	gh i	jk l
 300	mn o	pq r 
+Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid2.csv, Line: 4

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -1013,8 +1013,9 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
     /* BufferedOutputRange improves performance on narrow files with high percentages of
      * writes.
      */
-    immutable size_t flushSize =
-        cmdopt.lineBuffered ? 1 : BufferedOutputRangeDefaults.reserveSize;
+    immutable size_t flushSize = cmdopt.lineBuffered ?
+        BufferedOutputRangeDefaults.lineBufferedFlushSize :
+        BufferedOutputRangeDefaults.flushSize;
     auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, flushSize);
     size_t matchedLines = 0;
 
@@ -1086,6 +1087,7 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
             }
             catch (Exception e)
             {
+                bufferedOutput.flush;
                 throw new Exception(
                     format("Could not process line or field: %s\n  File: %s Line: %s%s",
                            e.msg, inputStream.name, lineNum,

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -20,8 +20,8 @@ Error test set 1
    Expected: '--eq <field>:<val>' or '--eq <field-list>:<val> where <val> is a number.
 
 ====[tsv-filter --header --le 1000:10 input1.tsv]====
-Error [tsv-filter]: Not enough fields in line. File: input1.tsv, Line: 2
 F1	F2	F3	F4
+Error [tsv-filter]: Not enough fields in line. File: input1.tsv, Line: 2
 
 ====[tsv-filter --header --le 1: input1.tsv]====
 [tsv-filter] Error processing command line arguments: Invalid option: [--le 1:]. No value after field list.
@@ -296,12 +296,12 @@ Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines
   File: input1_dos.tsv, Line: 1
 
 ====[tsv-filter --header --eq 2:1 input1.tsv input1_dos.tsv]====
-Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
-  File: input1_dos.tsv, Line: 1
 F1	F2	F3	F4
 1	1.0	a	A
-
-====[tsv-filter --str-eq 4:ABC input1.tsv input1_dos.tsv]====
 Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
   File: input1_dos.tsv, Line: 1
+
+====[tsv-filter --str-eq 4:ABC input1.tsv input1_dos.tsv]====
 10	10.1	abc	ABC
+Error [tsv-filter]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1

--- a/tsv-join/tests/gold/error_tests_1.txt
+++ b/tsv-join/tests/gold/error_tests_1.txt
@@ -52,8 +52,8 @@ Error [tsv-join]: Not enough fields in line. File: input1.tsv, Line: 1
 Error [tsv-join]: Not enough fields in line. File: input1.tsv, Line: 1
 
 ====[tsv-join --header -f input1.tsv -k 4 -d 6 input2.tsv]====
-Error [tsv-join]: Not enough fields in line. File: input2.tsv, Line: 2
 f1	f2	f3	f4	f5
+Error [tsv-join]: Not enough fields in line. File: input2.tsv, Line: 2
 
 ====[tsv-join -f input1_noheader.tsv -k 6 input2_noheader.tsv]====
 Error [tsv-join]: Not enough fields in line. File: input1_noheader.tsv, Line: 1

--- a/tsv-sample/tests/gold/error_tests_1.txt
+++ b/tsv-sample/tests/gold/error_tests_1.txt
@@ -11,9 +11,9 @@ Error test set 1
 [tsv-sample] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[tsv-sample -H -w 11 input3x25.tsv]====
+line	title	weight
 Error [tsv-sample]: Could not process line: Not enough fields on line. Number required: 11; Number found: 3
   File: input3x25.tsv Line: 2
-line	title	weight
 
 ====[tsv-sample -H -w 0 input3x25.tsv]====
 [tsv-sample] Error processing command line arguments: [--w|weight-field] Field numbers must be greater than zero: '0'.
@@ -70,8 +70,8 @@ line	title	weight
 Error [tsv-sample]: Not enough fields in line. File: input4x50.tsv, Line: 1
 
 ====[tsv-sample -H -p 0.5 -k 5 input4x50.tsv input4x15.tsv]====
-Error [tsv-sample]: Not enough fields in line. File: input4x50.tsv, Line: 2
 c-1	c-2	c-3	c-4
+Error [tsv-sample]: Not enough fields in line. File: input4x50.tsv, Line: 2
 
 ====[tsv-sample -H -p 0.5 -k no_such_field input4x50.tsv input4x15.tsv]====
 [tsv-sample] Error processing command line arguments: [--k|key-fields] Field not found in file header: 'no_such_field'.

--- a/tsv-sample/tests/gold/error_tests_2.txt
+++ b/tsv-sample/tests/gold/error_tests_2.txt
@@ -2,9 +2,9 @@ Error test set 2
 ----------------
 
 ====[tsv-sample -H -w 2 input3x25.tsv]====
+line	title	weight
 Error [tsv-sample]: Could not process line: no digits seen for input "Белые ночи".
   File: input3x25.tsv Line: 2
-line	title	weight
 
 ====[tsv-sample -w 3 input3x25.tsv]====
 Error [tsv-sample]: Could not process line: no digits seen for input "weight".

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -20,14 +20,14 @@ Error test set 1
 [tsv-select] Error processing command line arguments: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-select -f 1 input_3x1.tsv nosuchfile.tsv]====
-Error [tsv-select]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 f1
 3x1-r1
+Error [tsv-select]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-select -f 1,4 input_3plus_fields.tsv]====
-Error [tsv-select]: Not enough fields in line. File: input_3plus_fields.tsv,  Line: 3
 1	101
 2	5734
+Error [tsv-select]: Not enough fields in line. File: input_3plus_fields.tsv,  Line: 3
 
 ====[tsv-select -d ß -f 1 input1.tsv]====
 [tsv-select] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
@@ -135,8 +135,6 @@ Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines
   File: input1_dos.tsv, Line: 1
 
 ====[tsv-select -f 1 input1.tsv input1_dos.tsv]====
-Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
-  File: input1_dos.tsv, Line: 1
 f1
 1
 
@@ -146,10 +144,10 @@ f1
 6
 7
 8
+Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1
 
 ====[tsv-select -H -f 1 input1.tsv input1_dos.tsv]====
-Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
-  File: input1_dos.tsv, Line: 1
 f1
 1
 
@@ -159,3 +157,5 @@ f1
 6
 7
 8
+Error [tsv-select]: Windows/DOS line ending found. Convert file to Unix newlines before processing (e.g. 'dos2unix').
+  File: input1_dos.tsv, Line: 1

--- a/tsv-uniq/tests/gold/error_tests_1.txt
+++ b/tsv-uniq/tests/gold/error_tests_1.txt
@@ -74,9 +74,9 @@ Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 1
 [tsv-uniq] Error processing command line arguments: --number-header requires --z|number
 
 ====[tsv-uniq -H -f 2,30 input1.tsv]====
-Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 2
 f1	f2	f3	f4	f5
+Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 2
 
 ====[tsv-uniq -H -f 2-30 input1.tsv]====
-Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 2
 f1	f2	f3	f4	f5
+Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 2


### PR DESCRIPTION
This PR makes some updates to the line-buffered support added in PR #333. That PR added some general support in `BufferedByLine` and `BufferedOutoutRange` and added a `--line-buffered` option to `tsv-filter`.

This PR extends this by adding support to `ByLineSourceRange`. This was needed to add support to `tsv-select`.

Some changes were made to the flushing logic in `BufferedOutputRange`. This causes a flush to the output stream (eg. stdout) more often, but improves operation in unix pipelines (both header line flushing and line-buffered support). It also improves error messages. It was a small performance hit to `csv2tsv`, but the overall effect is worthwhile.