### PR TITLE
General --line-buffered support

### DIFF
--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -286,7 +286,7 @@ _tsv_uniq()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-fields --version --header --fields --ignore-case --repeated --at-least --max --number --equiv --equiv-header --equiv-start --delimiter"
+    opts="--help --help-verbose --help-fields --version --header --fields --ignore-case --repeated --at-least --max --number --equiv --equiv-header --equiv-start --delimiter --line-buffered"
 
     # Options requiring an argument or precluding other options
     case $prev in

--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -181,7 +181,7 @@ _tsv_sample()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-fields --version --header --num --prob --weight-field --key-fields --replace --inorder --print-random --gen-random-inorder --compatibility-mode --static-seed --seed-value --delimiter --prefer-skip-sampling --prefer-algorithm-r"
+    opts="--help --help-verbose --help-fields --version --header --num --prob --weight-field --key-fields --replace --inorder --print-random --gen-random-inorder --compatibility-mode --static-seed --seed-value --delimiter --line-buffered --prefer-skip-sampling --prefer-algorithm-r"
 
     # Options requiring an argument or precluding other options
     case $prev in

--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -73,7 +73,7 @@ _tsv_append()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --version --header --track-source --source-header --file --delimiter"
+    opts="--help --help-verbose --version --header --track-source --source-header --file --delimiter --line-buffered"
 
     # Options requiring an argument or precluding other options
     case $prev in

--- a/bash_completion/tsv-utils
+++ b/bash_completion/tsv-utils
@@ -124,7 +124,7 @@ _tsv_join()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--help --help-verbose --help-fields --version --filter-file --key-fields --data-fields --append-fields --header --prefix --write-all --exclude --delimiter --allow-duplicate-keys"
+    opts="--help --help-verbose --help-fields --version --filter-file --key-fields --data-fields --append-fields --header --prefix --write-all --exclude --delimiter --allow-duplicate-keys --line-buffered"
 
     # Options requiring an argument or precluding other options
     # Options requiring a filename argument are handled in their own case match, ie. -f|--filter-file

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -851,9 +851,16 @@ enum bool isFlushableOutputRange(R, E=char) = isOutputRange!(R, E)
     static assert(isFlushableOutputRange!(BufferedOutputRange!(Appender!(char[])), char));
 }
 
-/** Flag accepted by bufferedByLine to use line-buffering.
+/** Flag accepted by input buffering ranges to indicate if data should be read using
+line buffering. Input is read as soon as lines are available when line buffered mode
+is used.
  */
 alias LineBuffered = Flag!"lineBuffered";
+
+/** Flag accepted by input buffering ranges to indicate if the header line should be
+read when opening a file.
+*/
+alias ReadHeader = Flag!"readHeader";
 
 /**
 bufferedByLine is a performance enhancement over std.stdio.File.byLine. It works by
@@ -865,15 +872,19 @@ newline. This is similar to stdio.File.byLine, except specified as a template pa
 rather than a runtime parameter.
 
 Reading in blocks does mean that input is not read until a full buffer is available or
-end-of-file is reached. For this reason, bufferedByLine is not appropriate for
-interactive input. Note though that line-buffering can be achieved by specifying via
-the lineBuffered parameter. In this mode bufferedByLine reads each line as soon as it
-is available.
+end-of-file is reached. Reading each line as it is available can be enabled by setting
+the lineBuffered parameter to Yes.lineBuffered. In this case bufferedByLine behaves
+like stdio.File.byLine.
+
+As a separate option, the first line of the file can be read as soon as it is available,
+without waiting for a complete buffer. This is useful for reading the header line before
+the rest of the data is available. Set the readHeader parameter to Yes.readHeader to get
+this behavior.
 */
 
 auto bufferedByLine(KeepTerminator keepTerminator = No.keepTerminator, Char = char,
                     ubyte terminator = '\n', size_t readSize = 1024 * 128, size_t growSize = 1024 * 16)
-    (File file, LineBuffered lineBuffered = No.lineBuffered)
+(File file, LineBuffered lineBuffered = No.lineBuffered, ReadHeader readHeader = No.readHeader)
 if (is(Char == char) || is(Char == ubyte))
 {
     static assert(0 < growSize && growSize <= readSize);
@@ -893,11 +904,17 @@ if (is(Char == char) || is(Char == ubyte))
         private size_t _lineEnd = 0;
         private size_t _dataEnd = 0;
 
-        this (File f, LineBuffered lineBuffered)
+        this (File f, LineBuffered lineBuffered, ReadHeader readHeader)
         {
             _file = f;
             _lineBuffered = lineBuffered;
             _buffer = new ubyte[readSize + growSize];
+
+            if (!_file.eof)
+            {
+                if (readHeader) popFrontLineBuffered();
+                else popFront();
+            }
         }
 
         bool empty() const pure
@@ -921,7 +938,6 @@ if (is(Char == char) || is(Char == ubyte))
             }
         }
 
-        /* Note: Call popFront at initialization to do the initial read. */
         void popFront()
         {
             assert(!empty, "Attempt to popFront an empty bufferedByLine.");
@@ -930,8 +946,15 @@ if (is(Char == char) || is(Char == ubyte))
             else popFrontLineBuffered();
         }
 
