### PR TITLE
[tsv-utils/common/getopt_inorder.d] Fix unittest for dlang/phobos#10593

### DIFF
--- a/common/src/tsv_utils/common/getopt_inorder.d
+++ b/common/src/tsv_utils/common/getopt_inorder.d
@@ -716,7 +716,7 @@ unittest // Dashes
     assertThrown!GetOptException(getoptInorder(args, "abc", &abc));
 
     args = ["prog", "--abc=string"];
-    assertThrown!ConvException(getoptInorder(args, "abc", &abc));
+    assertThrown(getoptInorder(args, "abc", &abc));
 }
 
 @system unittest // From bugzilla 7693


### PR DESCRIPTION
dlang/phobos#10593 changes the thrown exception type from `ConvException` to `GetOptException` to provide more context on failed conversion.