+        /* Discards the current line and reads the next line with File.readln.
+         * Intended for use when reading in line-buffered mode. However, it is
+         * also used to read in the header line when in full-buffered mode.
+         */
         private void popFrontLineBuffered()
         {
+            assert(_lineEnd == _dataEnd);
+            assert(!empty, "Attempt to popFront (LineBuffered) an empty bufferedByLine.");
+
             char[] line = cast(char[]) _buffer;
             _lineStart = 0;
             _lineEnd = _dataEnd = _file.readln(line);
@@ -944,6 +967,8 @@ if (is(Char == char) || is(Char == ubyte))
         private void popFrontFullBuffered()
         {
             import std.algorithm: copy, find;
+
+            assert(!empty, "Attempt to popFront (Full Buffered) an empty bufferedByLine.");
 
             /* Pop the current line. */
             _lineStart = _lineEnd;
@@ -1002,9 +1027,7 @@ if (is(Char == char) || is(Char == ubyte))
 
     assert(file.isOpen, "bufferedByLine passed a closed file.");
 
-    auto r = new BufferedByLineImpl(file, lineBuffered);
-    if (!r.empty) r.popFront;
-    return r;
+    return new BufferedByLineImpl(file, lineBuffered, readHeader);
 }
 
 // BufferedByLine.
@@ -1039,287 +1062,231 @@ unittest
     string file1a = buildPath(testDir, "file1a.txt");
     string file1b = buildPath(testDir, "file1b.txt");
     string file1c = buildPath(testDir, "file1c.txt");
+    string file1d = buildPath(testDir, "file1d.txt");
+    string file1e = buildPath(testDir, "file1e.txt");
+
+    foreach (f; [file1a, file1b, file1c, file1d, file1e])
     {
-        auto f1aFH = file1a.File("wb");
-        f1aFH.write(data1.data);
-        f1aFH.close;
-
-        auto f1bFH = file1b.File("wb");
-        f1bFH.write(data1.data);
-        f1bFH.close;
-
-        auto f1cFH = file1c.File("wb");
-        f1cFH.write(data1.data);
-        f1cFH.close;
+        auto fh = f.File("wb");
+        fh.write(data1.data);
+        fh.close;
     }
 
-    /* Default template parameters. */
-    {
+    /* Default buffer sizes */
+    static foreach (keepTerm; [No.keepTerminator, Yes.keepTerminator])
+    {{
         auto f1aFH = file1a.File();
         auto f1bFH = file1b.File();
         auto f1cFH = file1c.File();
-        auto f1aIn = f1aFH.byLine(No.keepTerminator);
-        auto f1bIn = f1bFH.bufferedByLine!(No.keepTerminator);
-        auto f1cIn = f1cFH.bufferedByLine!(No.keepTerminator)(Yes.lineBuffered);
+        auto f1dFH = file1d.File();
+        auto f1eFH = file1e.File();
 
-        foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
+        auto f1aIn = f1aFH.byLine(keepTerm);
+        auto f1bIn = f1bFH.bufferedByLine!(keepTerm);
+        auto f1cIn = f1cFH.bufferedByLine!(keepTerm)(Yes.lineBuffered);
+        auto f1dIn = f1dFH.bufferedByLine!(keepTerm)(No.lineBuffered, Yes.readHeader);
+        auto f1eIn = f1eFH.bufferedByLine!(keepTerm)(Yes.lineBuffered, Yes.readHeader);
+
+        foreach (a, b, c, d, e; lockstep(f1aIn, f1bIn, f1cIn, f1dIn, f1eIn, StoppingPolicy.requireSameLength))
         {
             assert(a == b);
             assert(a == c);
+            assert(a == d);
+            assert(a == e);
         }
 
         f1aFH.close;
         f1bFH.close;
         f1cFH.close;
-    }
-    {
-        auto f1aFH = file1a.File();
-        auto f1bFH = file1b.File();
-        auto f1cFH = file1c.File();
-        auto f1aIn = f1aFH.byLine(Yes.keepTerminator);
-        auto f1bIn = f1bFH.bufferedByLine!(Yes.keepTerminator)(No.lineBuffered);
-        auto f1cIn = f1cFH.bufferedByLine!(Yes.keepTerminator)(Yes.lineBuffered);
-
-        foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
-        {
-            assert(a == b);
-            assert(a == c);
-        }
-
-        f1aFH.close;
-        f1bFH.close;
-        f1cFH.close;
-    }
+        f1dFH.close;
+        f1eFH.close;
+    }}
 
     /* Smaller read size. This will trigger buffer growth. */
-    {
+    static foreach (keepTerm; [No.keepTerminator, Yes.keepTerminator])
+    {{
         auto f1aFH = file1a.File();
         auto f1bFH = file1b.File();
         auto f1cFH = file1c.File();
-        auto f1aIn = f1aFH.byLine(No.keepTerminator);
-        auto f1bIn = f1bFH.bufferedByLine!(No.keepTerminator, char, '\n', 512, 256);
-        auto f1cIn = f1cFH.bufferedByLine!(No.keepTerminator, char, '\n', 512, 256)(Yes.lineBuffered);
+        auto f1dFH = file1d.File();
+        auto f1eFH = file1e.File();
 
-        foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
+        auto f1aIn = f1aFH.byLine(keepTerm);
+        auto f1bIn = f1bFH.bufferedByLine!(keepTerm, char, '\n', 512, 256);
+        auto f1cIn = f1cFH.bufferedByLine!(keepTerm, char, '\n', 512, 256)(Yes.lineBuffered);
+        auto f1dIn = f1dFH.bufferedByLine!(keepTerm, char, '\n', 512, 256)(No.lineBuffered, Yes.readHeader);
+        auto f1eIn = f1eFH.bufferedByLine!(keepTerm, char, '\n', 512, 256)(Yes.lineBuffered, Yes.readHeader);
+
+        foreach (a, b, c, d, e; lockstep(f1aIn, f1bIn, f1cIn, f1dIn, f1eIn, StoppingPolicy.requireSameLength))
         {
             assert(a == b);
             assert(a == c);
+            assert(a == d);
+            assert(a == e);
         }
 
         f1aFH.close;
         f1bFH.close;
         f1cFH.close;
-    }
+        f1dFH.close;
+        f1eFH.close;
+    }}
 
-    /* Exercise boundary cases in buffer growth.
-     * Note: static-foreach requires DMD 2.076 / LDC 1.6
-     */
-    static foreach (readSize; [1, 2, 4])
+    /* Exercise boundary cases in buffer growth. */
+    static foreach (keepTerm; [No.keepTerminator, Yes.keepTerminator])
     {
-        static foreach (growSize; 1 .. readSize + 1)
-        {{
-            auto f1aFH = file1a.File();
-            auto f1bFH = file1b.File();
-            auto f1cFH = file1c.File();
-            auto f1aIn = f1aFH.byLine(No.keepTerminator);
-            auto f1bIn = f1bFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f1cIn = f1cFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+        static foreach (readSize; [1, 2, 4])
+        {
+            static foreach (growSize; 1 .. readSize + 1)
+            {{
+                auto f1aFH = file1a.File();
+                auto f1bFH = file1b.File();
+                auto f1cFH = file1c.File();
+                auto f1dFH = file1d.File();
+                auto f1eFH = file1e.File();
 
-            foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
+                auto f1aIn = f1aFH.byLine(keepTerm);
+                auto f1bIn = f1bFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize);
+                auto f1cIn = f1cFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f1dIn = f1dFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered, Yes.readHeader);
+                auto f1eIn = f1eFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered, Yes.readHeader);
 
-            f1aFH.close;
-            f1bFH.close;
-            f1cFH.close;
-        }}
-        static foreach (growSize; 1 .. readSize + 1)
-        {{
-            auto f1aFH = file1a.File();
-            auto f1bFH = file1b.File();
-            auto f1cFH = file1c.File();
-            auto f1aIn = f1aFH.byLine(Yes.keepTerminator);
-            auto f1bIn = f1bFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize);
-            auto f1cIn = f1cFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                foreach (a, b, c, d, e; lockstep(f1aIn, f1bIn, f1cIn, f1dIn, f1eIn, StoppingPolicy.requireSameLength))
+                {
+                    assert(a == b);
+                    assert(a == c);
+                    assert(a == d);
+                    assert(a == e);
+                }
 
-            foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
-
-            f1aFH.close;
-            f1bFH.close;
-            f1cFH.close;
-        }}
+                f1aFH.close;
+                f1bFH.close;
+                f1cFH.close;
+                f1dFH.close;
+                f1eFH.close;
+            }}
+        }
     }
-
 
     /* Files that do not end in a newline. */
 
     string file2a = buildPath(testDir, "file2a.txt");
     string file2b = buildPath(testDir, "file2b.txt");
     string file2c = buildPath(testDir, "file2c.txt");
+    string file2d = buildPath(testDir, "file2d.txt");
+    string file2e = buildPath(testDir, "file2e.txt");
     string file3a = buildPath(testDir, "file3a.txt");
     string file3b = buildPath(testDir, "file3b.txt");
     string file3c = buildPath(testDir, "file3c.txt");
+    string file3d = buildPath(testDir, "file3d.txt");
+    string file3e = buildPath(testDir, "file3e.txt");
 
+    foreach (f; [file1a, file1b, file1c, file1d, file1e])
     {
-        auto f1aFH = file1a.File("wb");
-        f1aFH.write("a");
-        f1aFH.close;
-    }
-    {
-        auto f1bFH = file1b.File("wb");
-        f1bFH.write("a");
-        f1bFH.close;
-    }
-    {
-        auto f1cFH = file1c.File("wb");
-        f1cFH.write("a");
-        f1cFH.close;
-    }
-    {
-        auto f2aFH = file2a.File("wb");
-        f2aFH.write("ab");
-        f2aFH.close;
-    }
-    {
-        auto f2bFH = file2b.File("wb");
-        f2bFH.write("ab");
-        f2bFH.close;
-    }
-    {
-        auto f2cFH = file2c.File("wb");
-        f2cFH.write("ab");
-        f2cFH.close;
-    }
-    {
-        auto f3aFH = file3a.File("wb");
-        f3aFH.write("abc");
-        f3aFH.close;
-    }
-    {
-        auto f3bFH = file3b.File("wb");
-        f3bFH.write("abc");
-        f3bFH.close;
-    }
-    {
-        auto f3cFH = file3c.File("wb");
-        f3cFH.write("abc");
-        f3cFH.close;
+        auto fh = f.File("wb");
+        fh.write("a");
+        fh.close;
     }
 
-    static foreach (readSize; [1, 2, 4])
+    foreach (f; [file2a, file2b, file2c, file2d, file2e])
     {
-        static foreach (growSize; 1 .. readSize + 1)
-        {{
-            auto f1aFH = file1a.File();
-            auto f1bFH = file1b.File();
-            auto f1cFH = file1c.File();
-            auto f1aIn = f1aFH.byLine(No.keepTerminator);
-            auto f1bIn = f1bFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f1cIn = f1cFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+        auto fh = f.File("wb");
+        fh.write("ab");
+        fh.close;
+    }
 
-            foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
+    foreach (f; [file3a, file3b, file3c, file3d, file3e])
+    {
+        auto fh = f.File("wb");
+        fh.write("abc");
+        fh.close;
+    }
 
-            f1aFH.close;
-            f1bFH.close;
-            f1cFH.close;
+    static foreach (keepTerm; [No.keepTerminator, Yes.keepTerminator])
+    {
+        static foreach (readSize; [1, 2, 4])
+        {
+            static foreach (growSize; 1 .. readSize + 1)
+            {{
+                auto f1aFH = file1a.File();
+                auto f1bFH = file1b.File();
+                auto f1cFH = file1c.File();
+                auto f1dFH = file1d.File();
+                auto f1eFH = file1e.File();
 
-            auto f2aFH = file2a.File();
-            auto f2bFH = file2b.File();
-            auto f2cFH = file2c.File();
-            auto f2aIn = f2aFH.byLine(No.keepTerminator);
-            auto f2bIn = f2bFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f2cIn = f2cFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f1aIn = f1aFH.byLine(keepTerm);
+                auto f1bIn = f1bFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered);
+                auto f1cIn = f1cFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f1dIn = f1dFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered, Yes.readHeader);
+                auto f1eIn = f1eFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered, Yes.readHeader);
 
-            foreach (a, b, c; lockstep(f2aIn, f2bIn, f2cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
+                foreach (a, b, c, d, e; lockstep(f1aIn, f1bIn, f1cIn, f1dIn, f1eIn, StoppingPolicy.requireSameLength))
+                {
+                    assert(a == b);
+                    assert(a == c);
+                    assert(a == d);
+                    assert(a == e);
+                }
 
-            f2aFH.close;
-            f2bFH.close;
-            f2cFH.close;
+                f1aFH.close;
+                f1bFH.close;
+                f1cFH.close;
+                f1dFH.close;
+                f1eFH.close;
 
-            auto f3aFH = file3a.File();
-            auto f3bFH = file3b.File();
-            auto f3cFH = file3c.File();
-            auto f3aIn = f3aFH.byLine(No.keepTerminator);
-            auto f3bIn = f3bFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f3cIn = f3cFH.bufferedByLine!(No.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f2aFH = file2a.File();
+                auto f2bFH = file2b.File();
+                auto f2cFH = file2c.File();
+                auto f2dFH = file2d.File();
+                auto f2eFH = file2e.File();
 
-            foreach (a, b, c; lockstep(f3aIn, f3bIn, f3cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
+                auto f2aIn = f2aFH.byLine(keepTerm);
+                auto f2bIn = f2bFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered);
+                auto f2cIn = f2cFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f2dIn = f2dFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered, Yes.readHeader);
+                auto f2eIn = f2eFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered, Yes.readHeader);
 
-            f3aFH.close;
-            f3bFH.close;
-            f3cFH.close;
-        }}
-        static foreach (growSize; 1 .. readSize + 1)
-        {{
-            auto f1aFH = file1a.File();
-            auto f1bFH = file1b.File();
-            auto f1cFH = file1c.File();
-            auto f1aIn = f1aFH.byLine(Yes.keepTerminator);
-            auto f1bIn = f1bFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f1cIn = f1cFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                foreach (a, b, c, d, e; lockstep(f2aIn, f2bIn, f2cIn, f2dIn, f2eIn, StoppingPolicy.requireSameLength))
+                {
+                    assert(a == b);
+                    assert(a == c);
+                    assert(a == d);
+                    assert(a == e);
+                }
 
-            foreach (a, b, c; lockstep(f1aIn, f1bIn, f1cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
+                f2aFH.close;
+                f2bFH.close;
+                f2cFH.close;
+                f2dFH.close;
+                f2eFH.close;
 
-            f1aFH.close;
-            f1bFH.close;
-            f1cFH.close;
+                auto f3aFH = file3a.File();
+                auto f3bFH = file3b.File();
+                auto f3cFH = file3c.File();
+                auto f3dFH = file3d.File();
+                auto f3eFH = file3e.File();
 
-            auto f2aFH = file2a.File();
-            auto f2bFH = file2b.File();
-            auto f2cFH = file2c.File();
-            auto f2aIn = f2aFH.byLine(Yes.keepTerminator);
-            auto f2bIn = f2bFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f2cIn = f2cFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f3aIn = f3aFH.byLine(keepTerm);
+                auto f3bIn = f3bFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered);
+                auto f3cIn = f3cFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered);
+                auto f3dIn = f3dFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(No.lineBuffered, Yes.readHeader);
+                auto f3eIn = f3eFH.bufferedByLine!(keepTerm, char, '\n', readSize, growSize)(Yes.lineBuffered, Yes.readHeader);
 
-            foreach (a, b, c; lockstep(f2aIn, f2bIn, f2cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
+                foreach (a, b, c, d, e; lockstep(f3aIn, f3bIn, f3cIn, f3dIn, f3eIn, StoppingPolicy.requireSameLength))
+                {
+                    assert(a == b);
+                    assert(a == c);
+                    assert(a == d);
+                    assert(a == e);
+                }
 
-            f2aFH.close;
-            f2bFH.close;
-            f2cFH.close;
-
-            auto f3aFH = file3a.File();
-            auto f3bFH = file3b.File();
-            auto f3cFH = file3c.File();
-            auto f3aIn = f3aFH.byLine(Yes.keepTerminator);
-            auto f3bIn = f3bFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(No.lineBuffered);
-            auto f3cIn = f3cFH.bufferedByLine!(Yes.keepTerminator, char, '\n', readSize, growSize)(Yes.lineBuffered);
-
-            foreach (a, b, c; lockstep(f3aIn, f3bIn, f3cIn, StoppingPolicy.requireSameLength))
-            {
-                assert(a == b);
-                assert(a == c);
-            }
-
-            f3aFH.close;
-            f3bFH.close;
-            f3cFH.close;
-        }}
+                f3aFH.close;
+                f3bFH.close;
+                f3cFH.close;
+                f3dFH.close;
+                f3eFH.close;
+            }}
+        }
     }
 }
 
@@ -1670,11 +1637,6 @@ void throwIfWindowsNewline
     }
 }
 
-/** Flag used by InputSourceRange to determine if the header line should be when
-opening a file.
-*/
-alias ReadHeader = Flag!"readHeader";
-
 /**
 inputSourceRange is a helper function for creating new InputSourceRange objects.
 */
@@ -1709,7 +1671,7 @@ types of input sources will be added in the future.
 final class InputSourceRange
 {
     private string[] _filepaths;
-    private ReadHeader _readHeader;
+    private immutable ReadHeader _readHeader;
     private InputSource _front;
 
     this(string[] filepaths, ReadHeader readHeader)
@@ -2054,10 +2016,12 @@ byLineSourceRange is a helper function for creating new byLineSourceRange object
 */
 auto byLineSourceRange(
     KeepTerminator keepTerminator = No.keepTerminator, Char = char, ubyte terminator = '\n')
-(string[] filepaths, LineBuffered lineBuffered = No.lineBuffered)
+(string[] filepaths, LineBuffered lineBuffered = No.lineBuffered,
+ ReadHeader readHeader = No.readHeader)
 if (is(Char == char) || is(Char == ubyte))
 {
-    return new ByLineSourceRange!(keepTerminator, Char, terminator)(filepaths, lineBuffered);
+    return new ByLineSourceRange!(keepTerminator, Char, terminator)
+        (filepaths, lineBuffered, readHeader);
 }
 
 /**
@@ -2081,6 +2045,11 @@ Access to the first line of the first file is available after creating the
 ByLineSourceRange instance. The first file is opened and a bufferedByLine created.
 The first line of the first file is via byLine.front (after checking !byLine.empty).
 
+Buffering is handled by bufferedByLine. Full buffering is used by default, this can be
+changed to line buffering by Yes.lineBuffered. When using full buffering, the header
+line (first line) of the first file can read as soon as available using Yes.readHeader.
+This is only done for the first file, as that is when immediate processing is useful.
+
 Both ByLineSourceRange and ByLineSource are reference objects. This keeps their use
 limited to a single iteration over the set of files. The files can be iterated again
 by creating a new InputSourceRange against the same filepaths.
@@ -2098,7 +2067,8 @@ if (is(Char == char) || is(Char == ubyte))
     private immutable LineBuffered _lineBuffered;
     private ByLineSourceType _front;
 
-    this(string[] filepaths, LineBuffered lineBuffered = No.lineBuffered)
+    this(string[] filepaths, LineBuffered lineBuffered = No.lineBuffered,
+         ReadHeader readHeader = No.readHeader)
     {
         _filepaths = filepaths.dup;
         _lineBuffered = lineBuffered;
@@ -2106,7 +2076,7 @@ if (is(Char == char) || is(Char == ubyte))
 
         if (!_filepaths.empty)
         {
-            _front = new ByLineSourceType(_filepaths.front, _lineBuffered);
+            _front = new ByLineSourceType(_filepaths.front, _lineBuffered, readHeader);
             _front.open;
             _filepaths.popFront;
         }
@@ -2183,16 +2153,19 @@ if (is(Char == char) || is(Char == ubyte))
 
     private immutable string _filepath;
     private immutable LineBuffered _lineBuffered;
+    private immutable ReadHeader _readHeader;
     private immutable bool _isStdin;
     private bool _isOpen;
     private bool _hasBeenOpened;
     private File _file;
     private ByLineType _byLineRange;
 
-    private this(string filepath, LineBuffered lineBuffered = No.lineBuffered) pure nothrow @safe
+    private this(string filepath, LineBuffered lineBuffered = No.lineBuffered,
+                ReadHeader readHeader = No.readHeader) pure nothrow @safe
     {
         _filepath = filepath;
         _lineBuffered = lineBuffered;
+        _readHeader = readHeader;
         _isStdin = filepath == "-";
         _isOpen = false;
         _hasBeenOpened = false;
@@ -2251,7 +2224,7 @@ if (is(Char == char) || is(Char == ubyte))
         assert(!_hasBeenOpened);
 
         _file = isStdin ? stdin : _filepath.File("rb");
-        _byLineRange = newByLineFn(_file, _lineBuffered);
+        _byLineRange = newByLineFn(_file, _lineBuffered, _readHeader);
         _isOpen = true;
         _hasBeenOpened = true;
     }
@@ -2312,110 +2285,57 @@ unittest
 
     auto buffer = new char[1024];    // Must be large enough to hold the test files.
 
-    /* Tests without standard input. Don't want to count on state of standard
+    /* Test without standard input. Don't want to count on state of standard
      * input or modifying it when doing unit tests, so avoid reading from it.
      */
 
-    auto readSourcesNoTerminator = appender!(ByLineSource!(No.keepTerminator)[]);
-    auto readSourcesYesTerminator = appender!(ByLineSource!(Yes.keepTerminator)[]);
-
-    foreach(numFiles; 1 .. inputFiles.length + 1)
+    static foreach (keepTerm; [No.keepTerminator, Yes.keepTerminator])
     {
-        /* Using No.keepTerminator. */
-        readSourcesNoTerminator.clear;
-        auto inputSourcesNoTerminator = byLineSourceRange!(No.keepTerminator)(inputFiles[0 .. numFiles]);
-        assert(inputSourcesNoTerminator.length == numFiles);
-
-        foreach(fileNum, source; inputSourcesNoTerminator.enumerate)
+        foreach (lineBuf; [No.lineBuffered, Yes.lineBuffered])
         {
-            readSourcesNoTerminator.put(source);
-            assert(source.isOpen);
-            assert(source._file.isOpen);
-            assert(readSourcesNoTerminator.data[0 .. fileNum].all!(s => !s.isOpen));
-            assert(readSourcesNoTerminator.data[fileNum].isOpen);
-
-            auto headerNoTerminatorLength = fileHeaders[fileNum].length;
-            if (headerNoTerminatorLength > 0) --headerNoTerminatorLength;
-
-            assert(source.byLine.empty ||
-                   source.byLine.front == fileHeaders[fileNum][0 .. headerNoTerminatorLength]);
-
-            assert(source.name == inputFiles[fileNum]);
-            assert(!source.isStdin);
-
-            auto readFileData = appender!(char[]);
-            foreach(line; source.byLine)
+            foreach (readHdr; [No.readHeader, Yes.readHeader])
             {
-                readFileData.put(line);
-                readFileData.put('\n');
+                foreach(numFiles; 1 .. inputFiles.length + 1)
+                {
+                    auto readSources = appender!(ByLineSource!(keepTerm)[]);
+                    auto inputSources = byLineSourceRange!(keepTerm)(inputFiles[0 .. numFiles], lineBuf, readHdr);
+                    assert(inputSources.length == numFiles);
+
+                    foreach(fileNum, source; inputSources.enumerate)
+                    {
+                        readSources.put(source);
+                        assert(source.isOpen);
+                        assert(source._file.isOpen);
+                        assert(readSources.data[0 .. fileNum].all!(s => !s.isOpen));
+                        assert(readSources.data[fileNum].isOpen);
+
+                        auto headerLength = fileHeaders[fileNum].length;
+                        static if (!keepTerm)
+                        {
+                            if (headerLength > 0) --headerLength;
+                        }
+
+                        assert(source.byLine.empty ||
+                               source.byLine.front == fileHeaders[fileNum][0 .. headerLength]);
+
+                        assert(source.name == inputFiles[fileNum]);
+                        assert(!source.isStdin);
+
+                        auto readFileData = appender!(char[]);
+                        foreach(line; source.byLine)
+                        {
+                            readFileData.put(line);
+                            static if (!keepTerm) readFileData.put('\n');
+                        }
+
+                        assert(readFileData.data == fileData[fileNum]);
+                    }
+
+                    /* The ByLineSourceRange is a reference range, consumed by the foreach. */
+                    assert(inputSources.empty);
+                }
             }
-
-            assert(readFileData.data == fileData[fileNum]);
         }
-
-        /* The ByLineSourceRange is a reference range, consumed by the foreach. */
-        assert(inputSourcesNoTerminator.empty);
-
-        /* Using Yes.keepTerminator. */
-        readSourcesYesTerminator.clear;
-        auto inputSourcesYesTerminator = byLineSourceRange!(Yes.keepTerminator)(inputFiles[0 .. numFiles]);
-        assert(inputSourcesYesTerminator.length == numFiles);
-
-        foreach(fileNum, source; inputSourcesYesTerminator.enumerate)
-        {
-            readSourcesYesTerminator.put(source);
-            assert(source.isOpen);
-            assert(source._file.isOpen);
-            assert(readSourcesYesTerminator.data[0 .. fileNum].all!(s => !s.isOpen));
-            assert(readSourcesYesTerminator.data[fileNum].isOpen);
-
-            assert(source.byLine.empty || source.byLine.front == fileHeaders[fileNum]);
-
-            assert(source.name == inputFiles[fileNum]);
-            assert(!source.isStdin);
-
-            auto readFileData = appender!(char[]);
-            foreach(line; source.byLine)
-            {
-                readFileData.put(line);
-            }
-
-            assert(readFileData.data == fileData[fileNum]);
-        }
-
-        /* The ByLineSourceRange is a reference range, consumed by the foreach. */
-        assert(inputSourcesYesTerminator.empty);
-
-        /* Using Yes.keepTerminator, Yes.lineBuffered. */
-        readSourcesYesTerminator.clear;
-        auto inputSourcesYesTerminatorYesLineBuffered =
-            byLineSourceRange!(Yes.keepTerminator)(inputFiles[0 .. numFiles], Yes.lineBuffered);
-        assert(inputSourcesYesTerminatorYesLineBuffered.length == numFiles);
-
-        foreach(fileNum, source; inputSourcesYesTerminatorYesLineBuffered.enumerate)
-        {
-            readSourcesYesTerminator.put(source);
-            assert(source.isOpen);
-            assert(source._file.isOpen);
-            assert(readSourcesYesTerminator.data[0 .. fileNum].all!(s => !s.isOpen));
-            assert(readSourcesYesTerminator.data[fileNum].isOpen);
-
-            assert(source.byLine.empty || source.byLine.front == fileHeaders[fileNum]);
-
-            assert(source.name == inputFiles[fileNum]);
-            assert(!source.isStdin);
-
-            auto readFileData = appender!(char[]);
-            foreach(line; source.byLine)
-            {
-                readFileData.put(line);
-            }
-
-            assert(readFileData.data == fileData[fileNum]);
-        }
-
-        /* The ByLineSourceRange is a reference range, consumed by the foreach. */
-        assert(inputSourcesYesTerminatorYesLineBuffered.empty);
     }
 
     /* Empty filelist. */

--- a/common/src/tsv_utils/common/utils.d
+++ b/common/src/tsv_utils/common/utils.d
@@ -921,6 +921,7 @@ if (is(Char == char) || is(Char == ubyte))
             }
         }
 
+        /* Note: Call popFront at initialization to do the initial read. */
         void popFront()
         {
             assert(!empty, "Attempt to popFront an empty bufferedByLine.");
@@ -940,7 +941,6 @@ if (is(Char == char) || is(Char == ubyte))
             assert(_dataEnd == line.length);
         }
 
-        /* Note: Call popFront at initialization to do the initial read. */
         private void popFrontFullBuffered()
         {
             import std.algorithm: copy, find;

--- a/number-lines/src/tsv_utils/number-lines.d
+++ b/number-lines/src/tsv_utils/number-lines.d
@@ -133,18 +133,15 @@ void numberLines(const NumberLinesOptions cmdopt, const string[] inputFiles)
 {
     import std.conv : to;
     import std.range;
-    import tsv_utils.common.utils : BufferedOutputRange, BufferedOutputRangeDefaults,
-        bufferedByLine, LineBuffered, ReadHeader;
+    import tsv_utils.common.utils : bufferedByLine, BufferedOutputRange, LineBuffered, ReadHeader;
 
-    immutable size_t flushSize = cmdopt.lineBuffered ?
-        BufferedOutputRangeDefaults.lineBufferedFlushSize :
-        BufferedOutputRangeDefaults.flushSize;
-    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, flushSize);
+    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
+    immutable ReadHeader useReadHeader = cmdopt.hasHeader ? Yes.readHeader : No.readHeader;
+
+    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, isLineBuffered);
 
     long lineNum = cmdopt.startNum;
     bool headerWritten = false;
-    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
-    immutable ReadHeader useReadHeader = cmdopt.hasHeader ? Yes.readHeader : No.readHeader;
 
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {

--- a/number-lines/src/tsv_utils/number-lines.d
+++ b/number-lines/src/tsv_utils/number-lines.d
@@ -128,17 +128,13 @@ int main(string[] cmdArgs)
  *
  * Reads lines lines from each file, outputing each with a line number prepended. The
  * header from the first file is written, the header from subsequent files is dropped.
- *
- * Note: number-lines does not immediately flush the header line like most other
- * tsv-utils tools. This is because it directly uses bufferedByLine, which does not
- * support reading the header line independently of the rest of the buffer.
  */
 void numberLines(const NumberLinesOptions cmdopt, const string[] inputFiles)
 {
     import std.conv : to;
     import std.range;
     import tsv_utils.common.utils : BufferedOutputRange, BufferedOutputRangeDefaults,
-        bufferedByLine, LineBuffered;
+        bufferedByLine, LineBuffered, ReadHeader;
 
     immutable size_t flushSize = cmdopt.lineBuffered ?
         BufferedOutputRangeDefaults.lineBufferedFlushSize :
@@ -148,13 +144,14 @@ void numberLines(const NumberLinesOptions cmdopt, const string[] inputFiles)
     long lineNum = cmdopt.startNum;
     bool headerWritten = false;
     immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
+    immutable ReadHeader useReadHeader = cmdopt.hasHeader ? Yes.readHeader : No.readHeader;
 
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
         foreach (fileLineNum, line;
                  inputStream
-                 .bufferedByLine!(KeepTerminator.no)(isLineBuffered)
+                 .bufferedByLine!(KeepTerminator.no)(isLineBuffered, useReadHeader)
                  .enumerate(1))
         {
             if (cmdopt.hasHeader && fileLineNum == 1)
@@ -165,6 +162,14 @@ void numberLines(const NumberLinesOptions cmdopt, const string[] inputFiles)
                     bufferedOutput.append(cmdopt.delim);
                     bufferedOutput.appendln(line);
                     headerWritten = true;
+
+                    /* Flush the header immediately. This helps tasks further on in a
+                     * unix pipeline detect errors quickly, without waiting for all
+                     * the data to flow through the pipeline. Note that an upstream
+                     * task may have flushed its header line, so the header may
+                     * arrive long before the main block of data.
+                     */
+                    bufferedOutput.flush;
                 }
             }
             else

--- a/tsv-append/src/tsv_utils/tsv-append.d
+++ b/tsv-append/src/tsv_utils/tsv-append.d
@@ -28,7 +28,7 @@ else
      */
     int main(string[] cmdArgs)
     {
-        import tsv_utils.common.utils : BufferedOutputRange, BufferedOutputRangeDefaults;
+        import tsv_utils.common.utils : BufferedOutputRange, LineBuffered;
 
         /* When running in DMD code coverage mode, turn on report merging. */
         version(D_Coverage) version(DigitalMars)
@@ -41,11 +41,9 @@ else
         auto r = cmdopt.processArgs(cmdArgs);
         if (!r[0]) return r[1];
 
-        immutable size_t flushSize = cmdopt.lineBuffered ?
-            BufferedOutputRangeDefaults.lineBufferedFlushSize :
-            BufferedOutputRangeDefaults.flushSize;
+        immutable LineBuffered linebuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
 
-        try tsvAppend(cmdopt, BufferedOutputRange!(typeof(stdout))(stdout, flushSize));
+        try tsvAppend(cmdopt, BufferedOutputRange!(typeof(stdout))(stdout, linebuffered));
         catch (Exception exc)
         {
             stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);

--- a/tsv-append/src/tsv_utils/tsv-append.d
+++ b/tsv-append/src/tsv_utils/tsv-append.d
@@ -220,9 +220,11 @@ struct TsvAppendOptions
 void tsvAppend(OutputRange)(TsvAppendOptions cmdopt, auto ref OutputRange outputStream)
 if (isOutputRange!(OutputRange, char))
 {
-    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange, LineBuffered;
+    import tsv_utils.common.utils : bufferedByLine, isFlushableOutputRange, LineBuffered,
+        ReadHeader;
 
     immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
+    immutable ReadHeader useReadHeader = cmdopt.hasHeader ? Yes.readHeader : No.readHeader;
 
     bool headerWritten = false;
     foreach (filename; (cmdopt.files.length > 0) ? cmdopt.files : ["-"])
@@ -231,7 +233,7 @@ if (isOutputRange!(OutputRange, char))
         auto sourceName = cmdopt.fileSourceNames[filename];
         foreach (fileLineNum, line;
                  inputStream
-                 .bufferedByLine!(KeepTerminator.no)(isLineBuffered)
+                 .bufferedByLine!(KeepTerminator.no)(isLineBuffered, useReadHeader)
                  .enumerate(1))
         {
             if (cmdopt.hasHeader && fileLineNum == 1)

--- a/tsv-append/tests/gold/basic_tests_1.txt
+++ b/tsv-append/tests/gold/basic_tests_1.txt
@@ -273,6 +273,48 @@ standard-input	abc	def	ghi
 3x5	xy1	xy2	xy3
 3x5	pqx	pqy	pqz
 
+====[tsv-append --line-buffered input3x2.tsv input3x5.tsv]====
+field1	field2	field3
+abc	def	ghi
+field1	field2	field3
+jkl	mno	pqr
+123	456	789
+xy1	xy2	xy3
+pqx	pqy	pqz
+
+====[tsv-append --line-buffered --header input3x2.tsv input3x5.tsv]====
+field1	field2	field3
+abc	def	ghi
+jkl	mno	pqr
+123	456	789
+xy1	xy2	xy3
+pqx	pqy	pqz
+
+====[tsv-append --line-buffered -t input3x2.tsv input1x3.tsv input3x5.tsv input1x4.tsv]====
+input3x2	field1	field2	field3
+input3x2	abc	def	ghi
+input1x3	field1
+input1x3	row 1
+input1x3	row 2
+input3x5	field1	field2	field3
+input3x5	jkl	mno	pqr
+input3x5	123	456	789
+input3x5	xy1	xy2	xy3
+input3x5	pqx	pqy	pqz
+input1x4	field1
+input1x4	next-empty
+input1x4	
+input1x4	last-line
+
+====[cat input3x2.tsv | tsv-append --line-buffered -- - input3x5.tsv]====
+field1	field2	field3
+abc	def	ghi
+field1	field2	field3
+jkl	mno	pqr
+123	456	789
+xy1	xy2	xy3
+pqx	pqy	pqz
+
 Help and Version printing 1
 -----------------
 

--- a/tsv-append/tests/tests.sh
+++ b/tsv-append/tests/tests.sh
@@ -2,7 +2,7 @@
 
 ## Most tsv-append testing is done as unit tests. Tests executed by this script are
 ## run against the final executable. This provides a sanity check that the
-## final executable is good. Tests are easy to run in the format, so there is
+## final executable is good. Tests are easy to run in this format, so there is
 ## overlap. However, these tests do not test edge cases as rigorously as unit tests.
 ## Instead, these tests focus on areas that are hard to test in unit tests.
 
@@ -78,6 +78,14 @@ cat input3x2.tsv | ${prog} -H input3x5.tsv -- - >> ${basic_tests_1} 2>&1
 
 echo "" >> ${basic_tests_1}; echo "====[cat input3x2.tsv | tsv-append -H -f standard-input=- -f 3x5=input3x5.tsv ]====" >> ${basic_tests_1}
 cat input3x2.tsv | ${prog} -H -f standard-input=- -f 3x5=input3x5.tsv >> ${basic_tests_1} 2>&1
+
+## line-buffered tests
+runtest ${prog} "--line-buffered input3x2.tsv input3x5.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header input3x2.tsv input3x5.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -t input3x2.tsv input1x3.tsv input3x5.tsv input1x4.tsv" ${basic_tests_1}
+
+echo "" >> ${basic_tests_1}; echo "====[cat input3x2.tsv | tsv-append --line-buffered -- - input3x5.tsv]====" >> ${basic_tests_1}
+cat input3x2.tsv | ${prog} --line-buffered -- - input3x5.tsv >> ${basic_tests_1} 2>&1
 
 ## Help and Version printing
 

--- a/tsv-filter/src/tsv_utils/tsv-filter.d
+++ b/tsv-filter/src/tsv_utils/tsv-filter.d
@@ -1003,8 +1003,8 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
     import std.algorithm : all, any, splitter;
     import std.format : formattedWrite;
     import std.range;
-    import tsv_utils.common.utils : BufferedOutputRange, BufferedOutputRangeDefaults,
-        bufferedByLine, InputSourceRange, LineBuffered, throwIfWindowsNewline;
+    import tsv_utils.common.utils : bufferedByLine, BufferedOutputRange, InputSourceRange,
+        LineBuffered, throwIfWindowsNewline;
 
     /* inputSources must be an InputSourceRange and include at least stdin. */
     assert(!cmdopt.inputSources.empty);
@@ -1013,10 +1013,8 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
     /* BufferedOutputRange improves performance on narrow files with high percentages of
      * writes.
      */
-    immutable size_t flushSize = cmdopt.lineBuffered ?
-        BufferedOutputRangeDefaults.lineBufferedFlushSize :
-        BufferedOutputRangeDefaults.flushSize;
-    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, flushSize);
+    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
+    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, isLineBuffered);
     size_t matchedLines = 0;
 
      /* First header is read during command line argument processing. Immediately
@@ -1033,8 +1031,6 @@ void tsvFilter(ref TsvFilterOptions cmdopt)
     /* Process each input file, one line at a time. */
     immutable size_t fileBodyStartLine = cmdopt.hasHeader ? 2 : 1;
     auto lineFields = new char[][](cmdopt.maxFieldIndex + 1);
-
-    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
 
     foreach (inputStream; cmdopt.inputSources)
     {

--- a/tsv-join/src/tsv_utils/tsv-join.d
+++ b/tsv-join/src/tsv_utils/tsv-join.d
@@ -404,9 +404,9 @@ int main(string[] cmdArgs)
  */
 void tsvJoin(ref TsvJoinOptions cmdopt)
 {
-    import tsv_utils.common.utils : ByLineSourceRange, bufferedByLine, BufferedOutputRange,
-        BufferedOutputRangeDefaults, isFlushableOutputRange, InputFieldReordering,
-        InputSourceRange, LineBuffered, throwIfWindowsNewline;
+    import tsv_utils.common.utils : bufferedByLine, BufferedOutputRange, ByLineSourceRange,
+        InputFieldReordering, InputSourceRange, isFlushableOutputRange, LineBuffered,
+        throwIfWindowsNewline;
     import std.algorithm : splitter;
     import std.array : join;
     import std.range;
@@ -476,10 +476,8 @@ void tsvJoin(ref TsvJoinOptions cmdopt)
     /* Buffered output range for the final output. Setup here because the header line
      * (if any) gets written while reading the filter file.
      */
-    immutable size_t flushSize = cmdopt.lineBuffered ?
-        BufferedOutputRangeDefaults.lineBufferedFlushSize :
-        BufferedOutputRangeDefaults.flushSize;
-    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, flushSize);
+    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
+    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, isLineBuffered);
 
     /* Read the filter file. */
     {
@@ -579,7 +577,6 @@ void tsvJoin(ref TsvJoinOptions cmdopt)
     /* Now process each input file, one line at a time. */
 
     immutable size_t fileBodyStartLine = cmdopt.hasHeader ? 2 : 1;
-    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
 
     foreach (inputStream; cmdopt.inputSources)
     {

--- a/tsv-join/tests/gold/basic_tests_1.txt
+++ b/tsv-join/tests/gold/basic_tests_1.txt
@@ -3191,6 +3191,145 @@ col a:col b:Field B
 
 ====[tsv-join -H -f input1.tsv input_emptyfile.tsv]====
 
+====line-buffered tests===
+
+====[tsv-join --line-buffered --header --filter-file input1.tsv input2.tsv]====
+f1	f2	f3	f4	f5
+2	bbb	ZZZ	21	28
+9	v	vv	97	91
+10	GGG	nnn	101	102
+
+====[tsv-join --line-buffered --filter-file input1_noheader.tsv input2_noheader.tsv]====
+2	bbb	ZZZ	21	28
+9	v	vv	97	91
+10	GGG	nnn	101	102
+
+====[tsv-join --line-buffered --header -f input1.tsv --key-fields 1 input2.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101b	15b
+2	bbb	ZZZ	21	28
+3	nnn	GGG	336b	3b
+4	vvv	VVV	43b	403b
+5	ggg	CCC	5734b	52b
+6	ddd	ZZZ	65b	602b
+7	ßßß	SSS	7b	771b
+8	vv	v	85b	832b
+9	v	vv	97	91
+10	GGG	nnn	101	102
+11	v12	PPP	1123b	1167b
+12	àbc	P	1209b	1234b
+13	ÀSSC		1367b	1331b
+14	-1	1	1489b	1421b
+15		B	1522b	1567b
+16			1634b	1602b
+17	0	X	1721b	1703
+18	a g  ß	Y	1845b	1801b
+19	%tg-0	Z	1931b	1956b
+20	bbb	ZZZ	21	28
+
+====[tsv-join --line-buffered -f input1_noheader.tsv --key-fields 1 input2_noheader.tsv]====
+1	ggg	UUU	101b	15b
+2	bbb	ZZZ	21	28
+3	nnn	GGG	336b	3b
+4	vvv	VVV	43b	403b
+5	ggg	CCC	5734b	52b
+6	ddd	ZZZ	65b	602b
+7	ßßß	SSS	7b	771b
+8	vv	v	85b	832b
+9	v	vv	97	91
+10	GGG	nnn	101	102
+11	v12	PPP	1123b	1167b
+12	àbc	P	1209b	1234b
+13	ÀSSC		1367b	1331b
+14	-1	1	1489b	1421b
+15		B	1522b	1567b
+16			1634b	1602b
+17	0	X	1721b	1703
+18	a g  ß	Y	1845b	1801b
+19	%tg-0	Z	1931b	1956b
+20	bbb	ZZZ	21	28
+
+====[tsv-join --line-buffered --header -f input1.tsv -k 2 --data-fields 2 input2.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101b	15b
+2	bbb	ZZZ	21	28
+3	nnn	GGG	336b	3b
+4	vvv	VVV	43b	403b
+5	ggg	CCC	5734b	52b
+6	ddd	ZZZ	65b	602b
+7	ßßß	SSS	7b	771b
+8	vv	v	85b	832b
+9	v	vv	97	91
+10	GGG	nnn	101	102
+11	v12	PPP	1123b	1167b
+12	àbc	P	1209b	1234b
+13	ÀSSC		1367b	1331b
+14	-1	1	1489b	1421b
+15		B	1522b	1567b
+16			1634b	1602b
+17	0	X	1721b	1703
+18	a g  ß	Y	1845b	1801b
+19	%tg-0	Z	1931b	1956b
+20	bbb	ZZZ	21	28
+21	bbb	ZZZ	21	28
+22	ddd	ZZZ	65b	602b
+23	v12	PPP	1123b	1167b
+24	ÀSSC		1367b	1331b
+25	0	X	1721b	1703
+26	bbb	ZZZ	21	28
+31	 	 	sp-sp	2020b
+
+====[tsv-join --line-buffered --header -f input1.tsv -k 2 -a 5 --allow-duplicate-keys input2.tsv]====
+f1	f2	f3	f4	f5	f5
+1	ggg	UUU	101b	15b	52
+2	bbb	ZZZ	21	28	28
+3	nnn	GGG	336b	3b	 3
+4	vvv	VVV	43b	403b	403
+5	ggg	CCC	5734b	52b	52
+6	ddd	ZZZ	65b	602b	602
+7	ßßß	SSS	7b	771b	771
+8	vv	v	85b	832b	832
+9	v	vv	97	91	91
+10	GGG	nnn	101	102	102
+11	v12	PPP	1123b	1167b	1167
+12	àbc	P	1209b	1234b	1234
+13	ÀSSC		1367b	1331b	1331
+14	-1	1	1489b	1421b	1421
+15		B	1522b	1567b	1602
+16			1634b	1602b	1602
+17	0	X	1721b	1703	1703
+18	a g  ß	Y	1845b	1801b	1801
+19	%tg-0	Z	1931b	1956b	1956
+20	bbb	ZZZ	21	28	28
+21	bbb	ZZZ	21	28	28
+22	ddd	ZZZ	65b	602b	602
+23	v12	PPP	1123b	1167b	1167
+24	ÀSSC		1367b	1331b	1331
+25	0	X	1721b	1703	1703
+26	bbb	ZZZ	21	28	28
+31	 	 	sp-sp	2020b	2020
+
+====[tsv-join --line-buffered --header -f input1.tsv -k 3 -d 2 -a 0 --allow-duplicate-keys input2.tsv]====
+f1	f2	f3	f4	f5	f1	f2	f3	f4	f5
+3	nnn	GGG	336b	3b	10	GGG	nnn	101	102
+8	vv	v	85b	832b	9	v	vv	97	91
+9	v	vv	97	91	8	vv	v	85	832
+10	GGG	nnn	101	102	3	nnn	GGG	336	 3
+15		B	1522b	1567b	16			1634	1602
+16			1634b	1602b	16			1634	1602
+31	 	 	sp-sp	2020b	20	 	 	sp-sp	2020
+
+====[tail -n 10 input1.tsv | tsv-join --line-buffered -f - -k 4 -a 1 input2.tsv]====
+31	 	 	sp-sp	2020b	20
+
+====[tsv-join --line-buffered -f input_emptyfile.tsv input2.tsv]====
+
+====[tsv-join --line-buffered -H -f input_emptyfile.tsv input2.tsv]====
+
+====[tsv-join --line-buffered -f input1.tsv input_emptyfile.tsv]====
+
+====[tsv-join --line-buffered -H -f input1.tsv input_emptyfile.tsv]====
+
 Help and Version printing 1
 -----------------
 

--- a/tsv-join/tests/tests.sh
+++ b/tsv-join/tests/tests.sh
@@ -283,6 +283,23 @@ runtest ${prog} "-H -f input_emptyfile.tsv input2.tsv"  ${basic_tests_1}
 runtest ${prog} "-f input1.tsv input_emptyfile.tsv"  ${basic_tests_1}
 runtest ${prog} "-H -f input1.tsv input_emptyfile.tsv"  ${basic_tests_1}
 
+echo "" >> ${basic_tests_1}; echo "====line-buffered tests===" >> ${basic_tests_1}
+runtest ${prog} "--line-buffered --header --filter-file input1.tsv input2.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --filter-file input1_noheader.tsv input2_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header -f input1.tsv --key-fields 1 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -f input1_noheader.tsv --key-fields 1 input2_noheader.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header -f input1.tsv -k 2 --data-fields 2 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header -f input1.tsv -k 2 -a 5 --allow-duplicate-keys input2.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header -f input1.tsv -k 3 -d 2 -a 0 --allow-duplicate-keys input2.tsv" ${basic_tests_1}
+
+echo "" >> ${basic_tests_1}; echo "====[tail -n 10 input1.tsv | tsv-join --line-buffered -f - -k 4 -a 1 input2.tsv]====" >> ${basic_tests_1}
+tail -n 10 input1.tsv | ${prog} --line-buffered -f - -k 4 -a 1 input2.tsv >> ${basic_tests_1} 2>&1
+
+runtest ${prog} "--line-buffered -f input_emptyfile.tsv input2.tsv"  ${basic_tests_1}
+runtest ${prog} "--line-buffered -H -f input_emptyfile.tsv input2.tsv"  ${basic_tests_1}
+runtest ${prog} "--line-buffered -f input1.tsv input_emptyfile.tsv"  ${basic_tests_1}
+runtest ${prog} "--line-buffered -H -f input1.tsv input_emptyfile.tsv"  ${basic_tests_1}
+
 ## Help and Version printing
 
 echo "" >> ${basic_tests_1}

--- a/tsv-sample/tests/gold/basic_tests_1.txt
+++ b/tsv-sample/tests/gold/basic_tests_1.txt
@@ -391,6 +391,24 @@ line	title	weight
 23	佛說四十二章經	81
 24	La Navidad en las Montañas	100
 
+====[tsv-sample --line-buffered -H -s --inorder -n 15 --weight-field weight input3x10.tsv input3x25.tsv]====
+line	title	weight
+4	Soitannollisia satuja ja jutelmia	44
+8	Door het land der Skipetaren	30
+1	Белые ночи	98
+6	Große und kleine Welt	91
+11	Il "Damo viennese"	23
+12	הצופה לבית ישראל	91
+14	Pasáček Ali: Pověst z východu	64
+16	Leabhráin an Irisleabhair—III	53
+17	Diné yázhí ba'áłchíní	88
+18	Right Half Hollins	67
+19	Annie Laurie and Azalea	85
+20	羅生門	87
+22	豆棚閒話	73
+23	佛說四十二章經	81
+24	La Navidad en las Montañas	100
+
 ====[tsv-sample -H -s --prob 1.0 --print-random input3x10.tsv input3x25.tsv]====
 random_value	line	title	weight
 0.010968807619065046	1	Álomvilág: Elbeszélések	41
@@ -461,7 +479,18 @@ púrpura	2088	Macuco	1
 暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
 blanc	2038	Голубь	0
 
+====[tsv-sample --line-buffered -H -s -p 0.02 --inorder input4x50.tsv input4x15.tsv]====
+c-1	c-2	c-3	c-4
+púrpura	2088	Macuco	1
+暗紅色/暗赤色	2015	Malvasía Cabeciblanca	2
+blanc	2038	Голубь	0
+
 ====[tsv-sample -s -p 0.02 input4x50.tsv input4x15.tsv]====
+c-1	c-2	c-3	c-4
+Orange-red	2089	Purpurreiher	1
+Grünspan	2053	Pipit de Godlewski	4
+
+====[tsv-sample --line-buffered -s -p 0.02 input4x50.tsv input4x15.tsv]====
 c-1	c-2	c-3	c-4
 Orange-red	2089	Purpurreiher	1
 Grünspan	2053	Pipit de Godlewski	4
@@ -627,6 +656,14 @@ blutrot	2118	Tüpfelsumpfhuhn	4
 Cerise	2076	Malvasía Cabeciblanca	4
 café	2088	Purpurreiher	2
 
+====[tsv-sample --line-buffered -H -s -p .25 -k 1 -n 5 input4x50.tsv input4x15.tsv]====
+c-1	c-2	c-3	c-4
+púrpura	2088	Macuco	1
+blutrot	2142	Tüpfelsumpfhuhn	1
+blutrot	2118	Tüpfelsumpfhuhn	4
+Cerise	2076	Malvasía Cabeciblanca	4
+café	2088	Purpurreiher	2
+
 ====[tsv-sample -s -p .25 -k 1,3 input4x50.tsv input4x15.tsv]====
 púrpura	2088	Macuco	1
 blutrot	2142	Tüpfelsumpfhuhn	1
@@ -645,6 +682,25 @@ jaune	2090	Weißwangengans	4
 marrón	2121	Marreca-cabocla	2
 
 ====[tsv-sample -s -p .25 -k 3,1 input4x50.tsv input4x15.tsv]====
+púrpura	2088	Macuco	1
+schneeweiß	2117	Porrón Islándico	4
+café	2088	Purpurreiher	2
+Orange-red	2089	Purpurreiher	1
+púrpura	2070	Macreuse à bec jaune	2
+púrpura	2092	Macreuse à bec jaune	4
+púrpura	2093	Macreuse à bec jaune	4
+schneeweiß	2121	Porrón Islándico	1
+café	2062	Purpurreiher	4
+café	2100	Purpurreiher	2
+красный	2049	Weißwangengans	3
+púrpura	2119	Macuco	4
+púrpura	2145	Macreuse à bec jaune	2
+café	2041	Purpurreiher	4
+café	2019	Marreca-cabocla	1
+blutrot	2093	Araqua-pintado	2
+jaune	2104	Tüpfelsumpfhuhn	1
+
+====[tsv-sample --line-buffered -s -p .25 -k 3,1 input4x50.tsv input4x15.tsv]====
 púrpura	2088	Macuco	1
 schneeweiß	2117	Porrón Islándico	4
 café	2088	Purpurreiher	2

--- a/tsv-sample/tests/tests.sh
+++ b/tsv-sample/tests/tests.sh
@@ -63,6 +63,7 @@ runtest ${prog} "-H -s --inorder -n 15 --compatibility-mode input3x10.tsv input3
 runtest ${prog} "-H -s --inorder -n 15 --prefer-algorithm-r input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --inorder -n 15 --weight-field 3 input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s --inorder -n 15 --weight-field weight input3x10.tsv input3x25.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -H -s --inorder -n 15 --weight-field weight input3x10.tsv input3x25.tsv" ${basic_tests_1}
 
 # Bernoulli sampling
 runtest ${prog} "-H -s --prob 1.0 --print-random input3x10.tsv input3x25.tsv" ${basic_tests_1}
@@ -70,7 +71,9 @@ runtest ${prog} "-H -s -p 0.25 --compatibility-mode input3x10.tsv input3x25.tsv"
 runtest ${prog} "-H -s -p 0.75 -n 5 --compatibility-mode input3x10.tsv input3x25.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p 0.02 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p 0.02 --inorder input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -H -s -p 0.02 --inorder input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-s -p 0.02 input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -s -p 0.02 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 
 # Simple random sampling with replacement
 runtest ${prog} "-H -s --replace --compatibility-mode input3x3.tsv --num 5" ${basic_tests_1}
@@ -85,8 +88,10 @@ runtest ${prog} "-H -s -p .25 -k 1,3 input4x50.tsv input4x15.tsv" ${basic_tests_
 runtest ${prog} "-H -s -p .25 -k 1,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .25 --key-fields 1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .25 -k 1 -n 5 input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -H -s -p .25 -k 1 -n 5 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-s -p .25 -k 1,3 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-s -p .25 -k 3,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered -s -p .25 -k 3,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-s -p 1 -k 3,1 input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .2 -k 3 --print-random input4x50.tsv input4x15.tsv" ${basic_tests_1}
 runtest ${prog} "-H -s -p .2 -k 3 --print-random -n 5 input4x50.tsv input4x15.tsv" ${basic_tests_1}

--- a/tsv-select/src/tsv_utils/tsv-select.d
+++ b/tsv-select/src/tsv_utils/tsv-select.d
@@ -449,7 +449,7 @@ enum RestLocation { none, first, last };
 
 void tsvSelect(RestLocation rest)(ref TsvSelectOptions cmdopt)
 {
-    import tsv_utils.common.utils: BufferedOutputRange, BufferedOutputRangeDefaults,
+    import tsv_utils.common.utils: BufferedOutputRange,
         ByLineSourceRange, InputFieldReordering, LineBuffered, throwIfWindowsNewline;
     import std.algorithm: splitter;
     import std.array : appender, Appender;
@@ -494,10 +494,8 @@ void tsvSelect(RestLocation rest)(ref TsvSelectOptions cmdopt)
     /* BufferedOutputRange (from common/utils.d) is a performance improvement over
      * writing directly to stdout.
      */
-    immutable size_t flushSize = cmdopt.lineBuffered ?
-        BufferedOutputRangeDefaults.lineBufferedFlushSize :
-        BufferedOutputRangeDefaults.flushSize;
-    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, flushSize);
+    immutable LineBuffered isLineBuffered = cmdopt.lineBuffered ? Yes.lineBuffered : No.lineBuffered;
+    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout, isLineBuffered);
 
     /* Read each input file (or stdin) and iterate over each line.
      */

--- a/tsv-uniq/tests/gold/basic_tests_1.txt
+++ b/tsv-uniq/tests/gold/basic_tests_1.txt
@@ -1704,6 +1704,179 @@ f1	f2	f3	f4	f5
 5	ßßß	SSS	 76	771
 15	7	xyz	9999	8888
 
+==== line-buffered tests===
+
+====[tsv-uniq --line-buffered input1.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+14	 	 	sp-sp	2022
+17	0	Z	5734	602
+
+====[tsv-uniq --line-buffered --header input1.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+14	 	 	sp-sp	2022
+17	0	Z	5734	602
+
+====[tsv-uniq --line-buffered input1.tsv --fields 1]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+14	 	 	sp-sp	2022
+17	0	Z	5734	602
+
+====[tsv-uniq --line-buffered input1.tsv --header -f 2]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+
+====[tsv-uniq --line-buffered empty-file.txt]====
+
+====[tsv-uniq --line-buffered -H empty-file.txt]====
+
+====[tsv-uniq --line-buffered input1.tsv input2.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+14	 	 	sp-sp	2022
+17	0	Z	5734	602
+5	ßßß	SSSa	 7	771
+17	8	str	9997	8886
+5	ßßßz	SSS	 7	771
+16	pqr	uvw	9998	8887
+5	ßßß	SSS	 76	771
+15	7	xyz	9999	8888
+
+====[tsv-uniq --line-buffered --header -f 3,4 input1.tsv input2.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+17	0	Z	5734	602
+5	ßßß	SSSa	 7	771
+17	8	str	9997	8886
+16	pqr	uvw	9998	8887
+5	ßßß	SSS	 76	771
+15	7	xyz	9999	8888
+
+====[cat input1.tsv input2.tsv | tsv-uniq --line-buffered]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+14	 	 	sp-sp	2022
+17	0	Z	5734	602
+5	ßßß	SSSa	 7	771
+17	8	str	9997	8886
+5	ßßßz	SSS	 7	771
+16	pqr	uvw	9998	8887
+5	ßßß	SSS	 76	771
+15	7	xyz	9999	8888
+
+====[cat input1.tsv | tsv-uniq --line-buffered --header -f 3,4 -- - input2.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+17	0	Z	5734	602
+5	ßßß	SSSa	 7	771
+17	8	str	9997	8886
+16	pqr	uvw	9998	8887
+5	ßßß	SSS	 76	771
+15	7	xyz	9999	8888
+
 Help and Version printing 1
 -----------------
 

--- a/tsv-uniq/tests/tests.sh
+++ b/tsv-uniq/tests/tests.sh
@@ -168,6 +168,23 @@ cat input1.tsv | ${prog} --header -f 3,4 -- - input2.tsv >> ${basic_tests_1} 2>&
 echo "" >> ${basic_tests_1}; echo "====[cat input1.tsv | tsv-uniq --header -f 3,f4 -- - input2.tsv]====" >> ${basic_tests_1}
 cat input1.tsv | ${prog} --header -f 3,f4 -- - input2.tsv >> ${basic_tests_1} 2>&1
 
+## line-buffered tests
+echo "" >> ${basic_tests_1}; echo "==== line-buffered tests===" >> ${basic_tests_1}
+runtest ${prog} "--line-buffered input1.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header input1.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered input1.tsv --fields 1" ${basic_tests_1}
+runtest ${prog} "--line-buffered input1.tsv --header -f 2" ${basic_tests_1}
+runtest ${prog} "--line-buffered empty-file.txt" ${basic_tests_1}
+runtest ${prog} "--line-buffered -H empty-file.txt" ${basic_tests_1}
+runtest ${prog} "--line-buffered input1.tsv input2.tsv" ${basic_tests_1}
+runtest ${prog} "--line-buffered --header -f 3,4 input1.tsv input2.tsv" ${basic_tests_1}
+
+echo "" >> ${basic_tests_1}; echo "====[cat input1.tsv input2.tsv | tsv-uniq --line-buffered]====" >> ${basic_tests_1}
+cat input1.tsv input2.tsv | ${prog} --line-buffered >> ${basic_tests_1} 2>&1
+
+echo "" >> ${basic_tests_1}; echo "====[cat input1.tsv | tsv-uniq --line-buffered --header -f 3,4 -- - input2.tsv]====" >> ${basic_tests_1}
+cat input1.tsv | ${prog} --line-buffered --header -f 3,4 -- - input2.tsv >> ${basic_tests_1} 2>&1
+
 ## Help and Version printing
 
 echo "" >> ${basic_tests_1}


### PR DESCRIPTION
This PR completes basic support for line buffering in the toolkit. It is a follow-up to PRs #333, #334, and #335.

By default, tools read and write in a buffered mode where data is read and written in large blocks. This is a significant performance enhancement over reading and writing line-by-line. However, reading and writing each line as it becomes available is desirable when reading from live input streams having only occasional inputs.

Most tools now support a `--line-buffered` option that switches to line buffering mode. Tools supporting this are: `number-lines`, `tsv-append`, `tsv-filter`, `tsv-join`, `tsv-sample`, `tsv-select`, `tsv-uniq`.

This PR also cleaned up some code related to header line processing and stdout flushing. This results better error message processing in a few cases. (More timely error messages in unix pipelines; error messages written after all processed output has been flushed.)
